### PR TITLE
Also run CI checks after merging to release branches

### DIFF
--- a/.github/workflows/tests-ci.yaml
+++ b/.github/workflows/tests-ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release*
 
 jobs:
   tests:


### PR DESCRIPTION
Adds a glob to the CI workflow file to run post-merge CI checks on branches matching `release*`. This way we can be absolutely sure CI is passing there in case someone did a manual merge or something else changed on the branch somehow. Also, this will provide Codecov with a base coverage report for backport PRs.