### PR TITLE
Add popover to show condition messages on the status column in the providers and hosts tables

### DIFF
--- a/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
@@ -20,7 +20,7 @@ import { IOpenShiftProvider } from '@app/queries/types/providers.types';
 import ProviderActionsDropdown from '../ProviderActionsDropdown';
 import StatusCondition from '@app/common/components/StatusCondition';
 import { MappingType } from '@app/queries/types';
-import { mostSeriousCondition } from '@app/common/helpers';
+import { getMostSeriousCondition } from '@app/common/helpers';
 
 import './OpenShiftProvidersTable.css';
 import { ProviderType } from '@app/common/constants';
@@ -55,7 +55,7 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
       vmCount,
       networkCount,
       storageClasses.length,
-      provider.object.status ? mostSeriousCondition(provider.object.status?.conditions) : '',
+      provider.object.status ? getMostSeriousCondition(provider.object.status?.conditions) : '',
       '',
     ];
   };

--- a/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
@@ -15,7 +15,7 @@ import { useSortState, usePaginationState } from '@app/common/hooks';
 import { IVMwareProvider } from '@app/queries/types';
 import ProviderActionsDropdown from '../ProviderActionsDropdown';
 import StatusCondition from '@app/common/components/StatusCondition';
-import { mostSeriousCondition } from '@app/common/helpers';
+import { getMostSeriousCondition } from '@app/common/helpers';
 
 import './VMwareProvidersTable.css';
 import { ProviderType } from '@app/common/constants';
@@ -41,7 +41,7 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
       vmCount,
       networkCount,
       datastoreCount,
-      provider.object.status ? mostSeriousCondition(provider.object.status?.conditions) : '',
+      provider.object.status ? getMostSeriousCondition(provider.object.status?.conditions) : '',
       '',
     ];
   };

--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -17,7 +17,7 @@ import { useHostConfigsQuery } from '@app/queries';
 import { findHostConfig, findSelectedNetworkAdapter, formatHostNetworkAdapter } from './helpers';
 import ConditionalTooltip from '@app/common/components/ConditionalTooltip';
 import { ResolvedQuery } from '@app/common/components/ResolvedQuery';
-import { mostSeriousCondition } from '@app/common/helpers';
+import { getMostSeriousCondition } from '@app/common/helpers';
 import StatusCondition from '@app/common/components/StatusCondition';
 
 interface IVMwareProviderHostsTableProps {
@@ -65,7 +65,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
     return [
       '', // Checkbox column
       ...(cells.slice(0, -1) as string[]),
-      hostConfig?.status ? mostSeriousCondition(hostConfig?.status?.conditions) : '',
+      hostConfig?.status ? getMostSeriousCondition(hostConfig?.status?.conditions) : '',
     ];
   };
 

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -20,7 +20,7 @@ export const hasConditionsByCategory = (
   return !!conditions.find((condition) => condition.category === category);
 };
 
-export const mostSeriousCondition = (conditions: IStatusCondition[]): string => {
+export const getMostSeriousCondition = (conditions: IStatusCondition[]): string => {
   if (hasConditionsByCategory(conditions, StatusCategoryType.Critical)) {
     return StatusCategoryType.Critical;
   }
@@ -38,6 +38,12 @@ export const mostSeriousCondition = (conditions: IStatusCondition[]): string => 
     !hasCondition(conditions, PlanStatusType.Ready)
   ) {
     return StatusCategoryType.Advisory;
+  }
+  if (
+    hasConditionsByCategory(conditions, StatusCategoryType.Required) &&
+    !hasCondition(conditions, PlanStatusType.Ready)
+  ) {
+    return StatusCategoryType.Required;
   }
   if (
     hasConditionsByCategory(conditions, StatusCategoryType.Required) &&


### PR DESCRIPTION
Resolves #178 

The cell in the table will continue to show the most severe condition's severity, but now clicking on it will show a popover with all conditions present on the object, icons for their severity, and their full messages.