### PR TITLE
Clear errors in wizard on step navigation instead of component unmount

### DIFF
--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -8,6 +8,7 @@ import {
   PageSection,
   Title,
   Wizard,
+  WizardStepFunctionType,
 } from '@patternfly/react-core';
 import { Link, Prompt, Redirect, useHistory, useRouteMatch } from 'react-router-dom';
 import { QueryResult, QueryStatus } from 'react-query';
@@ -313,6 +314,14 @@ const PlanWizard: React.FunctionComponent = () => {
     },
   ];
 
+  const resetResultsOnNav: WizardStepFunctionType = (_newStep, prevStep) => {
+    if (prevStep.prevId === StepId.Review) {
+      createPlanResult.reset();
+      createNetworkMappingResult.reset();
+      createStorageMappingResult.reset();
+    }
+  };
+
   return (
     <ResolvedQueries
       results={[plansQuery, networkMappingsQuery, storageMappingsQuery, ...prefillQueries]}
@@ -363,6 +372,8 @@ const PlanWizard: React.FunctionComponent = () => {
               onSubmit={(event) => event.preventDefault()}
               onSave={onSave}
               onClose={onClose}
+              onBack={resetResultsOnNav}
+              onGoToStep={resetResultsOnNav}
             />
           </PageSection>
         </>

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -35,15 +35,6 @@ const Review: React.FunctionComponent<IReviewProps> = ({
   createStorageMappingResult,
   planBeingEdited,
 }: IReviewProps) => {
-  // Reset mutation state on unmount (going back in the wizard clears errors)
-  React.useEffect(() => {
-    return () => {
-      createPlanResult.reset();
-      createNetworkMappingResult.reset();
-      createStorageMappingResult.reset();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
   const { networkMapping, storageMapping } = generateMappings(forms);
   return (
     <Form>


### PR DESCRIPTION
Resolves #296 

I actually think the bug was inadvertently fixed in #293, since I couldn't reproduce it anymore before this change. However this is a cleaner and more reliable way to clear these errors anyway, so I think it's still worth merging.