### PR TITLE
Disable proxy endpoint for unused inventoryPayloadApi

### DIFF
--- a/deploy/server.js
+++ b/deploy/server.js
@@ -18,6 +18,8 @@ if (process.env['DATA_SOURCE'] === 'mock') {
   metaStr = fs.readFileSync(metaFile, 'utf8');
 }
 
+console.log(`\nUsing meta values:\n${metaStr}\n\n`);
+
 const meta = JSON.parse(metaStr);
 
 const app = express();
@@ -90,6 +92,7 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
     logLevel: process.env.DEBUG ? 'debug' : 'info',
   };
 
+  /* TODO restore this when https://github.com/konveyor/forklift-ui/issues/281 is settled
   let inventoryPayloadApiProxyOptions = {
     target: meta.inventoryPayloadApi,
     changeOrigin: true,
@@ -98,6 +101,7 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
     },
     logLevel: process.env.DEBUG ? 'debug' : 'info',
   };
+  */
 
   if (process.env['NODE_ENV'] === 'development') {
     clusterApiProxyOptions = {
@@ -110,19 +114,23 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
       secure: false,
     };
 
+    /* TODO restore this when https://github.com/konveyor/forklift-ui/issues/281 is settled
     inventoryPayloadApiProxyOptions = {
       ...inventoryPayloadApiProxyOptions,
       secure: false,
     };
+    */
   }
 
   const clusterApiProxy = createProxyMiddleware(clusterApiProxyOptions);
   const inventoryApiProxy = createProxyMiddleware(inventoryApiProxyOptions);
-  const inventoryPayloadApiProxy = createProxyMiddleware(inventoryPayloadApiProxyOptions);
+  // TODO restore this when https://github.com/konveyor/forklift-ui/issues/281 is settled
+  // const inventoryPayloadApiProxy = createProxyMiddleware(inventoryPayloadApiProxyOptions);
 
   app.use('/cluster-api/', clusterApiProxy);
   app.use('/inventory-api/', inventoryApiProxy);
-  app.use('/inventory-payload-api/', inventoryPayloadApiProxy);
+  // TODO restore this when https://github.com/konveyor/forklift-ui/issues/281 is settled
+  // app.use('/inventory-payload-api/', inventoryPayloadApiProxy);
 }
 
 app.get('*', (_, res) => {


### PR DESCRIPTION
Makes the `inventoryPayloadApi` value in `meta.json` no longer required until we address https://github.com/konveyor/forklift-ui/issues/281