### PR TITLE
Uniquely identify host networks by name instead of IP address, remove IP from dropdown

### DIFF
--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -60,10 +60,8 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
 
   const commonNetworkAdapters =
     selectedItems.length > 0
-      ? selectedItems[0].networkAdapters.filter(({ ipAddress }) =>
-          selectedItems.every((host) =>
-            host.networkAdapters.some((na) => na.ipAddress === ipAddress)
-          )
+      ? selectedItems[0].networkAdapters.filter(({ name }) =>
+          selectedItems.every((host) => host.networkAdapters.some((na) => na.name === name))
         )
       : [];
 
@@ -84,7 +82,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
             content={
               selectedItems.length === 0
                 ? 'Select at least one host'
-                : 'Selected hosts have no network adapters in common'
+                : 'Selected hosts have no networks in common'
             }
           >
             <div>

--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -17,7 +17,7 @@ export const findSelectedNetworkAdapter = (
 
 export const formatHostNetworkAdapter = (network: IHostNetworkAdapter): string => {
   if (network) {
-    return `${network.name} - ${network.ipAddress}`;
+    return network.name;
   }
   return 'Network not found';
 };

--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -95,20 +95,25 @@ const generateHostConfig = (
   host: IHost,
   provider: IVMwareProvider,
   secretRef: INameNamespaceRef | null
-): IHostConfig => ({
-  apiVersion: CLUSTER_API_VERSION,
-  kind: 'Host',
-  metadata: existingConfig?.metadata || {
-    name: `host-${host.id}-config`,
-    namespace: META.namespace,
-  },
-  spec: {
-    id: host.id,
-    ipAddress: values.selectedNetworkAdapter?.ipAddress || '',
-    provider: nameAndNamespace(provider),
-    secret: secretRef || null,
-  },
-});
+): IHostConfig => {
+  const matchingNetworkAdapter = host.networkAdapters.find(
+    ({ name }) => values.selectedNetworkAdapter?.name === name
+  );
+  return {
+    apiVersion: CLUSTER_API_VERSION,
+    kind: 'Host',
+    metadata: existingConfig?.metadata || {
+      name: `host-${host.id}-config`,
+      namespace: META.namespace,
+    },
+    spec: {
+      id: host.id,
+      ipAddress: matchingNetworkAdapter?.ipAddress || '',
+      provider: nameAndNamespace(provider),
+      secret: secretRef || null,
+    },
+  };
+};
 
 export const useConfigureHostsMutation = (
   provider: IVMwareProvider,


### PR DESCRIPTION
From a discussion with @fdupont-redhat . Network adapters connected to the same network on different hosts will have different IP addresses, so we can't use the host network adapter IP as a unique identifier for the network. Selecting more than one host would never result in any common networks to show in the modal.

This PR changes the logic so common networks are identified by networkAdapters with the same name instead of IP, and when creating the Host CRs the IP from each host's matching adapter is used. Also, the IP address has been removed from the dropdown menu of networks, only the name, bandwidth and MTU are shown.