### PR TITLE
Properly handle the "completed with errors" state of a migration plan

### DIFF
--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -134,7 +134,8 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
 
   const ratioVMs = (plan: IPlan) => {
     const totalVMs = plan.spec.vms.length;
-    const numVMsDone = plan.status?.migration?.vms?.filter((vm) => !!vm.completed).length || 0;
+    const numVMsDone =
+      plan.status?.migration?.vms?.filter((vm) => !!vm.completed && !vm.error).length || 0;
     const statusValue = totalVMs > 0 ? (numVMsDone * 100) / totalVMs : 0;
     const statusMessage = `${numVMsDone} of ${totalVMs} VMs migrated`;
 

--- a/src/app/common/components/PipelineSummary.tsx
+++ b/src/app/common/components/PipelineSummary.tsx
@@ -32,10 +32,10 @@ const Dash: React.FunctionComponent<IDashProps> = ({ isReached }: IDashProps) =>
 
 export const getPipelineSummaryTitle = (status: IVMStatus): string => {
   const { currentStep } = findCurrentStep(status.pipeline);
-  if (status.completed) {
+  if (status.completed && !status.error) {
     return 'Complete';
   }
-  if (status.started && !status.completed) {
+  if ((status.started && !status.completed) || status.error) {
     if (status.error) return `Error - ${currentStep?.description}`;
     if (currentStep?.description) return currentStep.description;
   }

--- a/src/app/common/components/PipelineSummary.tsx
+++ b/src/app/common/components/PipelineSummary.tsx
@@ -52,25 +52,28 @@ const GetStepTypeIcon: React.FunctionComponent<IGetStepTypeIcon> = ({
   index,
 }: IGetStepTypeIcon) => {
   const res = getStepType(status, index);
+  let icon: React.ReactNode;
   if (res === StepType.Full) {
-    return (
-      <>
-        <ResourcesFullIcon
-          color={isStepOnError(status, index) ? dangerColor.value : successColor.value}
-        />
-        {index < status.pipeline.length - 1 ? <Dash isReached={true} /> : null}
-      </>
+    icon = (
+      <ResourcesFullIcon
+        color={isStepOnError(status, index) ? dangerColor.value : successColor.value}
+      />
     );
   } else if (res === StepType.Half) {
-    return (
-      <>
-        <ResourcesAlmostFullIcon
-          color={isStepOnError(status, index) ? dangerColor.value : infoColor.value}
-        />
-        {index < status.pipeline.length - 1 ? <Dash isReached={true} /> : null}
-      </>
+    icon = (
+      <ResourcesAlmostFullIcon
+        color={isStepOnError(status, index) ? dangerColor.value : infoColor.value}
+      />
     );
-  } else return <ResourcesEmptyIcon key={index} color={disabledColor.value} />;
+  } else {
+    icon = <ResourcesEmptyIcon key={index} color={disabledColor.value} />;
+  }
+  return (
+    <>
+      {icon}
+      {index < status.pipeline.length - 1 ? <Dash isReached={true} /> : null}
+    </>
+  );
 };
 
 interface IPipelineSummaryProps {

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -57,10 +57,12 @@ export const getMostSeriousCondition = (conditions: IStatusCondition[]): string 
 export const findCurrentStep = (
   pipeline: IStep[]
 ): { currentStep: IStep | undefined; currentStepIndex: number } => {
-  const currentStep = pipeline
-    .slice(0)
-    .reverse()
-    .find((step) => !!step.started && !step.completed);
+  if (pipeline.length === 0) return { currentStep: undefined, currentStepIndex: 0 };
+  const currentStep =
+    pipeline
+      .slice(0)
+      .reverse()
+      .find((step) => !!step.started && !step.completed) || pipeline[pipeline.length - 1];
   const currentStepIndex = currentStep ? pipeline.indexOf(currentStep) : 0;
   return { currentStep, currentStepIndex };
 };

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -62,7 +62,8 @@ export const findCurrentStep = (
     pipeline
       .slice(0)
       .reverse()
-      .find((step) => !!step.started && !step.completed) || pipeline[pipeline.length - 1];
+      .find((step) => !!step.error || (!!step.started && !step.completed)) ||
+    pipeline[pipeline.length - 1];
   const currentStepIndex = currentStep ? pipeline.indexOf(currentStep) : 0;
   return { currentStep, currentStepIndex };
 };

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -42,14 +42,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         phase: 'Mock Step Phase',
         annotations: { unit: 'MB' },
         started: '2020-10-10T14:21:10Z',
-        completed: '2020-10-10T14:21:10Z',
+        completed: '2020-10-10T15:57:10Z',
       },
       {
         name: 'ImageConversion',
         description: 'Convert image to kubevirt.',
         progress: { total: 2, completed: 0 },
         phase: 'Mock Step Phase',
-        started: '2020-10-10T14:21:10Z',
+        started: '2020-10-10T15:57:10Z',
       },
       {
         name: 'PostHook',

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -381,5 +381,70 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  MOCK_PLANS = [plan1, plan2, plan3, plan4];
+  const vmStatus1WithError = {
+    ...vmStatus1,
+    pipeline: [
+      vmStatus1.pipeline[0],
+      {
+        ...vmStatus1.pipeline[1],
+        error: {
+          phase: 'DiskTransferFailed',
+          reasons: ['Error transferring disks'],
+        },
+      },
+      { ...vmStatus1.pipeline[2], started: undefined },
+      vmStatus1.pipeline[3],
+    ],
+    error: {
+      phase: 'DiskTransfer',
+      reasons: ['Error transferring disks'],
+    },
+  };
+
+  const vmStatus2WithError = {
+    ...vmStatus1,
+    pipeline: [
+      vmStatus1.pipeline[0],
+      vmStatus1.pipeline[1],
+      {
+        ...vmStatus1.pipeline[2],
+        completed: '2020-10-10T15:58:10Z',
+        error: {
+          phase: 'ImageConversionFailed',
+          reasons: ['Error converting image'],
+        },
+      },
+      vmStatus1.pipeline[3],
+    ],
+    error: {
+      phase: 'ImageConversion',
+      reasons: ['Error converting image'],
+    },
+  };
+
+  const plan5: IPlan = {
+    ...plan1,
+    metadata: { ...plan1.metadata, name: 'plantest-5' },
+    spec: { ...plan1.spec, description: 'completed with errors' },
+    status: {
+      conditions: [
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-10T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: true,
+          type: 'Failed',
+        },
+      ],
+      observedGeneration: 2,
+      migration: {
+        active: '',
+        started: '2020-10-10T14:04:10Z',
+        vms: [vmStatus1WithError, vmStatus2WithError],
+      },
+    },
+  };
+
+  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5];
 }

--- a/src/app/queries/types/common.types.ts
+++ b/src/app/queries/types/common.types.ts
@@ -34,7 +34,8 @@ export interface IStatusCondition {
   category: string;
   type: string;
   status: boolean;
-  reason: string;
+  reason?: string;
+  durable?: boolean;
   message: string;
   lastTransitionTime: string; // ISO timestamp
 }


### PR DESCRIPTION
Resolves #332 (https://bugzilla.redhat.com/show_bug.cgi?id=1908045)

The UI was treating a VM with the `completed` property as successfully migrated in terms of status shown on the plans table. This PR adds a condition to check for errors when including a VM in that number of completed VMs for the progress bar. Also, there were some issues with identifying the current step in this "completed with errors" case on the VM migration details page. Now the "current step" is considered to be the first step that either has errors or has a started time but not a completed time, and if there is no match (all steps have a completed time and no errors), it is the last step in the pipeline.

I also fixed a bug in the PipelineSummary component where if there is more than one not-started step in a row at the end of the pipeline, the dash would not properly appear between some of them.

Added a new mock plan to reproduce these cases (`plantest-5`).