### PR TITLE
Use 'Save' instead of 'Add' for confirm button text when selecting host network

### DIFF
--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -110,7 +110,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
                 }
               }}
             >
-              Add
+              Save
             </Button>
             <Button
               key="cancel"


### PR DESCRIPTION
@vconzola I realized that we used "Add" for the button text here, probably because we copied some code from the add provider modal, and it doesn't make sense to me. Does "Save" work for you?