### PR TITLE
Load and prefill secrets in the edit provider and select host network forms

### DIFF
--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -34,6 +34,7 @@ import {
   useCreateProviderMutation,
   usePatchProviderMutation,
   useClusterProvidersQuery,
+  useSecretQuery,
 } from '@app/queries';
 
 import './AddEditProviderModal.css';
@@ -120,6 +121,8 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
   usePausedPollingEffect();
 
   const clusterProvidersQuery = useClusterProvidersQuery();
+  const secretQuery = useSecretQuery(providerBeingEdited?.spec.secret?.name);
+  console.log({ secretQuery });
 
   const forms = useAddProviderFormState(clusterProvidersQuery, providerBeingEdited);
   const vmwareForm = forms[ProviderType.vsphere];

--- a/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -104,6 +104,9 @@ describe('<AddEditProviderModal />', () => {
       </NetworkContextProvider>
     );
 
+    await waitFor(() => {
+      expect(screen.getByText('Type')).toBeInTheDocument();
+    });
     const addButton = await screen.findByRole('button', { name: /Save/ });
     expect(addButton).not.toHaveAttribute('disabled');
   });

--- a/src/app/Providers/components/AddEditProviderModal/helpers.ts
+++ b/src/app/Providers/components/AddEditProviderModal/helpers.ts
@@ -1,0 +1,57 @@
+import { useSecretQuery } from '@app/queries';
+import * as React from 'react';
+import { IProviderObject } from '@app/queries/types';
+import { AddProviderFormState } from './AddEditProviderModal';
+import { ProviderType } from '@app/common/constants';
+import { vmwareUrlToHostname } from '@app/client/helpers';
+
+interface IEditProviderPrefillEffect {
+  isDonePrefilling: boolean;
+}
+
+export const useEditProviderPrefillEffect = (
+  forms: AddProviderFormState,
+  providerBeingEdited: IProviderObject | null
+): IEditProviderPrefillEffect => {
+  const [isDonePrefilling, setIsDonePrefilling] = React.useState(!providerBeingEdited);
+  const secretQuery = useSecretQuery(providerBeingEdited?.spec.secret?.name);
+  React.useEffect(() => {
+    if (
+      providerBeingEdited &&
+      !forms.vsphere.isDirty &&
+      !forms.openshift.isDirty &&
+      secretQuery.isSuccess
+    ) {
+      const secret = secretQuery.data;
+      if (providerBeingEdited.spec.type === ProviderType.vsphere) {
+        const { fields } = forms.vsphere;
+        fields.providerType.setValue(providerBeingEdited.spec.type);
+        fields.providerType.setIsTouched(true);
+        fields.name.setValue(providerBeingEdited.metadata.name);
+        fields.name.setIsTouched(true);
+        fields.hostname.setValue(vmwareUrlToHostname(providerBeingEdited.spec.url || ''));
+        fields.hostname.setIsTouched(true);
+        fields.username.setValue(atob(secret?.data.user || ''));
+        fields.username.setIsTouched(true);
+        fields.password.setValue(atob(secret?.data.password || ''));
+        fields.fingerprint.setValue(atob(secret?.data.thumbprint || ''));
+        fields.fingerprint.setIsTouched(true);
+      } else if (providerBeingEdited.spec.type === ProviderType.openshift) {
+        const { fields } = forms.openshift;
+        fields.providerType.setValue(providerBeingEdited.spec.type);
+        fields.providerType.setIsTouched(true);
+        fields.name.setValue(providerBeingEdited.metadata.name);
+        fields.name.setIsTouched(true);
+        fields.url.setValue(providerBeingEdited.spec.url || '');
+        fields.url.setIsTouched(true);
+        fields.saToken.setValue(atob(secret?.data.token || ''));
+        fields.saToken.setIsTouched(true);
+      }
+      // Wait for effects to run based on field changes first
+      window.setTimeout(() => {
+        setIsDonePrefilling(true);
+      }, 0);
+    }
+  }, [forms, providerBeingEdited, secretQuery.data, secretQuery.isSuccess]);
+  return { isDonePrefilling };
+};

--- a/src/app/Providers/components/AddEditProviderModal/helpers.ts
+++ b/src/app/Providers/components/AddEditProviderModal/helpers.ts
@@ -14,7 +14,7 @@ export const useEditProviderPrefillEffect = (
   providerBeingEdited: IProviderObject | null
 ): IEditProviderPrefillEffect => {
   const [isDonePrefilling, setIsDonePrefilling] = React.useState(!providerBeingEdited);
-  const secretQuery = useSecretQuery(providerBeingEdited?.spec.secret?.name);
+  const secretQuery = useSecretQuery(providerBeingEdited?.spec.secret?.name || null);
   React.useEffect(() => {
     if (
       providerBeingEdited &&

--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -6,7 +6,7 @@ import KubeClient, {
   CoreNamespacedResource,
 } from '@konveyor/lib-ui';
 import { META, ProviderType, CLUSTER_API_VERSION } from '@app/common/constants';
-import { IProviderObject, INewSecret } from '@app/queries/types';
+import { IProviderObject, ISecret } from '@app/queries/types';
 import { useNetworkContext } from '@app/common/context';
 import {
   AddProviderFormValues,
@@ -52,7 +52,7 @@ export function convertFormValuesToSecret(
   values: AddProviderFormValues,
   createdForResourceType: ForkliftResourceKind,
   providerBeingEdited: IProviderObject | null
-): INewSecret {
+): ISecret {
   if (values.providerType === ProviderType.openshift) {
     const openshiftValues = values as OpenshiftProviderFormValues;
     // btoa => to base64, atob => from base64

--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -66,13 +66,13 @@ export function convertFormValuesToSecret(
       metadata: {
         ...(!providerBeingEdited
           ? {
-              generateName: `${openshiftValues.clusterName}-`,
+              generateName: `${openshiftValues.name}-`,
               namespace: META.namespace,
             }
           : nameAndNamespace(providerBeingEdited.spec.secret)),
         labels: {
           createdForResourceType,
-          createdForResource: openshiftValues.clusterName,
+          createdForResource: openshiftValues.name,
         },
       },
       type: 'Opaque',
@@ -123,7 +123,7 @@ export const convertFormValuesToProvider = (
     url = vmwareHostnameToUrl(vmwareValues.hostname);
   } else {
     const openshiftValues = values as OpenshiftProviderFormValues;
-    name = openshiftValues.clusterName;
+    name = openshiftValues.name;
     url = openshiftValues.url;
   }
   return {

--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -10,7 +10,7 @@ import {
   mockKubeList,
 } from './helpers';
 import { MOCK_HOSTS, MOCK_HOST_CONFIGS } from './mocks/hosts.mock';
-import { IHost, IHostConfig, INameNamespaceRef, INewSecret, IVMwareProvider } from './types';
+import { IHost, IHostConfig, INameNamespaceRef, ISecret, IVMwareProvider } from './types';
 import { useAuthorizedFetch, useAuthorizedK8sClient } from './fetchHelpers';
 import { IKubeList, IKubeResponse, KubeClientError } from '@app/client/types';
 import { SelectNetworkFormValues } from '@app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal';
@@ -76,7 +76,7 @@ const generateSecret = (
   host: IHost,
   provider: IVMwareProvider,
   hostConfig?: IHostConfig
-): INewSecret => ({
+): ISecret => ({
   apiVersion: 'v1',
   data: {
     user: values.adminUsername && btoa(values.adminUsername),
@@ -156,8 +156,8 @@ export const useConfigureHostsMutation = (
         // Create or update a secret CR
         const newSecret = generateSecret(values, existingSecret, host, provider);
         const secretResult = await (existingSecret
-          ? client.patch<INewSecret>(secretResource, existingSecret.name, newSecret)
-          : client.create<INewSecret>(secretResource, newSecret));
+          ? client.patch<ISecret>(secretResource, existingSecret.name, newSecret)
+          : client.create<ISecret>(secretResource, newSecret));
         const newSecretRef = nameAndNamespace(secretResult.data.metadata);
 
         // Create or update a host CR
@@ -168,7 +168,7 @@ export const useConfigureHostsMutation = (
 
         // Patch the secret CR with an ownerReference to the host CR
         const updatedSecret = generateSecret(values, newSecretRef, host, provider, hostResult.data);
-        await client.patch<INewSecret>(secretResource, newSecretRef.name, updatedSecret);
+        await client.patch<ISecret>(secretResource, newSecretRef.name, updatedSecret);
 
         return hostResult;
       })

--- a/src/app/queries/index.ts
+++ b/src/app/queries/index.ts
@@ -6,3 +6,4 @@ export * from './tree';
 export * from './vms';
 export * from './plans';
 export * from './migrations';
+export * from './secrets';

--- a/src/app/queries/mocks/hosts.mock.ts
+++ b/src/app/queries/mocks/hosts.mock.ts
@@ -193,6 +193,10 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         id: host1.id,
         ipAddress: host1.networkAdapters[0].ipAddress,
         provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        secret: {
+          name: 'mock-secret',
+          namespace: 'openshift-migration',
+        },
       },
     },
   ];

--- a/src/app/queries/mocks/secrets.mock.ts
+++ b/src/app/queries/mocks/secrets.mock.ts
@@ -1,0 +1,5 @@
+import { ISecret } from '../types';
+
+export let MOCK_SECRET: ISecret;
+
+// TODO

--- a/src/app/queries/mocks/secrets.mock.ts
+++ b/src/app/queries/mocks/secrets.mock.ts
@@ -2,4 +2,25 @@ import { ISecret } from '../types';
 
 export let MOCK_SECRET: ISecret;
 
-// TODO
+if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
+  MOCK_SECRET = {
+    kind: 'Secret',
+    apiVersion: 'v1',
+    metadata: {
+      name: 'mock-secret',
+      namespace: 'openshift-migration',
+      selfLink: '/foo/secret',
+      uid: 'e0f1078b-ce2a-4487-8281-5176267b78c2',
+      resourceVersion: '1128317',
+      creationTimestamp: '2020-12-18T17:43:30Z',
+    },
+    data: {
+      password: 'bW9jay1wYXNzd29yZA==',
+      thumbprint:
+        'Mzk6NUQ6NkE6MkQ6MzY6Mzg6QjI6NTI6MkI6MjE6RUE6NzQ6MTE6NTk6ODk6NUU6MjA6RDU6RDk6QTU=',
+      user: 'bW9jay11c2Vy',
+      token: 'bW9jay1zYS10b2tlbg==',
+    },
+    type: 'Opaque',
+  };
+}

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -200,14 +200,12 @@ export const usePatchProviderMutation = (
         secret: providerBeingEdited?.spec.secret,
       },
     };
-    if (values.isReplacingCredentials) {
-      const secret = convertFormValuesToSecret(
-        values,
-        ForkliftResourceKind.Provider,
-        providerBeingEdited
-      );
-      await client.patch(secretResource, secret.metadata.name || '', secret);
-    }
+    const secret = convertFormValuesToSecret(
+      values,
+      ForkliftResourceKind.Provider,
+      providerBeingEdited
+    );
+    await client.patch(secretResource, secret.metadata.name || '', secret);
     return await client.patch<IProviderObject>(
       providerResource,
       providerWithSecret.metadata.name,

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -16,7 +16,7 @@ import { MOCK_CLUSTER_PROVIDERS, MOCK_INVENTORY_PROVIDERS } from './mocks/provid
 import {
   IProvidersByType,
   InventoryProvider,
-  INewSecret,
+  ISecret,
   IVMwareProvider,
   IOpenShiftProvider,
   ISrcDestRefs,
@@ -86,14 +86,10 @@ export const useCreateProviderMutation = (
       providerResource,
       providerWithoutSecret.metadata.name
     );
-    const secret: INewSecret = convertFormValuesToSecret(
-      values,
-      ForkliftResourceKind.Provider,
-      null
-    );
+    const secret: ISecret = convertFormValuesToSecret(values, ForkliftResourceKind.Provider, null);
 
-    const providerAddResults: Array<IKubeResponse<INewSecret | IProviderObject>> = [];
-    const providerSecretAddResult = await client.create<INewSecret>(secretResource, secret);
+    const providerAddResults: Array<IKubeResponse<ISecret | IProviderObject>> = [];
+    const providerSecretAddResult = await client.create<ISecret>(secretResource, secret);
 
     if (providerSecretAddResult.status === 201) {
       providerAddResults.push(providerSecretAddResult);
@@ -137,7 +133,7 @@ export const useCreateProviderMutation = (
         name: string;
       }
       const rollbackObjs = providerAddResults.reduce(
-        (rollbackAccum: IRollbackObj[], res: IKubeResponse<IProviderObject | INewSecret>) => {
+        (rollbackAccum: IRollbackObj[], res: IKubeResponse<IProviderObject | ISecret>) => {
           return res.status === 201
             ? [...rollbackAccum, { kind: res.data.kind, name: res.data.metadata.name || '' }]
             : rollbackAccum;

--- a/src/app/queries/secrets.ts
+++ b/src/app/queries/secrets.ts
@@ -13,7 +13,7 @@ import { ISecret } from './types';
 // TODO get rid of the checkbox in the provider form
 // TODO only prefill secrets on the host network form if exactly 1 host is selected
 
-export const useSecretQuery = (secretName?: string): QueryResult<ISecret> => {
+export const useSecretQuery = (secretName: string | null): QueryResult<ISecret> => {
   const client = useAuthorizedK8sClient();
   return useMockableQuery<ISecret>(
     {

--- a/src/app/queries/secrets.ts
+++ b/src/app/queries/secrets.ts
@@ -1,0 +1,1 @@
+export const useSecretQuery = () => {}; // TODO

--- a/src/app/queries/secrets.ts
+++ b/src/app/queries/secrets.ts
@@ -1,1 +1,29 @@
-export const useSecretQuery = () => {}; // TODO
+import { secretResource } from '@app/client/helpers';
+import { usePollingContext } from '@app/common/context';
+import { QueryResult } from 'react-query';
+import { useAuthorizedK8sClient } from './fetchHelpers';
+import { useMockableQuery } from './helpers';
+import { MOCK_SECRET } from './mocks/secrets.mock';
+import { ISecret } from './types';
+
+// TODO use this query in one of the forms to look up the associated secret
+// TODO test it in remote mode to inspect the structure and create the mock data
+// TODO figure out how to decode the secret data
+// TODO adjust the form init to prefill secrets
+// TODO get rid of the checkbox in the provider form
+// TODO only prefill secrets on the host network form if exactly 1 host is selected
+
+export const useSecretQuery = (secretName?: string): QueryResult<ISecret> => {
+  const client = useAuthorizedK8sClient();
+  return useMockableQuery<ISecret>(
+    {
+      queryKey: ['secret', secretName],
+      queryFn: async () => (await client.get<ISecret>(secretResource, secretName || '')).data,
+      config: {
+        refetchInterval: usePollingContext().refetchInterval,
+        enabled: !!secretName,
+      },
+    },
+    MOCK_SECRET
+  );
+};

--- a/src/app/queries/types/common.types.ts
+++ b/src/app/queries/types/common.types.ts
@@ -23,7 +23,16 @@ export interface IMetaObjectMeta {
   annotations?: {
     'kubectl.kubernetes.io/last-applied-configuration': string; // JSON
   };
+  labels?: {
+    createdForResourceType?: string;
+    createdForResource?: string;
+  };
+  managedFields?: unknown[];
   ownerReferences?: IObjectReference[];
+}
+
+export interface IMetaObjectGenerateName extends Partial<IMetaObjectMeta> {
+  generateName?: string;
 }
 
 export interface ICR extends IMetaTypeMeta {

--- a/src/app/queries/types/index.ts
+++ b/src/app/queries/types/index.ts
@@ -8,3 +8,4 @@ export * from './datastores.types';
 export * from './storageClasses.types';
 export * from './tree.types';
 export * from './vms.types';
+export * from './secrets.types';

--- a/src/app/queries/types/providers.types.ts
+++ b/src/app/queries/types/providers.types.ts
@@ -1,11 +1,5 @@
 import { ProviderType } from '@app/common/constants';
-import {
-  ICR,
-  IMetaTypeMeta,
-  INameNamespaceRef,
-  IObjectReference,
-  IStatusCondition,
-} from '@app/queries/types';
+import { ICR, INameNamespaceRef, IStatusCondition } from '@app/queries/types';
 
 export interface IProviderObject extends ICR {
   spec: {
@@ -17,26 +11,6 @@ export interface IProviderObject extends ICR {
     conditions: IStatusCondition[];
     observedGeneration: number;
   };
-}
-
-export interface INewSecret extends IMetaTypeMeta {
-  data: {
-    user?: string;
-    password?: string;
-    thumbprint?: string;
-    token?: string;
-  };
-  metadata: {
-    name?: string;
-    generateName?: string;
-    namespace: string;
-    labels: {
-      createdForResourceType: string;
-      createdForResource: string;
-    };
-    ownerReferences?: IObjectReference[];
-  };
-  type: string;
 }
 
 export interface ICommonProvider {

--- a/src/app/queries/types/secrets.types.ts
+++ b/src/app/queries/types/secrets.types.ts
@@ -1,0 +1,21 @@
+import { IMetaTypeMeta, IObjectReference } from '.';
+
+export interface ISecret extends IMetaTypeMeta {
+  data: {
+    user?: string;
+    password?: string;
+    thumbprint?: string;
+    token?: string;
+  };
+  metadata: {
+    name?: string;
+    generateName?: string;
+    namespace: string;
+    labels: {
+      createdForResourceType: string;
+      createdForResource: string;
+    };
+    ownerReferences?: IObjectReference[];
+  };
+  type: string;
+}

--- a/src/app/queries/types/secrets.types.ts
+++ b/src/app/queries/types/secrets.types.ts
@@ -1,4 +1,4 @@
-import { IMetaTypeMeta, IObjectReference } from '.';
+import { IMetaObjectGenerateName, IMetaTypeMeta } from '.';
 
 export interface ISecret extends IMetaTypeMeta {
   data: {
@@ -7,15 +7,6 @@ export interface ISecret extends IMetaTypeMeta {
     thumbprint?: string;
     token?: string;
   };
-  metadata: {
-    name?: string;
-    generateName?: string;
-    namespace: string;
-    labels: {
-      createdForResourceType: string;
-      createdForResource: string;
-    };
-    ownerReferences?: IObjectReference[];
-  };
+  metadata: IMetaObjectGenerateName;
   type: string;
 }


### PR DESCRIPTION
Resolves #336 (https://bugzilla.redhat.com/show_bug.cgi?id=1907734). Secrets can be loaded and decoded when opening them for editing, so we can get rid of our logic to only require those fields if the user desires to change them, etc.