### PR TITLE
Load and use Provider CRs as source of truth instead of only loading …

### DIFF
--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -33,19 +33,20 @@ import {
   getProviderNameSchema,
   useCreateProviderMutation,
   usePatchProviderMutation,
-  useInventoryProvidersQuery,
+  useClusterProvidersQuery,
 } from '@app/queries';
 
 import './AddEditProviderModal.css';
-import { IProvidersByType, Provider } from '@app/queries/types';
+import { IProviderObject } from '@app/queries/types';
 import { QueryResult } from 'react-query';
 import { vmwareUrlToHostname } from '@app/client/helpers';
 import { HelpIcon } from '@patternfly/react-icons';
 import { QuerySpinnerMode, ResolvedQuery } from '@app/common/components/ResolvedQuery';
+import { IKubeList } from '@app/client/types';
 
 interface IAddEditProviderModalProps {
   onClose: () => void;
-  providerBeingEdited: Provider | null;
+  providerBeingEdited: IProviderObject | null;
 }
 
 const PROVIDER_TYPE_OPTIONS = Object.values(ProviderType).map((type) => ({
@@ -54,11 +55,11 @@ const PROVIDER_TYPE_OPTIONS = Object.values(ProviderType).map((type) => ({
 })) as OptionWithValue<ProviderType>[];
 
 const useAddProviderFormState = (
-  providersQuery: QueryResult<IProvidersByType>,
-  providerBeingEdited: Provider | null
+  clusterProvidersQuery: QueryResult<IKubeList<IProviderObject>>,
+  providerBeingEdited: IProviderObject | null
 ) => {
   const providerTypeField = useFormField<ProviderType | null>(
-    providerBeingEdited?.type || null,
+    providerBeingEdited?.spec.type || null,
     yup.mixed().label('Provider type').oneOf(Object.values(ProviderType)).required()
   );
   const isReplacingCredentialsField = useFormField(false, yup.boolean().required());
@@ -71,13 +72,11 @@ const useAddProviderFormState = (
       providerType: providerTypeField,
       isReplacingCredentials: isReplacingCredentialsField,
       name: useFormField(
-        providerBeingEdited?.name || '',
-        getProviderNameSchema(providersQuery, ProviderType.vsphere, providerBeingEdited)
-          .label('Name')
-          .required()
+        providerBeingEdited?.metadata.name || '',
+        getProviderNameSchema(clusterProvidersQuery, providerBeingEdited).label('Name').required()
       ),
       hostname: useFormField(
-        vmwareUrlToHostname(providerBeingEdited?.object.spec.url || ''),
+        vmwareUrlToHostname(providerBeingEdited?.spec.url || ''),
         vmwareHostnameSchema
       ),
       fingerprint: useFormField(
@@ -98,15 +97,12 @@ const useAddProviderFormState = (
       providerType: providerTypeField,
       isReplacingCredentials: isReplacingCredentialsField,
       clusterName: useFormField(
-        providerBeingEdited?.name || '',
-        getProviderNameSchema(providersQuery, ProviderType.openshift, providerBeingEdited)
+        providerBeingEdited?.metadata.name || '',
+        getProviderNameSchema(clusterProvidersQuery, providerBeingEdited)
           .label('Cluster name')
           .required()
       ),
-      url: useFormField(
-        providerBeingEdited?.object.spec.url || '',
-        urlSchema.label('URL').required()
-      ),
+      url: useFormField(providerBeingEdited?.spec.url || '', urlSchema.label('URL').required()),
       saToken: useFormField('', areCredentialsRequired ? saTokenSchema.required() : saTokenSchema),
     }),
   };
@@ -123,9 +119,9 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
 }: IAddEditProviderModalProps) => {
   usePausedPollingEffect();
 
-  const providersQuery = useInventoryProvidersQuery();
+  const clusterProvidersQuery = useClusterProvidersQuery();
 
-  const forms = useAddProviderFormState(providersQuery, providerBeingEdited);
+  const forms = useAddProviderFormState(clusterProvidersQuery, providerBeingEdited);
   const vmwareForm = forms[ProviderType.vsphere];
   const openshiftForm = forms[ProviderType.openshift];
   const providerTypeField = vmwareForm.fields.providerType;
@@ -191,7 +187,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
         </Stack>
       }
     >
-      <ResolvedQuery result={providersQuery} errorTitle="Error loading providers">
+      <ResolvedQuery result={clusterProvidersQuery} errorTitle="Error loading providers">
         <Form>
           <FormGroup
             label="Type"

--- a/src/app/Providers/components/ProvidersTable/OpenShift/__tests__/OpenShiftProvidersTable.test.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/__tests__/OpenShiftProvidersTable.test.tsx
@@ -7,12 +7,21 @@ import { Router } from 'react-router-dom';
 
 import { NetworkContextProvider } from '@app/common/context';
 import OpenShiftProvidersTable from '../OpenShiftProvidersTable';
-import { MOCK_PROVIDERS } from '@app/queries/mocks/providers.mock';
+import {
+  MOCK_CLUSTER_PROVIDERS,
+  MOCK_INVENTORY_PROVIDERS,
+} from '@app/queries/mocks/providers.mock';
+import { correlateProviders } from '../../helpers';
+import { ProviderType } from '@app/common/constants';
 
 describe('<OpenShiftProvidersTable />', () => {
   const history = createMemoryHistory();
   const props = {
-    providers: MOCK_PROVIDERS.openshift,
+    providers: correlateProviders(
+      MOCK_CLUSTER_PROVIDERS,
+      MOCK_INVENTORY_PROVIDERS.openshift,
+      ProviderType.openshift
+    ),
   };
 
   it('renders openshift table', () => {

--- a/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
+++ b/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Dropdown, KebabToggle, DropdownItem, DropdownPosition } from '@patternfly/react-core';
 import { useDeleteProviderMutation } from '@app/queries';
-import { Provider } from '@app/queries/types';
+import { ICorrelatedProvider, InventoryProvider } from '@app/queries/types';
 import { PlanStatusType, ProviderType, PROVIDER_TYPE_NAMES } from '@app/common/constants';
 import ConfirmDeleteModal from '@app/common/components/ConfirmDeleteModal';
 import { EditProviderContext } from '@app/Providers/ProvidersPage';
@@ -10,7 +10,7 @@ import { hasCondition } from '@app/common/helpers';
 import { isSameResource } from '@app/queries/helpers';
 
 interface IProviderActionsDropdownProps {
-  provider: Provider;
+  provider: ICorrelatedProvider<InventoryProvider>;
   providerType: ProviderType;
 }
 
@@ -29,9 +29,11 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
     .filter((plan) => hasCondition(plan.status?.conditions || [], PlanStatusType.Executing))
     .find((runningPlan) => {
       const { source, destination } = runningPlan.spec.provider;
-      return isSameResource(provider, source) || isSameResource(provider, destination);
+      return (
+        isSameResource(provider.metadata, source) || isSameResource(provider.metadata, destination)
+      );
     });
-  const isEditDeleteDisabled = !provider.object.spec.url || hasRunningMigration;
+  const isEditDeleteDisabled = !provider.spec.url || hasRunningMigration;
   return (
     <>
       <Dropdown
@@ -44,7 +46,7 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
             key="edit"
             isTooltipEnabled={isEditDeleteDisabled}
             content={
-              !provider.object.spec.url
+              !provider.spec.url
                 ? 'The host provider cannot be edited'
                 : hasRunningMigration
                 ? 'This provider cannot be edited because it has running migrations'
@@ -66,7 +68,7 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
             key="remove"
             isTooltipEnabled={isEditDeleteDisabled}
             content={
-              !provider.object.spec.url
+              !provider.spec.url
                 ? 'The host provider cannot be removed'
                 : hasRunningMigration
                 ? 'This provider cannot be removed because it has running migrations'
@@ -96,7 +98,7 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
         body={
           <>
             Are you sure you want to remove the {PROVIDER_TYPE_NAMES[providerType]} provider &quot;
-            <strong>{provider.name}</strong>&quot;?
+            <strong>{provider.metadata.name}</strong>&quot;?
           </>
         }
         deleteButtonText="Remove"

--- a/src/app/Providers/components/ProvidersTable/ProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/ProvidersTable.tsx
@@ -2,22 +2,41 @@ import * as React from 'react';
 import { ProviderType } from '@app/common/constants';
 import VMwareProvidersTable from './VMware/VMwareProvidersTable';
 import OpenShiftProvidersTable from './OpenShift/OpenShiftProvidersTable';
-import { IProvidersByType } from '@app/queries/types';
+import { IProviderObject, IProvidersByType } from '@app/queries/types';
+import { correlateProviders } from './helpers';
 
 interface IProvidersTableProps {
-  providersByType: IProvidersByType;
+  inventoryProvidersByType: IProvidersByType;
+  clusterProviders: IProviderObject[];
   activeProviderType: ProviderType;
 }
 
 const ProvidersTable: React.FunctionComponent<IProvidersTableProps> = ({
-  providersByType,
+  inventoryProvidersByType,
+  clusterProviders,
   activeProviderType,
 }) => {
   if (activeProviderType === ProviderType.vsphere) {
-    return <VMwareProvidersTable providers={providersByType.vsphere} />;
+    return (
+      <VMwareProvidersTable
+        providers={correlateProviders(
+          clusterProviders,
+          inventoryProvidersByType.vsphere || [],
+          ProviderType.vsphere
+        )}
+      />
+    );
   }
   if (activeProviderType === ProviderType.openshift) {
-    return <OpenShiftProvidersTable providers={providersByType.openshift} />;
+    return (
+      <OpenShiftProvidersTable
+        providers={correlateProviders(
+          clusterProviders,
+          inventoryProvidersByType.openshift || [],
+          ProviderType.openshift
+        )}
+      />
+    );
   }
   return null;
 };

--- a/src/app/Providers/components/ProvidersTable/VMware/__tests__/VMwareProvidersTable.test.tsx
+++ b/src/app/Providers/components/ProvidersTable/VMware/__tests__/VMwareProvidersTable.test.tsx
@@ -5,19 +5,28 @@ import { createMemoryHistory } from 'history';
 import '@testing-library/jest-dom';
 import { Router } from 'react-router-dom';
 
-import VMwareProvidersTables from '../VMwareProvidersTable';
-import { MOCK_PROVIDERS } from '@app/queries/mocks/providers.mock';
+import VMwareProvidersTable from '../VMwareProvidersTable';
+import {
+  MOCK_CLUSTER_PROVIDERS,
+  MOCK_INVENTORY_PROVIDERS,
+} from '@app/queries/mocks/providers.mock';
+import { correlateProviders } from '../../helpers';
+import { ProviderType } from '@app/common/constants';
 
-describe('<VMwareProvidersTables />', () => {
+describe('<VMwareProvidersTable />', () => {
   const history = createMemoryHistory();
   const props = {
-    providers: MOCK_PROVIDERS.vsphere,
+    providers: correlateProviders(
+      MOCK_CLUSTER_PROVIDERS,
+      MOCK_INVENTORY_PROVIDERS.vsphere,
+      ProviderType.vsphere
+    ),
   };
 
   it('renders vsphere table', () => {
     render(
       <Router history={history}>
-        <VMwareProvidersTables {...props} />
+        <VMwareProvidersTable {...props} />
       </Router>
     );
 
@@ -38,20 +47,20 @@ describe('<VMwareProvidersTables />', () => {
   it('renders Hosts links', () => {
     render(
       <Router history={history}>
-        <VMwareProvidersTables {...props} />
+        <VMwareProvidersTable {...props} />
       </Router>
     );
 
     const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2); // NOTE: no link for non-ready vcenter-2 provider
     expect(links[0]).toHaveAttribute('href', '/providers/vcenter-1');
-    expect(links[1]).toHaveAttribute('href', '/providers/vcenter-2');
-    expect(links[2]).toHaveAttribute('href', '/providers/vcenter-3');
+    expect(links[1]).toHaveAttribute('href', '/providers/vcenter-3');
   });
 
   it('renders status condition', async () => {
     render(
       <Router history={history}>
-        <VMwareProvidersTables {...props} />
+        <VMwareProvidersTable {...props} />
       </Router>
     );
 
@@ -65,7 +74,7 @@ describe('<VMwareProvidersTables />', () => {
   it('renders action menu', async () => {
     render(
       <Router history={history}>
-        <VMwareProvidersTables {...props} />
+        <VMwareProvidersTable {...props} />
       </Router>
     );
 

--- a/src/app/Providers/components/ProvidersTable/helpers.ts
+++ b/src/app/Providers/components/ProvidersTable/helpers.ts
@@ -1,0 +1,18 @@
+import { ProviderType } from '@app/common/constants';
+import { isSameResource } from '@app/queries/helpers';
+import { InventoryProvider, ICorrelatedProvider, IProviderObject } from '@app/queries/types';
+
+export const correlateProviders = <T extends InventoryProvider>(
+  clusterProviders: IProviderObject[],
+  inventoryProviders: T[],
+  providerType: ProviderType
+): ICorrelatedProvider<T>[] =>
+  clusterProviders
+    .filter((provider) => provider.spec.type === providerType)
+    .map((provider) => ({
+      ...provider,
+      inventory:
+        inventoryProviders.find((inventoryProvider) =>
+          isSameResource(inventoryProvider, provider.metadata)
+        ) || null,
+    }));

--- a/src/app/Providers/helpers.ts
+++ b/src/app/Providers/helpers.ts
@@ -1,6 +1,0 @@
-import { IProvidersByType } from '@app/queries/types';
-
-export const checkAreProvidersEmpty = (providersByType: IProvidersByType | undefined): boolean =>
-  !providersByType ||
-  Object.keys(providersByType).length === 0 ||
-  Object.keys(providersByType).every((key) => providersByType[key].length === 0);

--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -6,7 +6,7 @@ import KubeClient, {
   CoreNamespacedResource,
 } from '@konveyor/lib-ui';
 import { META, ProviderType, CLUSTER_API_VERSION } from '@app/common/constants';
-import { ICommonProviderObject, INewSecret, Provider } from '@app/queries/types';
+import { IProviderObject, INewSecret } from '@app/queries/types';
 import { useNetworkContext } from '@app/common/context';
 import {
   AddProviderFormValues,
@@ -51,7 +51,7 @@ export const providerResource = new ForkliftResource(ForkliftResourceKind.Provid
 export function convertFormValuesToSecret(
   values: AddProviderFormValues,
   createdForResourceType: ForkliftResourceKind,
-  providerBeingEdited: Provider | null
+  providerBeingEdited: IProviderObject | null
 ): INewSecret {
   if (values.providerType === ProviderType.openshift) {
     const openshiftValues = values as OpenshiftProviderFormValues;
@@ -69,7 +69,7 @@ export function convertFormValuesToSecret(
               generateName: `${openshiftValues.clusterName}-`,
               namespace: META.namespace,
             }
-          : nameAndNamespace(providerBeingEdited.object.spec.secret)),
+          : nameAndNamespace(providerBeingEdited.spec.secret)),
         labels: {
           createdForResourceType,
           createdForResource: openshiftValues.clusterName,
@@ -94,7 +94,7 @@ export function convertFormValuesToSecret(
       metadata: {
         ...(!providerBeingEdited
           ? { generateName: `${vmwareValues.name}-`, namespace: META.namespace }
-          : nameAndNamespace(providerBeingEdited.object.spec.secret)),
+          : nameAndNamespace(providerBeingEdited.spec.secret)),
         labels: {
           createdForResourceType,
           createdForResource: vmwareValues.name,
@@ -114,7 +114,7 @@ export const vmwareHostnameToUrl = (hostname: string): string => `https://${host
 export const convertFormValuesToProvider = (
   values: AddProviderFormValues,
   providerType: ProviderType | null
-): ICommonProviderObject => {
+): IProviderObject => {
   let name: string;
   let url: string;
   if (providerType === 'vsphere') {

--- a/src/app/common/components/StatusCondition.tsx
+++ b/src/app/common/components/StatusCondition.tsx
@@ -16,7 +16,7 @@ const StatusCondition: React.FunctionComponent<IStatusConditionProps> = ({
 }: IStatusConditionProps) => {
   const getStatusType = (severity: string) => {
     if (status) {
-      if (severity === PlanStatusType.Ready || severity === StatusCategoryType.Required) {
+      if (severity === PlanStatusType.Ready) {
         return StatusType.Ok;
       }
       if (severity === StatusCategoryType.Advisory) {
@@ -37,14 +37,18 @@ const StatusCondition: React.FunctionComponent<IStatusConditionProps> = ({
       return <>{unknownFallback}</>;
     }
 
-    const icon = (
-      <StatusIcon status={getStatusType(mostSeriousCondition)} label={mostSeriousCondition} />
-    );
+    let label = mostSeriousCondition;
+    if (mostSeriousCondition === StatusCategoryType.Required) {
+      label = 'Not ready';
+    }
+
+    const icon = <StatusIcon status={getStatusType(mostSeriousCondition)} label={label} />;
 
     if (conditions.length === 0) return icon;
 
     return (
       <Popover
+        hasAutoWidth
         bodyContent={
           <>
             {conditions.map((condition) => {

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -13,40 +13,42 @@ export const hasCondition = (conditions: IStatusCondition[], type: string): bool
   return !!conditions.find((condition) => condition.type === type);
 };
 
-export const hasConditionsByCategory = (
+export const findConditionByCategory = (
   conditions: IStatusCondition[],
   category: string
-): boolean => {
-  return !!conditions.find((condition) => condition.category === category);
+): IStatusCondition | undefined => {
+  return conditions.find((condition) => condition.category === category);
 };
 
 export const getMostSeriousCondition = (conditions: IStatusCondition[]): string => {
-  if (hasConditionsByCategory(conditions, StatusCategoryType.Critical)) {
+  if (findConditionByCategory(conditions, StatusCategoryType.Critical)) {
     return StatusCategoryType.Critical;
   }
-  if (hasConditionsByCategory(conditions, StatusCategoryType.Error)) {
+  if (findConditionByCategory(conditions, StatusCategoryType.Error)) {
     return StatusCategoryType.Error;
   }
   if (
-    hasConditionsByCategory(conditions, StatusCategoryType.Warn) &&
+    findConditionByCategory(conditions, StatusCategoryType.Warn) &&
     !hasCondition(conditions, PlanStatusType.Ready)
   ) {
     return StatusCategoryType.Warn;
   }
+  const requiredCondition = findConditionByCategory(conditions, StatusCategoryType.Required);
   if (
-    hasConditionsByCategory(conditions, StatusCategoryType.Advisory) &&
-    !hasCondition(conditions, PlanStatusType.Ready)
-  ) {
-    return StatusCategoryType.Advisory;
-  }
-  if (
-    hasConditionsByCategory(conditions, StatusCategoryType.Required) &&
+    requiredCondition &&
+    requiredCondition.status !== 'True' &&
     !hasCondition(conditions, PlanStatusType.Ready)
   ) {
     return StatusCategoryType.Required;
   }
   if (
-    hasConditionsByCategory(conditions, StatusCategoryType.Required) &&
+    findConditionByCategory(conditions, StatusCategoryType.Advisory) &&
+    !hasCondition(conditions, PlanStatusType.Ready)
+  ) {
+    return StatusCategoryType.Advisory;
+  }
+  if (
+    findConditionByCategory(conditions, StatusCategoryType.Required) &&
     hasCondition(conditions, PlanStatusType.Ready)
   ) {
     return PlanStatusType.Ready;
@@ -101,4 +103,9 @@ export const isStepOnError = (status: IVMStatus, index: number): boolean => {
   const step = status.pipeline[index];
   if (step.error) return true;
   return false;
+};
+
+export const numStr = (num: number | undefined): string => {
+  if (num === undefined) return '';
+  return String(num);
 };

--- a/src/app/queries/mocks/hosts.mock.ts
+++ b/src/app/queries/mocks/hosts.mock.ts
@@ -1,7 +1,7 @@
 import { CLUSTER_API_VERSION, META } from '@app/common/constants';
 import { nameAndNamespace } from '../helpers';
 import { IHost, IHostConfig } from '../types/hosts.types';
-import { MOCK_PROVIDERS } from './providers.mock';
+import { MOCK_INVENTORY_PROVIDERS } from './providers.mock';
 
 export let MOCK_HOSTS: IHost[] = [];
 export let MOCK_HOST_CONFIGS: IHostConfig[] = [];
@@ -192,7 +192,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       spec: {
         id: host1.id,
         ipAddress: host1.networkAdapters[0].ipAddress,
-        provider: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
+        provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
       },
     },
   ];

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -1,6 +1,6 @@
 import { IStorageMapping, INetworkMapping } from '../types/mappings.types';
 import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from './storageClasses.mock';
-import { MOCK_PROVIDERS } from './providers.mock';
+import { MOCK_INVENTORY_PROVIDERS } from './providers.mock';
 import { MOCK_OPENSHIFT_NETWORKS, MOCK_VMWARE_NETWORKS } from './networks.mock';
 import { MOCK_VMWARE_DATASTORES } from './datastores.mock';
 import { nameAndNamespace } from '../helpers';
@@ -19,8 +19,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
     spec: {
       provider: {
-        source: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_PROVIDERS.openshift[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       map: [
         {
@@ -44,8 +44,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
     spec: {
       provider: {
-        source: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_PROVIDERS.openshift[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       map: [
         {
@@ -71,8 +71,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
     spec: {
       provider: {
-        source: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_PROVIDERS.openshift[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       map: [
         {
@@ -97,8 +97,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
     spec: {
       provider: {
-        source: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_PROVIDERS.openshift[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       map: [
         {
@@ -123,8 +123,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
     spec: {
       provider: {
-        source: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_PROVIDERS.openshift[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       map: [
         {

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -1,5 +1,5 @@
 import { IPlan, IPlanVM, IVMStatus } from '../types';
-import { MOCK_PROVIDERS } from '@app/queries/mocks/providers.mock';
+import { MOCK_INVENTORY_PROVIDERS } from '@app/queries/mocks/providers.mock';
 import { CLUSTER_API_VERSION } from '@app/common/constants';
 import { nameAndNamespace } from '../helpers';
 import { MOCK_NETWORK_MAPPINGS, MOCK_STORAGE_MAPPINGS } from './mappings.mock';
@@ -201,8 +201,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     spec: {
       description: 'my first plan',
       provider: {
-        source: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_PROVIDERS.openshift[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
       map: {
@@ -218,7 +218,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           lastTransitionTime: '2020-09-18T16:04:10Z',
           message: 'The destination provider is not valid.',
           reason: 'TypeNotValid',
-          status: true,
+          status: 'True',
           type: 'DestinationProviderNotValid',
         },
         {
@@ -226,7 +226,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           lastTransitionTime: '2020-09-18T16:04:10Z',
           message: 'Source network not valid.',
           reason: 'NotFound',
-          status: true,
+          status: 'True',
           type: 'SourceNetworkNotValid',
         },
         {
@@ -234,7 +234,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           lastTransitionTime: '2020-09-18T16:04:10Z',
           message: 'In progress',
           reason: 'Valid',
-          status: true,
+          status: 'True',
           type: 'Executing',
         },
       ],
@@ -263,8 +263,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     spec: {
       description: 'my 2nd plan',
       provider: {
-        source: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_PROVIDERS.openshift[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
       map: {
@@ -280,7 +280,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           lastTransitionTime: '2020-09-18T16:04:10Z',
           message: 'Ready for migration',
           reason: 'Valid',
-          status: true,
+          status: 'True',
           type: 'Ready',
         },
       ],
@@ -304,8 +304,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     spec: {
       description: 'my 3nd plan',
       provider: {
-        source: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_PROVIDERS.openshift[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
       map: {
@@ -321,7 +321,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           lastTransitionTime: '2020-09-10T16:04:10Z',
           message: 'Ready for migration',
           reason: 'Valid',
-          status: true,
+          status: 'True',
           type: 'Failed',
         },
       ],
@@ -350,8 +350,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     spec: {
       description: 'my 4th plan',
       provider: {
-        source: nameAndNamespace(MOCK_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_PROVIDERS.openshift[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
       map: {
@@ -367,7 +367,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           lastTransitionTime: '2020-09-10T16:04:10Z',
           message: 'Ready for migration',
           reason: 'Valid',
-          status: true,
+          status: 'True',
           type: 'Succeeded',
         },
       ],
@@ -433,7 +433,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           lastTransitionTime: '2020-09-10T16:04:10Z',
           message: 'Ready for migration',
           reason: 'Valid',
-          status: true,
+          status: 'True',
           type: 'Failed',
         },
       ],

--- a/src/app/queries/mocks/providers.mock.ts
+++ b/src/app/queries/mocks/providers.mock.ts
@@ -1,169 +1,180 @@
-import { IVMwareProvider, IOpenShiftProvider, IProvidersByType } from '../types/providers.types';
+import {
+  IVMwareProvider,
+  IOpenShiftProvider,
+  IProvidersByType,
+  IProviderObject,
+} from '../types/providers.types';
 import { ProviderType } from '@app/common/constants';
 
-export let MOCK_PROVIDERS: IProvidersByType = {
+export let MOCK_INVENTORY_PROVIDERS: IProvidersByType = {
   [ProviderType.vsphere]: [],
   [ProviderType.openshift]: [],
 };
 
-// TODO put this condition back when we don't directly import mocks into components anymore
-// if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-const vmwareProvider1: IVMwareProvider = {
-  uid: '1',
-  version: '12345',
-  namespace: 'openshift-migration',
-  name: 'vcenter-1',
-  selfLink: '/foo/vmwareprovider/1',
-  type: ProviderType.vsphere,
-  object: {
-    apiVersion: '12345',
-    kind: 'foo-kind',
-    metadata: {
-      name: 'VCenter1',
-      namespace: 'openshift-migration',
-      selfLink: '/foo/bar',
-      uid: 'foo-uid',
-      resourceVersion: '12345',
-      generation: 1,
-      creationTimestamp: '2020-08-21T18:36:41.468Z',
-    },
-    spec: {
-      type: ProviderType.vsphere,
-      url: 'vcenter.v2v.bos.redhat.com',
-      secret: {
+export let MOCK_CLUSTER_PROVIDERS: IProviderObject[];
+
+if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
+  const vmwareProvider1: IVMwareProvider = {
+    uid: '1',
+    version: '12345',
+    namespace: 'openshift-migration',
+    name: 'vcenter-1',
+    selfLink: '/foo/vmwareprovider/1',
+    type: ProviderType.vsphere,
+    object: {
+      apiVersion: '12345',
+      kind: 'foo-kind',
+      metadata: {
+        name: 'vcenter-1',
         namespace: 'openshift-migration',
-        name: 'boston',
+        selfLink: '/foo/bar',
+        uid: 'foo-uid',
+        resourceVersion: '12345',
+        generation: 1,
+        creationTimestamp: '2020-08-21T18:36:41.468Z',
+      },
+      spec: {
+        type: ProviderType.vsphere,
+        url: 'vcenter.v2v.bos.redhat.com',
+        secret: {
+          namespace: 'openshift-migration',
+          name: 'boston',
+        },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+            category: 'Required',
+            message: 'The provider is ready.',
+            lastTransitionTime: '2020-08-21T18:36:41.468Z',
+            reason: '',
+          },
+        ],
+        observedGeneration: 1,
       },
     },
-    status: {
-      conditions: [
-        {
-          type: 'Ready',
-          status: true,
-          category: 'Required',
-          message: 'The provider is ready.',
-          lastTransitionTime: '2020-08-21T18:36:41.468Z',
-          reason: '',
-        },
-      ],
-      observedGeneration: 1,
-    },
-  },
-  datacenterCount: 1,
-  clusterCount: 2,
-  hostCount: 2,
-  vmCount: 41,
-  networkCount: 8,
-  datastoreCount: 3,
-};
+    datacenterCount: 1,
+    clusterCount: 2,
+    hostCount: 2,
+    vmCount: 41,
+    networkCount: 8,
+    datastoreCount: 3,
+  };
 
-const vmwareProvider2: IVMwareProvider = {
-  ...vmwareProvider1,
-  uid: '2',
-  name: 'vcenter-2',
-  selfLink: '/foo/vmwareprovider/2',
-  object: {
-    ...vmwareProvider1.object,
-    metadata: {
-      ...vmwareProvider1.object.metadata,
-      name: 'VCenter2',
+  const vmwareProvider2: IVMwareProvider = {
+    ...vmwareProvider1,
+    uid: '2',
+    name: 'vcenter-2',
+    selfLink: '/foo/vmwareprovider/2',
+    object: {
+      ...vmwareProvider1.object,
+      metadata: {
+        ...vmwareProvider1.object.metadata,
+        name: 'vcenter-2',
+      },
+      status: {
+        conditions: [
+          {
+            type: 'URLNotValid',
+            status: 'True',
+            category: 'Critical',
+            message: 'The provider is not responding.',
+            lastTransitionTime: '2020-08-21T18:36:41.468Z',
+            reason: '',
+          },
+        ],
+        observedGeneration: 1,
+      },
     },
-    status: {
-      conditions: [
-        {
-          type: 'URLNotValid',
-          status: true,
-          category: 'Critical',
-          message: 'The provider is not responding.',
-          lastTransitionTime: '2020-08-21T18:36:41.468Z',
-          reason: '',
-        },
-      ],
-      observedGeneration: 1,
-    },
-  },
-};
+  };
 
-const vmwareProvider3: IVMwareProvider = {
-  ...vmwareProvider1,
-  uid: '3',
-  name: 'vcenter-3',
-  selfLink: '/foo/vmwareprovider/3',
-  object: {
-    ...vmwareProvider1.object,
-    metadata: {
-      ...vmwareProvider1.object.metadata,
-      name: 'VCenter3',
+  const vmwareProvider3: IVMwareProvider = {
+    ...vmwareProvider1,
+    uid: '3',
+    name: 'vcenter-3',
+    selfLink: '/foo/vmwareprovider/3',
+    object: {
+      ...vmwareProvider1.object,
+      metadata: {
+        ...vmwareProvider1.object.metadata,
+        name: 'vcenter-3',
+      },
     },
-  },
-};
+  };
 
-const openshiftProvider1: IOpenShiftProvider = {
-  ...vmwareProvider1,
-  uid: '1',
-  name: 'ocpv-1',
-  selfLink: '/foo/openshiftprovider/1',
-  type: ProviderType.openshift,
-  object: {
-    ...vmwareProvider1.object,
-    metadata: {
-      ...vmwareProvider1.object.metadata,
-      name: 'ocpv-1',
+  const openshiftProvider1: IOpenShiftProvider = {
+    ...vmwareProvider1,
+    uid: '1',
+    name: 'ocpv-1',
+    selfLink: '/foo/openshiftprovider/1',
+    type: ProviderType.openshift,
+    object: {
+      ...vmwareProvider1.object,
+      metadata: {
+        ...vmwareProvider1.object.metadata,
+        name: 'ocpv-1',
+      },
+      spec: {
+        ...vmwareProvider1.object.spec,
+        type: ProviderType.openshift,
+        url: 'https://my_OCPv_url',
+      },
     },
-    spec: {
-      ...vmwareProvider1.object.spec,
-      type: ProviderType.openshift,
-      url: 'https://my_OCPv_url',
-    },
-  },
-  namespaceCount: 41,
-  vmCount: 26,
-  networkCount: 8,
-};
+    namespaceCount: 41,
+    vmCount: 26,
+    networkCount: 8,
+  };
 
-const openshiftProvider2: IOpenShiftProvider = {
-  ...openshiftProvider1,
-  uid: '2',
-  name: 'ocpv-2',
-  selfLink: '/foo/openshiftprovider/2',
-  object: {
-    ...openshiftProvider1.object,
-    metadata: {
-      ...openshiftProvider1.object.metadata,
-      name: 'ocpv-2',
+  const openshiftProvider2: IOpenShiftProvider = {
+    ...openshiftProvider1,
+    uid: '2',
+    name: 'ocpv-2',
+    selfLink: '/foo/openshiftprovider/2',
+    object: {
+      ...openshiftProvider1.object,
+      metadata: {
+        ...openshiftProvider1.object.metadata,
+        name: 'ocpv-2',
+      },
+      status: {
+        conditions: [
+          {
+            type: 'URLNotValid',
+            status: 'True',
+            category: 'Critical',
+            message: 'The provider is not responding.',
+            lastTransitionTime: '2020-08-21T18:36:41.468Z',
+            reason: '',
+          },
+        ],
+        observedGeneration: 1,
+      },
     },
-    status: {
-      conditions: [
-        {
-          type: 'URLNotValid',
-          status: true,
-          category: 'Critical',
-          message: 'The provider is not responding.',
-          lastTransitionTime: '2020-08-21T18:36:41.468Z',
-          reason: '',
-        },
-      ],
-      observedGeneration: 1,
-    },
-  },
-};
+  };
 
-const openshiftProvider3: IOpenShiftProvider = {
-  ...openshiftProvider1,
-  uid: '3',
-  name: 'ocpv-3',
-  selfLink: '/foo/openshiftprovider/3',
-  object: {
-    ...openshiftProvider1.object,
-    metadata: {
-      ...openshiftProvider1.object.metadata,
-      name: 'ocpv-3',
+  const openshiftProvider3: IOpenShiftProvider = {
+    ...openshiftProvider1,
+    uid: '3',
+    name: 'ocpv-3',
+    selfLink: '/foo/openshiftprovider/3',
+    object: {
+      ...openshiftProvider1.object,
+      metadata: {
+        ...openshiftProvider1.object.metadata,
+        name: 'ocpv-3',
+      },
     },
-  },
-};
+  };
 
-MOCK_PROVIDERS = {
-  [ProviderType.vsphere]: [vmwareProvider1, vmwareProvider2, vmwareProvider3],
-  [ProviderType.openshift]: [openshiftProvider1, openshiftProvider2, openshiftProvider3],
-};
-// }
+  MOCK_INVENTORY_PROVIDERS = {
+    [ProviderType.vsphere]: [vmwareProvider1, vmwareProvider2, vmwareProvider3],
+    [ProviderType.openshift]: [openshiftProvider1, openshiftProvider2, openshiftProvider3],
+  };
+
+  MOCK_CLUSTER_PROVIDERS = [
+    ...MOCK_INVENTORY_PROVIDERS[ProviderType.vsphere],
+    ...MOCK_INVENTORY_PROVIDERS[ProviderType.openshift],
+  ].map((inventoryProvider) => ({ ...inventoryProvider.object }));
+}

--- a/src/app/queries/networks.ts
+++ b/src/app/queries/networks.ts
@@ -9,12 +9,12 @@ import {
   IVMwareNetwork,
   IVMwareProvider,
   MappingType,
-  Provider,
+  InventoryProvider,
 } from './types';
 import { useAuthorizedFetch } from './fetchHelpers';
 
 export const useNetworksQuery = <T extends IVMwareNetwork | IOpenShiftNetwork>(
-  provider: Provider | null,
+  provider: InventoryProvider | null,
   providerType: ProviderType,
   mappingType: MappingType,
   mockNetworks: T[]

--- a/src/app/queries/storageClasses.ts
+++ b/src/app/queries/storageClasses.ts
@@ -6,14 +6,17 @@ import { MOCK_STORAGE_CLASSES_BY_PROVIDER } from './mocks/storageClasses.mock';
 import { authorizedFetch, useFetchContext } from './fetchHelpers';
 
 export const useStorageClassesQuery = (
-  providers: IOpenShiftProvider[] | null,
+  providers: (IOpenShiftProvider | null)[] | null,
   mappingType: MappingType
 ): QueryResult<IStorageClassesByProvider> => {
   const fetchContext = useFetchContext();
+  const definedProviders = providers
+    ? (providers.filter((provider) => !!provider) as IOpenShiftProvider[])
+    : [];
   const result = useMockableQuery<IStorageClassesByProvider>(
     {
       // Key by the provider names combined, so it refetches if the list of providers changes
-      queryKey: ['storageClasses', ...(providers || []).map((provider) => provider.name)],
+      queryKey: ['storageClasses', ...definedProviders.map((provider) => provider.name)],
       // Fetch multiple resources in one query via Promise.all()
       queryFn: async () => {
         const storageClassLists: IStorageClass[][] = await Promise.all(
@@ -24,7 +27,7 @@ export const useStorageClassesQuery = (
             )
           )
         );
-        return (providers || []).reduce(
+        return definedProviders.reduce(
           (newObj, provider, index) => ({ ...newObj, [provider.name]: storageClassLists[index] }),
           {} as IStorageClassesByProvider
         );

--- a/src/app/queries/types/common.types.ts
+++ b/src/app/queries/types/common.types.ts
@@ -33,7 +33,7 @@ export interface ICR extends IMetaTypeMeta {
 export interface IStatusCondition {
   category: string;
   type: string;
-  status: boolean;
+  status: 'True' | 'False';
   reason?: string;
   durable?: boolean;
   message: string;

--- a/src/app/queries/types/providers.types.ts
+++ b/src/app/queries/types/providers.types.ts
@@ -7,7 +7,7 @@ import {
   IStatusCondition,
 } from '@app/queries/types';
 
-export interface ICommonProviderObject extends ICR {
+export interface IProviderObject extends ICR {
   spec: {
     type: ProviderType | null;
     url?: string; // No url = host provider
@@ -46,7 +46,7 @@ export interface ICommonProvider {
   name: string;
   selfLink: string;
   type: ProviderType;
-  object: ICommonProviderObject;
+  object: IProviderObject;
 }
 
 export interface IVMwareProvider extends ICommonProvider {
@@ -64,11 +64,15 @@ export interface IOpenShiftProvider extends ICommonProvider {
   namespaceCount: number;
 }
 
-export type Provider = IVMwareProvider | IOpenShiftProvider;
+export type InventoryProvider = IVMwareProvider | IOpenShiftProvider;
 
 export interface IProvidersByType {
   [ProviderType.vsphere]: IVMwareProvider[];
   [ProviderType.openshift]: IOpenShiftProvider[];
+}
+
+export interface ICorrelatedProvider<T extends InventoryProvider> extends IProviderObject {
+  inventory: T | null;
 }
 
 export interface ISrcDestRefs {


### PR DESCRIPTION
…providers from inventory (#334)

* Fix some naming, types and mock data

* Use provider CRs as the source of truth, add ICorrelatedProvider type to attach inventory data

* Factor out helper, fix tests

* Properly handle a false Required condition as 'Not ready' warning status

* Don't link to hosts page for a provider that isn't ready

* Fix mock data for status boolean-to-string change

* Fix tests

* Fix type error after rebase

(cherry picked from commit 03f3ec5de848d6b488433349f3daef5fb2ae54dc)