### PR TITLE
Disable Select migration network when needed

### DIFF
--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -21,6 +21,7 @@ interface ISelectNetworkModalProps {
   selectedHosts: IHost[];
   hostConfigs: IHostConfig[];
   provider: IVMwareProvider;
+  commonNetworkAdapters: IHostNetworkAdapter[];
   onClose: () => void;
 }
 
@@ -66,6 +67,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
   selectedHosts,
   hostConfigs,
   provider,
+  commonNetworkAdapters,
   onClose,
 }: ISelectNetworkModalProps) => {
   const [configureHosts, configureHostsResult] = useConfigureHostsMutation(
@@ -76,11 +78,6 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
   );
 
   const form = useSelectNetworkFormState(selectedHosts, hostConfigs, provider);
-
-  const commonNetworkAdapters: IHostNetworkAdapter[] = selectedHosts[0].networkAdapters.filter(
-    ({ ipAddress }) =>
-      selectedHosts.every((host) => host.networkAdapters.some((na) => na.ipAddress === ipAddress))
-  );
 
   const networkOptions = commonNetworkAdapters.map((networkAdapter) => ({
     toString: () => formatHostNetworkAdapter(networkAdapter),

--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -63,7 +63,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
       hosts.every((host) => host.networkAdapters.some((na) => na.ipAddress === ipAddress))
     );
 
-  const isCommonNetworkAdapters = () => {
+  const hasCommonNetworkAdapters = () => {
     if (selectedItems.length > 0) {
       return commonNetworkAdapters(selectedItems).length > 0 ? true : false;
     }
@@ -87,7 +87,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
       <Level>
         <LevelItem>
           <ConditionalTooltip
-            isTooltipEnabled={!isCommonNetworkAdapters()}
+            isTooltipEnabled={!hasCommonNetworkAdapters()}
             content={
               selectedItems.length === 0
                 ? 'Select at least one host'
@@ -98,7 +98,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
               <Button
                 variant="secondary"
                 onClick={() => setIsSelectNetworkModalOpen(true)}
-                isDisabled={!isCommonNetworkAdapters()}
+                isDisabled={!hasCommonNetworkAdapters()}
               >
                 Select migration network
               </Button>

--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -57,6 +57,18 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
     }
   );
 
+  const commonNetworkAdapters = (hosts: IHost[]) =>
+    hosts[0].networkAdapters.filter(({ ipAddress }) =>
+      hosts.every((host) => host.networkAdapters.some((na) => na.ipAddress === ipAddress))
+    );
+
+  const isCommonNetworkAdapters = () => {
+    if (selectedItems.length > 0) {
+      return commonNetworkAdapters(selectedItems).length > 0 ? true : false;
+    }
+    return false;
+  };
+
   const rows: IRow[] = sortedItems.map((host: IHost) => ({
     meta: { host },
     selected: isItemSelected(host),
@@ -76,7 +88,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
           <Button
             variant="secondary"
             onClick={() => setIsSelectNetworkModalOpen(true)}
-            isDisabled={selectedItems.length === 0}
+            isDisabled={!isCommonNetworkAdapters()}
           >
             Select migration network
           </Button>
@@ -105,6 +117,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
       {isSelectNetworkModalOpen && (
         <SelectNetworkModal
           selectedHosts={selectedItems}
+          commonNetworkAdapters={commonNetworkAdapters(selectedItems)}
           hostConfigs={hostConfigs}
           provider={provider as IVMwareProvider}
           onClose={() => setIsSelectNetworkModalOpen(false)}

--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -16,6 +16,7 @@ import SelectNetworkModal from './SelectNetworkModal';
 import { useHostConfigsQuery } from '@app/queries';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import { findSelectedNetworkAdapter, formatHostNetworkAdapter } from './helpers';
+import ConditionalTooltip from '@app/common/components/ConditionalTooltip';
 
 interface IVMwareProviderHostsTableProps {
   provider: IVMwareProvider;
@@ -85,13 +86,24 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
     <>
       <Level>
         <LevelItem>
-          <Button
-            variant="secondary"
-            onClick={() => setIsSelectNetworkModalOpen(true)}
-            isDisabled={!isCommonNetworkAdapters()}
+          <ConditionalTooltip
+            isTooltipEnabled={!isCommonNetworkAdapters()}
+            content={
+              selectedItems.length === 0
+                ? 'Select at least one host'
+                : 'Selected hosts have no network adapters in common'
+            }
           >
-            Select migration network
-          </Button>
+            <div>
+              <Button
+                variant="secondary"
+                onClick={() => setIsSelectNetworkModalOpen(true)}
+                isDisabled={!isCommonNetworkAdapters()}
+              >
+                Select migration network
+              </Button>
+            </div>
+          </ConditionalTooltip>
         </LevelItem>
         <LevelItem>
           <Pagination {...paginationProps} widgetId="providers-table-pagination-top" />

--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -58,17 +58,14 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
     }
   );
 
-  const commonNetworkAdapters = (hosts: IHost[]) =>
-    hosts[0].networkAdapters.filter(({ ipAddress }) =>
-      hosts.every((host) => host.networkAdapters.some((na) => na.ipAddress === ipAddress))
-    );
-
-  const hasCommonNetworkAdapters = () => {
-    if (selectedItems.length > 0) {
-      return commonNetworkAdapters(selectedItems).length > 0 ? true : false;
-    }
-    return false;
-  };
+  const commonNetworkAdapters =
+    selectedItems.length > 0
+      ? selectedItems[0].networkAdapters.filter(({ ipAddress }) =>
+          selectedItems.every((host) =>
+            host.networkAdapters.some((na) => na.ipAddress === ipAddress)
+          )
+        )
+      : [];
 
   const rows: IRow[] = sortedItems.map((host: IHost) => ({
     meta: { host },
@@ -87,7 +84,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
       <Level>
         <LevelItem>
           <ConditionalTooltip
-            isTooltipEnabled={!hasCommonNetworkAdapters()}
+            isTooltipEnabled={commonNetworkAdapters.length === 0}
             content={
               selectedItems.length === 0
                 ? 'Select at least one host'
@@ -98,7 +95,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
               <Button
                 variant="secondary"
                 onClick={() => setIsSelectNetworkModalOpen(true)}
-                isDisabled={!hasCommonNetworkAdapters()}
+                isDisabled={commonNetworkAdapters.length === 0}
               >
                 Select migration network
               </Button>
@@ -129,7 +126,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
       {isSelectNetworkModalOpen && (
         <SelectNetworkModal
           selectedHosts={selectedItems}
-          commonNetworkAdapters={commonNetworkAdapters(selectedItems)}
+          commonNetworkAdapters={commonNetworkAdapters}
           hostConfigs={hostConfigs}
           provider={provider as IVMwareProvider}
           onClose={() => setIsSelectNetworkModalOpen(false)}


### PR DESCRIPTION
- Lift up `commonNetworkAdapters` logic to `VMwareProviderHostsTable` to enable/disable "select migration network" button if there are or not common adapters between hosts.
- Display a Tooltip messages when no selection has been made:
![select-message1](https://user-images.githubusercontent.com/1901741/100766423-ea418300-33f8-11eb-9663-68f13d8a4ce0.png)
- Display a Tooltip message when selected hosts offers no adapters in common:
![select-message2](https://user-images.githubusercontent.com/1901741/100766517-047b6100-33f9-11eb-967f-1b959ee43767.png)


Resolves https://github.com/konveyor/virt-ui/issues/261