### PR TITLE
[Backport] Prevent selecting non-ready providers, prevent editing mappings/plans with non-ready associated providers (#358)

### DIFF
--- a/src/app/Mappings/MappingsPage.tsx
+++ b/src/app/Mappings/MappingsPage.tsx
@@ -13,7 +13,11 @@ import { Mapping, MappingType } from '@app/queries/types';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import MappingsTable from './components/MappingsTable';
 import AddEditMappingModal from './components/AddEditMappingModal';
-import { useHasSufficientProvidersQuery, useMappingsQuery } from '@app/queries';
+import {
+  useClusterProvidersQuery,
+  useHasSufficientProvidersQuery,
+  useMappingsQuery,
+} from '@app/queries';
 import CreateMappingButton from './components/CreateMappingButton';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 
@@ -25,6 +29,7 @@ const MappingsPage: React.FunctionComponent<IMappingsPageProps> = ({
   mappingType,
 }: IMappingsPageProps) => {
   const sufficientProvidersQuery = useHasSufficientProvidersQuery();
+  const clusterProvidersQuery = useClusterProvidersQuery();
   const mappingsQuery = useMappingsQuery(mappingType);
 
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
@@ -47,8 +52,12 @@ const MappingsPage: React.FunctionComponent<IMappingsPageProps> = ({
       </PageSection>
       <PageSection>
         <ResolvedQueries
-          results={[sufficientProvidersQuery.result, mappingsQuery]}
-          errorTitles={['Error loading providers', 'Error loading mappings']}
+          results={[sufficientProvidersQuery.result, clusterProvidersQuery, mappingsQuery]}
+          errorTitles={[
+            'Error loading provider inventory data',
+            'Error loading providers from cluster',
+            'Error loading mappings',
+          ]}
           errorsInline={false}
         >
           <Card>

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -1,24 +1,9 @@
 import * as React from 'react';
 import * as yup from 'yup';
-import {
-  Modal,
-  Button,
-  Form,
-  FormGroup,
-  Grid,
-  GridItem,
-  Stack,
-  Flex,
-} from '@patternfly/react-core';
+import { Modal, Button, Form, Grid, GridItem, Stack, Flex } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import {
-  useFormField,
-  useFormState,
-  getFormGroupProps,
-  ValidatedTextInput,
-} from '@konveyor/lib-ui';
+import { useFormField, useFormState, ValidatedTextInput } from '@konveyor/lib-ui';
 
-import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
 import { MappingBuilder, IMappingBuilderItem, mappingBuilderItemsSchema } from './MappingBuilder';
 import { getMappingFromBuilderItems } from './MappingBuilder/helpers';
 import { MappingType, IOpenShiftProvider, IVMwareProvider, Mapping } from '@app/queries/types';
@@ -30,6 +15,7 @@ import {
   useMappingsQuery,
   usePatchMappingMutation,
   findProvidersByRefs,
+  useClusterProvidersQuery,
 } from '@app/queries';
 import { usePausedPollingEffect } from '@app/common/context';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
@@ -43,6 +29,8 @@ import {
   ResolvedQueries,
   QuerySpinnerMode,
 } from '@app/common/components/ResolvedQuery';
+import ProviderSelect from '@app/common/components/ProviderSelect';
+import { ProviderType } from '@app/common/constants';
 
 interface IAddEditMappingModalProps {
   title: string;
@@ -85,13 +73,14 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
   usePausedPollingEffect();
 
   const mappingsQuery = useMappingsQuery(mappingType);
-  const providersQuery = useInventoryProvidersQuery();
+  const inventoryProvidersQuery = useInventoryProvidersQuery();
+  const clusterProvidersQuery = useClusterProvidersQuery();
 
   const form = useMappingFormState(mappingsQuery, mappingBeingEdited);
 
   const mappingBeingEditedProviders = findProvidersByRefs(
     mappingBeingEdited?.spec.provider || null,
-    providersQuery
+    inventoryProvidersQuery
   );
 
   const mappingResourceQueries = useMappingResourceQueries(
@@ -105,25 +94,9 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
     mappingBeingEdited,
     mappingType,
     mappingBeingEditedProviders,
-    providersQuery,
+    inventoryProvidersQuery,
     mappingResourceQueries
   );
-
-  // TODO these might be reusable for any other provider dropdowns elsewhere in the UI
-  const sourceProviderOptions: OptionWithValue<IVMwareProvider>[] =
-    providersQuery.isLoading || !providersQuery.data
-      ? []
-      : providersQuery.data.vsphere.map((provider) => ({
-          value: provider,
-          toString: () => provider.name,
-        }));
-  const targetProviderOptions: OptionWithValue<IOpenShiftProvider>[] =
-    providersQuery.isLoading || !providersQuery.data
-      ? []
-      : providersQuery.data.openshift.map((provider) => ({
-          value: provider,
-          toString: () => provider.name,
-        }));
 
   // If you change providers, reset the mapping selections.
   React.useEffect(() => {
@@ -185,7 +158,13 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
       }
     >
       <Form className="extraSelectMargin">
-        <ResolvedQuery result={providersQuery} errorTitle="Error loading providers">
+        <ResolvedQueries
+          results={[inventoryProvidersQuery, clusterProvidersQuery]}
+          errorTitles={[
+            'Error loading provider inventory data',
+            'Error loading providers from cluster',
+          ]}
+        >
           {!isDonePrefilling ? (
             <LoadingEmptyState />
           ) : (
@@ -204,56 +183,20 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                 </GridItem>
                 <GridItem />
                 <GridItem sm={12} md={5}>
-                  <FormGroup
+                  <ProviderSelect
                     label="Source provider"
-                    isRequired
-                    fieldId="source-provider"
-                    validated={form.fields.sourceProvider.isValid ? 'default' : 'error'}
-                    {...getFormGroupProps(form.fields.sourceProvider)}
-                  >
-                    <SimpleSelect
-                      id="source-provider"
-                      aria-label="Source provider"
-                      options={sourceProviderOptions}
-                      value={[
-                        sourceProviderOptions.find(
-                          (option) => option.value.name === form.values.sourceProvider?.name
-                        ),
-                      ]}
-                      onChange={(selection) =>
-                        form.fields.sourceProvider.setValue(
-                          (selection as OptionWithValue<IVMwareProvider>).value
-                        )
-                      }
-                      placeholderText="Select a source provider..."
-                    />
-                  </FormGroup>
+                    providerType={ProviderType.vsphere}
+                    field={form.fields.sourceProvider}
+                    notReadyTooltipPosition="right"
+                  />
                 </GridItem>
                 <GridItem sm={1} />
                 <GridItem sm={12} md={5}>
-                  <FormGroup
+                  <ProviderSelect
                     label="Target provider"
-                    isRequired
-                    fieldId="target-provider"
-                    {...getFormGroupProps(form.fields.sourceProvider)}
-                  >
-                    <SimpleSelect
-                      id="target-provider"
-                      aria-label="Target provider"
-                      options={targetProviderOptions}
-                      value={[
-                        targetProviderOptions.find(
-                          (option) => option.value.name === form.values.targetProvider?.name
-                        ),
-                      ]}
-                      onChange={(selection) =>
-                        form.fields.targetProvider.setValue(
-                          (selection as OptionWithValue<IOpenShiftProvider>).value
-                        )
-                      }
-                      placeholderText="Select a target provider..."
-                    />
-                  </FormGroup>
+                    providerType={ProviderType.openshift}
+                    field={form.fields.targetProvider}
+                  />
                 </GridItem>
                 <GridItem sm={1} />
               </Grid>
@@ -276,7 +219,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
               ) : null}
             </>
           )}
-        </ResolvedQuery>
+        </ResolvedQueries>
       </Form>
     </Modal>
   );

--- a/src/app/Mappings/components/MappingsActionsDropdown.tsx
+++ b/src/app/Mappings/components/MappingsActionsDropdown.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { Dropdown, KebabToggle, DropdownItem, DropdownPosition } from '@patternfly/react-core';
 import { MappingType, Mapping } from '@app/queries/types';
-import { useDeleteMappingMutation } from '@app/queries';
+import { useClusterProvidersQuery, useDeleteMappingMutation } from '@app/queries';
 import ConfirmDeleteModal from '@app/common/components/ConfirmDeleteModal';
+import { areAssociatedProvidersReady } from '@app/queries/helpers';
+import ConditionalTooltip from '@app/common/components/ConditionalTooltip';
 
 interface IMappingsActionsDropdownProps {
   mappingType: MappingType;
@@ -21,6 +23,11 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
     mappingType,
     toggleDeleteModal
   );
+  const clusterProvidersQuery = useClusterProvidersQuery();
+  const areProvidersReady = React.useMemo(
+    () => kebabIsOpen && areAssociatedProvidersReady(clusterProvidersQuery, mapping.spec.provider),
+    [kebabIsOpen, clusterProvidersQuery, mapping.spec.provider]
+  );
   return (
     <>
       <Dropdown
@@ -29,15 +36,22 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
         isOpen={kebabIsOpen}
         isPlain
         dropdownItems={[
-          <DropdownItem
-            onClick={() => {
-              setKebabIsOpen(false);
-              openEditMappingModal(mapping);
-            }}
+          <ConditionalTooltip
             key="edit"
+            isTooltipEnabled={!areProvidersReady}
+            content="This mapping cannot be edited because the inventory data for its associated providers is not ready"
           >
-            Edit
-          </DropdownItem>,
+            <DropdownItem
+              onClick={() => {
+                setKebabIsOpen(false);
+                openEditMappingModal(mapping);
+              }}
+              key="edit"
+              isDisabled={!areProvidersReady}
+            >
+              Edit
+            </DropdownItem>
+          </ConditionalTooltip>,
           <DropdownItem
             onClick={() => {
               setKebabIsOpen(false);

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -111,8 +111,6 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
       });
     }
   });
-  // I wonder if we can make use of generics right in the props interface?
-  // Might be overkill: https://wanago.io/2020/03/09/functional-react-components-with-generic-props-in-typescript/
 
   return (
     <>
@@ -125,7 +123,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
           />
         </LevelItem>
         <LevelItem>
-          <Pagination {...paginationProps} widgetId="providers-table-pagination-top" />
+          <Pagination {...paginationProps} widgetId="mappings-table-pagination-top" />
         </LevelItem>
       </Level>
       <Table
@@ -143,7 +141,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
       </Table>
       <Pagination
         {...paginationProps}
-        widgetId="providers-table-pagination-bottom"
+        widgetId="mappings-table-pagination-bottom"
         variant="bottom"
       />
     </>

--- a/src/app/Plans/PlansPage.tsx
+++ b/src/app/Plans/PlansPage.tsx
@@ -15,6 +15,7 @@ import {
   useHasSufficientProvidersQuery,
   usePlansQuery,
   useCreateMigrationMutation,
+  useClusterProvidersQuery,
 } from '@app/queries';
 
 import PlansTable from './components/PlansTable';
@@ -32,6 +33,7 @@ import {
 
 const PlansPage: React.FunctionComponent = () => {
   const sufficientProvidersQuery = useHasSufficientProvidersQuery();
+  const clusterProvidersQuery = useClusterProvidersQuery();
   const plansQuery = usePlansQuery();
   const [planBeingStarted, setPlanBeingStarted] = React.useState<IPlan | null>(null);
   const [baseCreateMigration, baseCreateMigrationResult] = useCreateMigrationMutation();
@@ -85,8 +87,12 @@ const PlansPage: React.FunctionComponent = () => {
           className={spacing.mbMd}
         />
         <ResolvedQueries
-          results={[sufficientProvidersQuery.result, plansQuery]}
-          errorTitles={['Error loading providers', 'Error loading plans']}
+          results={[sufficientProvidersQuery.result, clusterProvidersQuery, plansQuery]}
+          errorTitles={[
+            'Error loading providers',
+            'Error loading providers from cluster',
+            'Error loading plans',
+          ]}
           errorsInline={false}
         >
           <Card>

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -3,12 +3,18 @@ import { Form, FormGroup, TextArea, Title } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { getFormGroupProps, ValidatedTextInput } from '@konveyor/lib-ui';
 
-import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
-import { IOpenShiftProvider, IPlan, IVMwareProvider } from '@app/queries/types';
-import { useInventoryProvidersQuery } from '@app/queries';
+import SimpleSelect from '@app/common/components/SimpleSelect';
+import { IPlan } from '@app/queries/types';
+import { useClusterProvidersQuery, useInventoryProvidersQuery } from '@app/queries';
 import { PlanWizardFormState } from './PlanWizard';
 import { useNamespacesQuery } from '@app/queries/namespaces';
-import { QuerySpinnerMode, ResolvedQuery } from '@app/common/components/ResolvedQuery';
+import {
+  QuerySpinnerMode,
+  ResolvedQueries,
+  ResolvedQuery,
+} from '@app/common/components/ResolvedQuery';
+import ProviderSelect from '@app/common/components/ProviderSelect';
+import { ProviderType } from '@app/common/constants';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
@@ -19,24 +25,18 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   form,
   planBeingEdited,
 }: IGeneralFormProps) => {
-  const providersQuery = useInventoryProvidersQuery();
-  const vmwareProviders = providersQuery.data?.vsphere || [];
-  const openshiftProviders = providersQuery.data?.openshift || [];
-
+  const inventoryProvidersQuery = useInventoryProvidersQuery();
+  const clusterProvidersQuery = useClusterProvidersQuery();
   const namespacesQuery = useNamespacesQuery(form.values.targetProvider);
 
-  const sourceProvidersOptions = Object.values(vmwareProviders).map((provider) => ({
-    toString: () => provider.name,
-    value: provider,
-  })) as OptionWithValue<IVMwareProvider>[];
-
-  const targetProvidersOptions = Object.values(openshiftProviders).map((provider) => ({
-    toString: () => provider.name,
-    value: provider,
-  })) as OptionWithValue<IOpenShiftProvider>[];
-
   return (
-    <ResolvedQuery result={providersQuery} errorTitle="Error loading providers">
+    <ResolvedQueries
+      results={[inventoryProvidersQuery, clusterProvidersQuery]}
+      errorTitles={[
+        'Error loading provider inventory data',
+        'Error loading providers from cluster',
+      ]}
+    >
       <Form className={spacing.pbXl}>
         <Title headingLevel="h2" size="md">
           Give your plan a name and a description
@@ -57,52 +57,16 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
         <Title headingLevel="h3" size="md">
           Select source and target providers
         </Title>
-        <FormGroup
+        <ProviderSelect
           label="Source provider"
-          isRequired
-          fieldId="source-provider"
-          {...getFormGroupProps(form.fields.sourceProvider)}
-        >
-          <SimpleSelect
-            id="source-provider"
-            aria-label="Source provider"
-            options={sourceProvidersOptions}
-            value={[
-              sourceProvidersOptions.find(
-                (option) => option.value.name === form.values.sourceProvider?.name
-              ),
-            ]}
-            onChange={(selection) =>
-              form.fields.sourceProvider.setValue(
-                (selection as OptionWithValue<IVMwareProvider>).value
-              )
-            }
-            placeholderText="Select a provider"
-          />
-        </FormGroup>
-        <FormGroup
+          providerType={ProviderType.vsphere}
+          field={form.fields.sourceProvider}
+        />
+        <ProviderSelect
           label="Target provider"
-          isRequired
-          fieldId="target-provider"
-          {...getFormGroupProps(form.fields.targetProvider)}
-        >
-          <SimpleSelect
-            id="target-provider"
-            aria-label="Target provider"
-            options={targetProvidersOptions}
-            value={[
-              targetProvidersOptions.find(
-                (option) => option.value.name === form.values.targetProvider?.name
-              ),
-            ]}
-            onChange={(selection) =>
-              form.fields.targetProvider.setValue(
-                (selection as OptionWithValue<IOpenShiftProvider>).value
-              )
-            }
-            placeholderText="Select a provider"
-          />
-        </FormGroup>
+          providerType={ProviderType.openshift}
+          field={form.fields.targetProvider}
+        />
         <FormGroup
           label="Target namespace"
           isRequired
@@ -129,7 +93,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
           </ResolvedQuery>
         </FormGroup>
       </Form>
-    </ResolvedQuery>
+    </ResolvedQueries>
   );
 };
 

--- a/src/app/common/components/ProviderSelect/ProviderSelect.css
+++ b/src/app/common/components/ProviderSelect/ProviderSelect.css
@@ -1,0 +1,9 @@
+.pf-c-select__menu-item.pf-m-disabled.disabled-with-pointer-events {
+  pointer-events: auto;
+  padding: 0;
+}
+
+.pf-c-select__menu-item.pf-m-disabled.disabled-with-pointer-events > div {
+  padding: var(--pf-c-select__menu-item--PaddingTop) var(--pf-c-select__menu-item--PaddingRight)
+    var(--pf-c-select__menu-item--PaddingBottom) var(--pf-c-select__menu-item--PaddingLeft);
+}

--- a/src/app/common/components/ProviderSelect/ProviderSelect.tsx
+++ b/src/app/common/components/ProviderSelect/ProviderSelect.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { useClusterProvidersQuery, useInventoryProvidersQuery } from '@app/queries';
+import { InventoryProvider, IProviderObject } from '@app/queries/types';
+import { getFormGroupProps, IValidatedFormField } from '@konveyor/lib-ui';
+import { FormGroup } from '@patternfly/react-core';
+import { PlanStatusType, ProviderType } from '../../constants';
+import { hasCondition } from '../../helpers';
+import ConditionalTooltip from '../ConditionalTooltip';
+import { QuerySpinnerMode, ResolvedQueries } from '../ResolvedQuery';
+import SimpleSelect, { OptionWithValue } from '../SimpleSelect';
+
+import './ProviderSelect.css';
+import { isSameResource } from '@app/queries/helpers';
+
+interface IProviderSelectProps<T extends InventoryProvider> {
+  label: string;
+  providerType: ProviderType;
+  field: IValidatedFormField<T | null>;
+  notReadyTooltipPosition?: 'left' | 'right';
+}
+
+const ProviderSelect = <T extends InventoryProvider>({
+  label,
+  providerType,
+  field,
+  notReadyTooltipPosition = 'left',
+}: React.PropsWithChildren<IProviderSelectProps<T>>): JSX.Element | null => {
+  const inventoryProvidersQuery = useInventoryProvidersQuery();
+  const clusterProvidersQuery = useClusterProvidersQuery();
+  const { data: inventoryData } = inventoryProvidersQuery;
+  const inventoryProviders = ((inventoryData && inventoryData[providerType]) || []) as T[];
+  const clusterProviders =
+    clusterProvidersQuery.data?.items.filter((provider) => provider.spec.type === providerType) ||
+    [];
+
+  const getMatchingInventoryProvider = (clusterProvider: IProviderObject) =>
+    inventoryProviders.find((provider) => isSameResource(provider, clusterProvider.metadata));
+
+  const options = Object.values(clusterProviders).map((provider) => {
+    const inventoryProvider = getMatchingInventoryProvider(provider);
+    const isReady =
+      !!inventoryProvider && hasCondition(provider.status?.conditions || [], PlanStatusType.Ready);
+    return {
+      toString: () => provider.metadata.name,
+      value: provider,
+      props: {
+        isDisabled: !isReady,
+        className: !isReady ? 'disabled-with-pointer-events' : '',
+        children: (
+          <ConditionalTooltip
+            isTooltipEnabled={!isReady}
+            content="This provider cannot be selected because its inventory data is not ready"
+            position={notReadyTooltipPosition}
+          >
+            <div>{provider.metadata.name}</div>
+          </ConditionalTooltip>
+        ),
+      },
+    } as OptionWithValue<IProviderObject>;
+  });
+
+  return (
+    <ResolvedQueries
+      results={[inventoryProvidersQuery, clusterProvidersQuery]}
+      errorTitles={[
+        'Error loading provider inventory data',
+        'Error loading providers from cluster',
+      ]}
+      spinnerMode={QuerySpinnerMode.Inline}
+    >
+      <FormGroup
+        label={label}
+        isRequired
+        fieldId={`provider-select-${providerType}`}
+        {...getFormGroupProps(field)}
+      >
+        <SimpleSelect
+          id={`provider-select-${providerType}`}
+          aria-label={label}
+          options={options}
+          value={[options.find((option) => option.value.metadata.name === field.value?.name)]}
+          onChange={(selection) => {
+            const matchingInventoryProvider = inventoryProviders.find(
+              (provider) =>
+                provider.name ===
+                (selection as OptionWithValue<IProviderObject>).value.metadata.name
+            );
+            if (matchingInventoryProvider) {
+              field.setValue(matchingInventoryProvider);
+            }
+          }}
+          placeholderText="Select a provider..."
+        />
+      </FormGroup>
+    </ResolvedQueries>
+  );
+};
+
+export default ProviderSelect;

--- a/src/app/common/components/ProviderSelect/index.ts
+++ b/src/app/common/components/ProviderSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ProviderSelect';

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -44,7 +44,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
     spec: {
       provider: {
-        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[1]),
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       map: [
@@ -98,7 +98,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     spec: {
       provider: {
         source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),
       },
       map: [
         {

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -302,7 +302,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
     spec: {
-      description: 'my 3nd plan',
+      description: 'my 3rd plan',
       provider: {
         source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -446,5 +446,46 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5];
+  const plan6: IPlan = {
+    apiVersion: CLUSTER_API_VERSION,
+    kind: 'Plan',
+    metadata: {
+      name: 'plantest-6',
+      namespace: 'openshift-migration',
+      generation: 2,
+      resourceVersion: '30825024',
+      selfLink:
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-2',
+      uid: '28fde094-b667-4d21-8f29-27c18f22178c',
+      creationTimestamp: '2020-08-27T19:40:49Z',
+    },
+    spec: {
+      description: 'has a non-ready provider',
+      provider: {
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),
+      },
+      targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
+      map: {
+        networks: MOCK_NETWORK_MAPPINGS[0].spec.map,
+        datastores: MOCK_STORAGE_MAPPINGS[0].spec.map,
+      },
+      vms: [vm1],
+    },
+    status: {
+      conditions: [
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
+        },
+      ],
+      observedGeneration: 2,
+    },
+  };
+
+  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6];
 }


### PR DESCRIPTION
* Factor out common ProviderSelect component

* Use provider CRs for provider selection options, disable non-ready ones with a tooltip

* Better tooltip positioning

* Larger mouse hitbox

* Prevent editing mappings with non-ready associated providers

* Prevent editing plans with non-ready associated providers

* Add a mock plan to reproduce the edit tooltip in the plans table