### PR TITLE
[Backport] Adds navigation for provider types (#343)

### DIFF
--- a/src/app/Providers/HostsPage.tsx
+++ b/src/app/Providers/HostsPage.tsx
@@ -27,7 +27,7 @@ export interface IHostsMatchParams {
 
 export const HostsPage: React.FunctionComponent = () => {
   const match = useRouteMatch<IHostsMatchParams>({
-    path: '/providers/:providerName',
+    path: '/providers/vsphere/:providerName',
     strict: true,
     sensitive: true,
   });
@@ -47,6 +47,9 @@ export const HostsPage: React.FunctionComponent = () => {
             <Breadcrumb>
               <BreadcrumbItem>
                 <Link to={`/providers`}>Providers</Link>
+              </BreadcrumbItem>
+              <BreadcrumbItem>
+                <Link to={`/providers/vsphere`}>VMware</Link>
               </BreadcrumbItem>
               <BreadcrumbItem>{match?.params.providerName}</BreadcrumbItem>
               <BreadcrumbItem isActive>Hosts</BreadcrumbItem>

--- a/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
@@ -131,7 +131,7 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
         hostCount !== undefined
           ? {
               title: hasCondition(provider.status?.conditions || [], PlanStatusType.Ready) ? (
-                <Link to={`/providers/${provider.metadata.name}`}>{hostsCell}</Link>
+                <Link to={`/providers/vsphere/${provider.metadata.name}`}>{hostsCell}</Link>
               ) : (
                 hostsCell
               ),

--- a/src/app/Providers/components/ProvidersTable/VMware/__tests__/VMwareProvidersTable.test.tsx
+++ b/src/app/Providers/components/ProvidersTable/VMware/__tests__/VMwareProvidersTable.test.tsx
@@ -53,8 +53,8 @@ describe('<VMwareProvidersTable />', () => {
 
     const links = screen.getAllByRole('link');
     expect(links).toHaveLength(2); // NOTE: no link for non-ready vcenter-2 provider
-    expect(links[0]).toHaveAttribute('href', '/providers/vcenter-1');
-    expect(links[1]).toHaveAttribute('href', '/providers/vcenter-3');
+    expect(links[0]).toHaveAttribute('href', '/providers/vsphere/vcenter-1');
+    expect(links[1]).toHaveAttribute('href', '/providers/vsphere/vcenter-3');
   });
 
   it('renders status condition', async () => {

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { App } from '.';
 import { APP_TITLE } from './common/constants';
@@ -7,7 +7,6 @@ import { APP_TITLE } from './common/constants';
 describe('App', () => {
   test('renders welcome page without errors', async () => {
     render(<App />);
-    await waitFor(() => screen.getByRole('heading'));
-    expect(screen.getByRole('heading')).toHaveTextContent(APP_TITLE);
+    expect(screen.getByRole('heading', { name: new RegExp(APP_TITLE) })).toBeInTheDocument;
   });
 });

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -65,9 +65,17 @@ export const routes: AppRouteConfig[] = [
     isProtected: true,
   },
   {
+    component: ProvidersPage,
+    exact: true,
+    path: '/providers/:providerType',
+    title: `${APP_TITLE} | Providers`,
+    isProtected: true,
+    // No label property, so it won't be rendered in the nav
+  },
+  {
     component: HostsPage,
     exact: false,
-    path: '/providers/:providerName',
+    path: '/providers/vsphere/:providerName',
     title: `${APP_TITLE} | Hosts`,
     isProtected: true,
   },


### PR DESCRIPTION
* Add navigation for provider types

* Fix tests

* Use better selector for welcome heading

* useHistory() instead of useState() for current provider tab

* Get welcome heading with role's name

* Restore useEffect to select initial tab when on base /providers route

* Use APP_TITLE in test instead of hard-coding Forklift

Co-authored-by: Mike Turley <mike.turley@alum.cs.umass.edu>