### PR TITLE
Use process.env.BRAND_TYPE to determine brand logo

### DIFF
--- a/src/app/global-flags.ts
+++ b/src/app/global-flags.ts
@@ -3,7 +3,4 @@ export enum BrandType {
   RedHat = 'RedHat',
 }
 
-// TODO: this should probably be a build config option instead
-//   maybe even just have the konveyor logo as a generic filename and have a script swap in the Red Hat file
-//   instead of having any reference to Red Hat branding in here.
-export const APP_BRAND: BrandType = BrandType.Konveyor;
+export const APP_BRAND: BrandType = (process.env.BRAND_TYPE as BrandType) || BrandType.Konveyor;


### PR DESCRIPTION
To switch from the Konveyor logo to the Red Hat logo in the masthead, use `BRAND_TYPE=RedHat` as a prefix on any of the webpack scripts (start:dev:* or build), or add it as an entry in a `.env` file at the repo root.