### PR TITLE
Forms to have disabled save button unless really changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,9 +1036,9 @@
       }
     },
     "@konveyor/lib-ui": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-1.10.5.tgz",
-      "integrity": "sha512-iAKeroSJdFR3SSGReEjYl3wgUkUCP/lE+0VKEv91SYzTy7Dz7KgRcOF/lqapsJFxBqEQIclXqNsxzo23QUh0Cg==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-1.10.8.tgz",
+      "integrity": "sha512-YGigTgGPvflEUSaDGBAwpEeEDvvyqF03zcV/yfcNG/HQhQ6ywOA7gu/P5Ao+DaeXDFTZI4vTfJN3DnAUAvZbXQ==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "yup": "^0.29.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,9 +1036,9 @@
       }
     },
     "@konveyor/lib-ui": {
-      "version": "1.10.8",
-      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-1.10.8.tgz",
-      "integrity": "sha512-YGigTgGPvflEUSaDGBAwpEeEDvvyqF03zcV/yfcNG/HQhQ6ywOA7gu/P5Ao+DaeXDFTZI4vTfJN3DnAUAvZbXQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-1.11.0.tgz",
+      "integrity": "sha512-RLL1RvsGL5tnoSY9/3n6qDbAmaz21/T+MHnaqWsg49U39rxVcPdxjxhuDTiN4AaMFY6IZgluHlr62Z5TQMKQfA==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "yup": "^0.29.3"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {
-    "@konveyor/lib-ui": "^1.10.5",
+    "@konveyor/lib-ui": "^1.10.8",
     "@patternfly/react-core": "^4.79.2",
     "@patternfly/react-icons": "^4.7.18",
     "@patternfly/react-styles": "^4.7.16",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {
-    "@konveyor/lib-ui": "^1.10.8",
+    "@konveyor/lib-ui": "^1.11.0",
     "@patternfly/react-core": "^4.79.2",
     "@patternfly/react-icons": "^4.7.18",
     "@patternfly/react-styles": "^4.7.16",

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -141,7 +141,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                   mutateMapping(generatedMapping);
                 }
               }}
-              isDisabled={!form.isValid || mutationResult.isLoading}
+              isDisabled={!form.isDirty || !form.isValid || mutationResult.isLoading}
             >
               {!mappingBeingEdited ? 'Create' : 'Save'}
             </Button>

--- a/src/app/Mappings/components/helpers.ts
+++ b/src/app/Mappings/components/helpers.ts
@@ -70,25 +70,24 @@ export const useEditingMappingPrefillEffect = (
   providersQuery: QueryResult<IProvidersByType>,
   mappingResourceQueries: IMappingResourcesResult
 ): { isDonePrefilling: boolean } => {
+  const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
   const [isDonePrefilling, setIsDonePrefilling] = React.useState(!mappingBeingEdited);
   React.useEffect(() => {
     if (
+      !isStartedPrefilling &&
       mappingBeingEdited &&
-      !form.isDirty &&
       providersQuery.isSuccess &&
       mappingResourceQueries.status === QueryStatus.Success
     ) {
+      setIsStartedPrefilling(true);
       const { sourceProvider, targetProvider } = mappingBeingEditedProviders;
       const { availableSources, availableTargets } = mappingResourceQueries;
 
-      form.fields.name.setValue(mappingBeingEdited.metadata.name);
-      form.fields.name.setIsTouched(true);
-      form.fields.sourceProvider.setValue(sourceProvider);
-      form.fields.sourceProvider.setIsTouched(true);
-      form.fields.targetProvider.setValue(targetProvider);
-      form.fields.targetProvider.setIsTouched(true);
+      form.fields.name.setInitialValue(mappingBeingEdited.metadata.name);
+      form.fields.sourceProvider.setInitialValue(sourceProvider);
+      form.fields.targetProvider.setInitialValue(targetProvider);
 
-      form.fields.builderItems.setValue(
+      form.fields.builderItems.setInitialValue(
         getBuilderItemsFromMapping(
           mappingBeingEdited,
           mappingType,
@@ -96,7 +95,6 @@ export const useEditingMappingPrefillEffect = (
           availableTargets
         )
       );
-      form.fields.builderItems.setIsTouched(true);
 
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {
@@ -104,8 +102,8 @@ export const useEditingMappingPrefillEffect = (
       }, 0);
     }
   }, [
+    isStartedPrefilling,
     form.fields,
-    form.isDirty,
     mappingBeingEdited,
     mappingBeingEditedProviders,
     mappingResourceQueries,

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -102,7 +102,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
   const providerType = providerTypeField.value;
   const formValues = providerType ? forms[providerType].values : vmwareForm.values;
   const isFormValid = providerType ? forms[providerType].isValid : false;
-  const isFormTouched = providerType ? forms[providerType].isTouched : false;
+  const isFormDirty = providerType ? forms[providerType].isDirty : false;
 
   const [createProvider, createProviderResult] = useCreateProviderMutation(providerType, onClose);
   const [patchProvider, patchProviderResult] = usePatchProviderMutation(
@@ -131,7 +131,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
             <Button
               key="confirm"
               variant="primary"
-              isDisabled={!isFormTouched || !isFormValid || mutateProviderResult.isLoading}
+              isDisabled={!isFormDirty || !isFormValid || mutateProviderResult.isLoading}
               onClick={() => {
                 mutateProvider(formValues);
               }}

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -102,6 +102,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
   const providerType = providerTypeField.value;
   const formValues = providerType ? forms[providerType].values : vmwareForm.values;
   const isFormValid = providerType ? forms[providerType].isValid : false;
+  const isFormTouched = providerType ? forms[providerType].isTouched : false;
 
   const [createProvider, createProviderResult] = useCreateProviderMutation(providerType, onClose);
   const [patchProvider, patchProviderResult] = usePatchProviderMutation(
@@ -130,7 +131,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
             <Button
               key="confirm"
               variant="primary"
-              isDisabled={!isFormValid || mutateProviderResult.isLoading}
+              isDisabled={!isFormTouched || !isFormValid || mutateProviderResult.isLoading}
               onClick={() => {
                 mutateProvider(formValues);
               }}

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -24,16 +24,17 @@ import {
   useCreateProviderMutation,
   usePatchProviderMutation,
   useClusterProvidersQuery,
+  useSecretQuery,
 } from '@app/queries';
 
 import './AddEditProviderModal.css';
-import { IProviderObject } from '@app/queries/types';
+import { IProviderObject, ISecret } from '@app/queries/types';
 import { QueryResult } from 'react-query';
 import { HelpIcon } from '@patternfly/react-icons';
 import { QuerySpinnerMode, ResolvedQuery } from '@app/common/components/ResolvedQuery';
 import { IKubeList } from '@app/client/types';
-import { useEditProviderPrefillEffect } from './helpers';
-import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
+// import { useEditProviderPrefillEffect } from './helpers';
+// import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
 interface IAddEditProviderModalProps {
   onClose: () => void;
@@ -47,10 +48,11 @@ const PROVIDER_TYPE_OPTIONS = Object.values(ProviderType).map((type) => ({
 
 const useAddProviderFormState = (
   clusterProvidersQuery: QueryResult<IKubeList<IProviderObject>>,
-  providerBeingEdited: IProviderObject | null
+  providerBeingEdited: IProviderObject | null,
+  secret: ISecret | null
 ) => {
   const providerTypeField = useFormField<ProviderType | null>(
-    null,
+    providerBeingEdited ? providerBeingEdited.spec.type : null,
     yup.mixed().label('Provider type').oneOf(Object.values(ProviderType)).required()
   );
 
@@ -58,23 +60,44 @@ const useAddProviderFormState = (
     [ProviderType.vsphere]: useFormState({
       providerType: providerTypeField,
       name: useFormField(
-        '',
+        providerBeingEdited ? providerBeingEdited.metadata.name : '',
         getProviderNameSchema(clusterProvidersQuery, providerBeingEdited).label('Name').required()
       ),
-      hostname: useFormField('', vmwareHostnameSchema),
-      username: useFormField('', vmwareUsernameSchema.required()),
-      password: useFormField('', yup.string().max(256).label('Password').required()),
-      fingerprint: useFormField('', vmwareFingerprintSchema.required()),
-      fingerprintFilename: useFormField('', yup.string()),
+      hostname: useFormField(
+        providerBeingEdited ? providerBeingEdited.spec.url : '',
+        vmwareHostnameSchema
+      ),
+      username: useFormField(
+        providerBeingEdited ? atob(secret?.data.user || '') : '',
+        vmwareUsernameSchema.required()
+      ),
+      password: useFormField(
+        secret ? atob(secret?.data.password || '') : '',
+        yup.string().max(256).label('Password').required()
+      ),
+      fingerprint: useFormField(
+        secret ? atob(secret?.data.password || '') : '',
+        vmwareFingerprintSchema.required()
+      ),
+      fingerprintFilename: useFormField(
+        secret ? atob(secret?.data.thumbprint || '') : '',
+        yup.string()
+      ),
     }),
     [ProviderType.openshift]: useFormState({
       providerType: providerTypeField,
       name: useFormField(
-        '',
+        providerBeingEdited ? providerBeingEdited.metadata.name : '',
         getProviderNameSchema(clusterProvidersQuery, providerBeingEdited).label('Name').required()
       ),
-      url: useFormField('', urlSchema.label('URL').required()),
-      saToken: useFormField('', yup.string().label('Service account token').required()),
+      url: useFormField(
+        providerBeingEdited ? providerBeingEdited.spec.url : '',
+        urlSchema.label('URL').required()
+      ),
+      saToken: useFormField(
+        secret ? atob(secret?.data.token || '') : '',
+        yup.string().label('Service account token').required()
+      ),
     }),
   };
 };
@@ -92,9 +115,14 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
 
   const clusterProvidersQuery = useClusterProvidersQuery();
 
-  const forms = useAddProviderFormState(clusterProvidersQuery, providerBeingEdited);
+  const secretQuery = useSecretQuery(providerBeingEdited?.spec.secret?.name || null);
+  const forms = useAddProviderFormState(
+    clusterProvidersQuery,
+    providerBeingEdited,
+    secretQuery.data || null
+  );
 
-  const { isDonePrefilling } = useEditProviderPrefillEffect(forms, providerBeingEdited);
+  // const { isDonePrefilling } = useEditProviderPrefillEffect(forms, providerBeingEdited);
 
   const vmwareForm = forms[ProviderType.vsphere];
   const openshiftForm = forms[ProviderType.openshift];
@@ -151,197 +179,197 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
       }
     >
       <ResolvedQuery result={clusterProvidersQuery} errorTitle="Error loading providers">
-        {!isDonePrefilling ? (
+        {/* {!isDonePrefilling ? (
           <LoadingEmptyState />
-        ) : (
-          <Form>
-            <FormGroup
-              label="Type"
-              isRequired
-              fieldId="provider-type"
-              className={!providerType ? 'extraSelectMargin' : ''}
-              {...getFormGroupProps(providerTypeField)}
-            >
-              <SimpleSelect
-                id="provider-type"
-                aria-label="Provider type"
-                options={PROVIDER_TYPE_OPTIONS}
-                value={[PROVIDER_TYPE_OPTIONS.find((option) => option.value === providerType)]}
-                onChange={(selection) => {
-                  providerTypeField.setValue((selection as OptionWithValue<ProviderType>).value);
-                  providerTypeField.setIsTouched(true);
+        ) : ( */}
+        <Form>
+          <FormGroup
+            label="Type"
+            isRequired
+            fieldId="provider-type"
+            className={!providerType ? 'extraSelectMargin' : ''}
+            {...getFormGroupProps(providerTypeField)}
+          >
+            <SimpleSelect
+              id="provider-type"
+              aria-label="Provider type"
+              options={PROVIDER_TYPE_OPTIONS}
+              value={[PROVIDER_TYPE_OPTIONS.find((option) => option.value === providerType)]}
+              onChange={(selection) => {
+                providerTypeField.setValue((selection as OptionWithValue<ProviderType>).value);
+                providerTypeField.setIsTouched(true);
+              }}
+              placeholderText="Select a provider type..."
+              isDisabled={!!providerBeingEdited}
+            />
+          </FormGroup>
+          {providerType === ProviderType.vsphere ? (
+            <>
+              <ValidatedTextInput
+                field={vmwareForm.fields.name}
+                label="Name"
+                isRequired
+                fieldId="vmware-name"
+                inputProps={{
+                  isDisabled: !!providerBeingEdited,
                 }}
-                placeholderText="Select a provider type..."
-                isDisabled={!!providerBeingEdited}
+                formGroupProps={{
+                  labelIcon: (
+                    <Popover bodyContent="User specified name that will be displayed in the UI.">
+                      <button
+                        aria-label="More info for name field"
+                        onClick={(e) => e.preventDefault()}
+                        aria-describedby="vmware-name-info"
+                        className="pf-c-form__group-label-help"
+                      >
+                        <HelpIcon noVerticalAlign />
+                      </button>
+                    </Popover>
+                  ),
+                }}
               />
-            </FormGroup>
-            {providerType === ProviderType.vsphere ? (
-              <>
-                <ValidatedTextInput
-                  field={vmwareForm.fields.name}
-                  label="Name"
-                  isRequired
-                  fieldId="vmware-name"
-                  inputProps={{
-                    isDisabled: !!providerBeingEdited,
-                  }}
-                  formGroupProps={{
-                    labelIcon: (
-                      <Popover bodyContent="User specified name that will be displayed in the UI.">
-                        <button
-                          aria-label="More info for name field"
-                          onClick={(e) => e.preventDefault()}
-                          aria-describedby="vmware-name-info"
-                          className="pf-c-form__group-label-help"
-                        >
-                          <HelpIcon noVerticalAlign />
-                        </button>
-                      </Popover>
-                    ),
-                  }}
-                />
-                <ValidatedTextInput
-                  field={vmwareForm.fields.hostname}
-                  label="Hostname or IP address"
-                  isRequired
-                  fieldId="vmware-hostname"
-                />
-                <ValidatedTextInput
-                  field={vmwareForm.fields.username}
-                  label="Username"
-                  isRequired
-                  fieldId="vmware-username"
-                />
-                <ValidatedTextInput
-                  field={vmwareForm.fields.password}
-                  type="password"
-                  label="Password"
-                  isRequired
-                  fieldId="vmware-password"
-                />
-                <ValidatedTextInput
-                  field={vmwareForm.fields.fingerprint}
-                  label="Certificate SHA1 Fingerprint"
-                  isRequired
-                  fieldId="vmware-fingerprint"
-                  formGroupProps={{
-                    labelIcon: (
-                      <Popover
-                        bodyContent={
-                          <div>
-                            See{' '}
-                            <a href={PRODUCT_DOCO_LINK.href} target="_blank" rel="noreferrer">
-                              {PRODUCT_DOCO_LINK.label}
-                            </a>{' '}
-                            for instructions on how to retrieve the fingerprint.
-                          </div>
-                        }
+              <ValidatedTextInput
+                field={vmwareForm.fields.hostname}
+                label="Hostname or IP address"
+                isRequired
+                fieldId="vmware-hostname"
+              />
+              <ValidatedTextInput
+                field={vmwareForm.fields.username}
+                label="Username"
+                isRequired
+                fieldId="vmware-username"
+              />
+              <ValidatedTextInput
+                field={vmwareForm.fields.password}
+                type="password"
+                label="Password"
+                isRequired
+                fieldId="vmware-password"
+              />
+              <ValidatedTextInput
+                field={vmwareForm.fields.fingerprint}
+                label="Certificate SHA1 Fingerprint"
+                isRequired
+                fieldId="vmware-fingerprint"
+                formGroupProps={{
+                  labelIcon: (
+                    <Popover
+                      bodyContent={
+                        <div>
+                          See{' '}
+                          <a href={PRODUCT_DOCO_LINK.href} target="_blank" rel="noreferrer">
+                            {PRODUCT_DOCO_LINK.label}
+                          </a>{' '}
+                          for instructions on how to retrieve the fingerprint.
+                        </div>
+                      }
+                    >
+                      <button
+                        aria-label="More info for SHA1 Fingerprint field"
+                        onClick={(e) => e.preventDefault()}
+                        aria-describedby="vmware-fingerprint"
+                        className="pf-c-form__group-label-help"
                       >
-                        <button
-                          aria-label="More info for SHA1 Fingerprint field"
-                          onClick={(e) => e.preventDefault()}
-                          aria-describedby="vmware-fingerprint"
-                          className="pf-c-form__group-label-help"
-                        >
-                          <HelpIcon noVerticalAlign />
-                        </button>
-                      </Popover>
-                    ),
-                  }}
-                />
-              </>
-            ) : null}
-            {providerType === ProviderType.openshift ? (
-              <>
-                <ValidatedTextInput
-                  field={openshiftForm.fields.name}
-                  label="Name"
-                  isRequired
-                  fieldId="openshift-name"
-                  inputProps={{
-                    isDisabled: !!providerBeingEdited,
-                  }}
-                  formGroupProps={{
-                    labelIcon: (
-                      <Popover bodyContent="User specified name that will be displayed in the UI.">
-                        <button
-                          aria-label="More info for name field"
-                          onClick={(e) => e.preventDefault()}
-                          aria-describedby="openshift-name-info"
-                          className="pf-c-form__group-label-help"
-                        >
-                          <HelpIcon noVerticalAlign />
-                        </button>
-                      </Popover>
-                    ),
-                  }}
-                />
-                <ValidatedTextInput
-                  field={openshiftForm.fields.url}
-                  label="URL"
-                  isRequired
-                  fieldId="openshift-url"
-                  formGroupProps={{
-                    labelIcon: (
-                      <Popover
-                        bodyContent={
-                          <>
-                            OpenShift cluster API endpoint.
-                            <br />
-                            For example: <i>https://api.clusterName.domain:6443</i>
-                          </>
-                        }
+                        <HelpIcon noVerticalAlign />
+                      </button>
+                    </Popover>
+                  ),
+                }}
+              />
+            </>
+          ) : null}
+          {providerType === ProviderType.openshift ? (
+            <>
+              <ValidatedTextInput
+                field={openshiftForm.fields.name}
+                label="Name"
+                isRequired
+                fieldId="openshift-name"
+                inputProps={{
+                  isDisabled: !!providerBeingEdited,
+                }}
+                formGroupProps={{
+                  labelIcon: (
+                    <Popover bodyContent="User specified name that will be displayed in the UI.">
+                      <button
+                        aria-label="More info for name field"
+                        onClick={(e) => e.preventDefault()}
+                        aria-describedby="openshift-name-info"
+                        className="pf-c-form__group-label-help"
                       >
-                        <button
-                          aria-label="More info for URL field"
-                          onClick={(e) => e.preventDefault()}
-                          aria-describedby="openshift-cluster-url-info"
-                          className="pf-c-form__group-label-help"
-                        >
-                          <HelpIcon noVerticalAlign />
-                        </button>
-                      </Popover>
-                    ),
-                  }}
-                />
-                (
-                <ValidatedTextInput
-                  field={openshiftForm.fields.saToken}
-                  type="password"
-                  label="Service account token"
-                  isRequired
-                  fieldId="openshift-sa-token"
-                  formGroupProps={{
-                    labelIcon: (
-                      <Popover
-                        bodyContent={
-                          <>
-                            To obtain SA token, run the following command:
-                            <br />
-                            <i>
-                              $ oc serviceaccounts get-token serviceaccount_name -n namespace_name
-                            </i>
-                            <br />
-                            <br />
-                            <b>** Be sure to use the namespace in which you created the SA.</b>
-                          </>
-                        }
+                        <HelpIcon noVerticalAlign />
+                      </button>
+                    </Popover>
+                  ),
+                }}
+              />
+              <ValidatedTextInput
+                field={openshiftForm.fields.url}
+                label="URL"
+                isRequired
+                fieldId="openshift-url"
+                formGroupProps={{
+                  labelIcon: (
+                    <Popover
+                      bodyContent={
+                        <>
+                          OpenShift cluster API endpoint.
+                          <br />
+                          For example: <i>https://api.clusterName.domain:6443</i>
+                        </>
+                      }
+                    >
+                      <button
+                        aria-label="More info for URL field"
+                        onClick={(e) => e.preventDefault()}
+                        aria-describedby="openshift-cluster-url-info"
+                        className="pf-c-form__group-label-help"
                       >
-                        <button
-                          aria-label="More info for service account field"
-                          onClick={(e) => e.preventDefault()}
-                          aria-describedby="service-account-info"
-                          className="pf-c-form__group-label-help"
-                        >
-                          <HelpIcon noVerticalAlign />
-                        </button>
-                      </Popover>
-                    ),
-                  }}
-                />
-              </>
-            ) : null}
-            {/* TODO re-enable this when we have the API capability
+                        <HelpIcon noVerticalAlign />
+                      </button>
+                    </Popover>
+                  ),
+                }}
+              />
+              (
+              <ValidatedTextInput
+                field={openshiftForm.fields.saToken}
+                type="password"
+                label="Service account token"
+                isRequired
+                fieldId="openshift-sa-token"
+                formGroupProps={{
+                  labelIcon: (
+                    <Popover
+                      bodyContent={
+                        <>
+                          To obtain SA token, run the following command:
+                          <br />
+                          <i>
+                            $ oc serviceaccounts get-token serviceaccount_name -n namespace_name
+                          </i>
+                          <br />
+                          <br />
+                          <b>** Be sure to use the namespace in which you created the SA.</b>
+                        </>
+                      }
+                    >
+                      <button
+                        aria-label="More info for service account field"
+                        onClick={(e) => e.preventDefault()}
+                        aria-describedby="service-account-info"
+                        className="pf-c-form__group-label-help"
+                      >
+                        <HelpIcon noVerticalAlign />
+                      </button>
+                    </Popover>
+                  ),
+                }}
+              />
+            </>
+          ) : null}
+          {/* TODO re-enable this when we have the API capability
             providerType ? (
               <div>
                 <Button variant="link" isInline icon={<ConnectedIcon />} onClick={() => alert('TODO')}>
@@ -350,8 +378,8 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
               </div>
             ) : null
             */}
-          </Form>
-        )}
+        </Form>
+        {/* )} */}
       </ResolvedQuery>
     </Modal>
   );

--- a/src/app/Providers/components/AddEditProviderModal/helpers.ts
+++ b/src/app/Providers/components/AddEditProviderModal/helpers.ts
@@ -25,18 +25,18 @@ export const useEditProviderPrefillEffect = (
       const secret = secretQuery.data;
       if (providerBeingEdited.spec.type === ProviderType.vsphere) {
         const { fields } = forms.vsphere;
-        fields.providerType.setValue(providerBeingEdited.spec.type);
-        fields.name.setValue(providerBeingEdited.metadata.name);
-        fields.hostname.setValue(vmwareUrlToHostname(providerBeingEdited.spec.url || ''));
-        fields.username.setValue(atob(secret?.data.user || ''));
-        fields.password.setValue(atob(secret?.data.password || ''));
-        fields.fingerprint.setValue(atob(secret?.data.thumbprint || ''));
+        fields.providerType.setInitialValue(providerBeingEdited.spec.type);
+        fields.name.setInitialValue(providerBeingEdited.metadata.name);
+        fields.hostname.setInitialValue(vmwareUrlToHostname(providerBeingEdited.spec.url || ''));
+        fields.username.setInitialValue(atob(secret?.data.user || ''));
+        fields.password.setInitialValue(atob(secret?.data.password || ''));
+        fields.fingerprint.setInitialValue(atob(secret?.data.thumbprint || ''));
       } else if (providerBeingEdited.spec.type === ProviderType.openshift) {
         const { fields } = forms.openshift;
-        fields.providerType.setValue(providerBeingEdited.spec.type);
-        fields.name.setValue(providerBeingEdited.metadata.name);
-        fields.url.setValue(providerBeingEdited.spec.url || '');
-        fields.saToken.setValue(atob(secret?.data.token || ''));
+        fields.providerType.setInitialValue(providerBeingEdited.spec.type);
+        fields.name.setInitialValue(providerBeingEdited.metadata.name);
+        fields.url.setInitialValue(providerBeingEdited.spec.url || '');
+        fields.saToken.setInitialValue(atob(secret?.data.token || ''));
       }
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {

--- a/src/app/Providers/components/AddEditProviderModal/helpers.ts
+++ b/src/app/Providers/components/AddEditProviderModal/helpers.ts
@@ -13,15 +13,12 @@ export const useEditProviderPrefillEffect = (
   forms: AddProviderFormState,
   providerBeingEdited: IProviderObject | null
 ): IEditProviderPrefillEffect => {
+  const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
   const [isDonePrefilling, setIsDonePrefilling] = React.useState(!providerBeingEdited);
   const secretQuery = useSecretQuery(providerBeingEdited?.spec.secret?.name || null);
   React.useEffect(() => {
-    if (
-      providerBeingEdited &&
-      !forms.vsphere.isDirty &&
-      !forms.openshift.isDirty &&
-      secretQuery.isSuccess
-    ) {
+    if (!isStartedPrefilling && providerBeingEdited && secretQuery.isSuccess) {
+      setIsStartedPrefilling(true);
       const secret = secretQuery.data;
       if (providerBeingEdited.spec.type === ProviderType.vsphere) {
         const { fields } = forms.vsphere;
@@ -43,6 +40,13 @@ export const useEditProviderPrefillEffect = (
         setIsDonePrefilling(true);
       }, 0);
     }
-  }, [forms, providerBeingEdited, secretQuery.data, secretQuery.isSuccess]);
+  }, [
+    isStartedPrefilling,
+    forms.openshift,
+    forms.vsphere,
+    providerBeingEdited,
+    secretQuery.data,
+    secretQuery.isSuccess,
+  ]);
   return { isDonePrefilling };
 };

--- a/src/app/Providers/components/AddEditProviderModal/helpers.ts
+++ b/src/app/Providers/components/AddEditProviderModal/helpers.ts
@@ -26,26 +26,17 @@ export const useEditProviderPrefillEffect = (
       if (providerBeingEdited.spec.type === ProviderType.vsphere) {
         const { fields } = forms.vsphere;
         fields.providerType.setValue(providerBeingEdited.spec.type);
-        fields.providerType.setIsTouched(true);
         fields.name.setValue(providerBeingEdited.metadata.name);
-        fields.name.setIsTouched(true);
         fields.hostname.setValue(vmwareUrlToHostname(providerBeingEdited.spec.url || ''));
-        fields.hostname.setIsTouched(true);
         fields.username.setValue(atob(secret?.data.user || ''));
-        fields.username.setIsTouched(true);
         fields.password.setValue(atob(secret?.data.password || ''));
         fields.fingerprint.setValue(atob(secret?.data.thumbprint || ''));
-        fields.fingerprint.setIsTouched(true);
       } else if (providerBeingEdited.spec.type === ProviderType.openshift) {
         const { fields } = forms.openshift;
         fields.providerType.setValue(providerBeingEdited.spec.type);
-        fields.providerType.setIsTouched(true);
         fields.name.setValue(providerBeingEdited.metadata.name);
-        fields.name.setIsTouched(true);
         fields.url.setValue(providerBeingEdited.spec.url || '');
-        fields.url.setIsTouched(true);
         fields.saToken.setValue(atob(secret?.data.token || ''));
-        fields.saToken.setIsTouched(true);
       }
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -82,7 +82,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
             <Button
               key="confirm"
               variant="primary"
-              isDisabled={!form.isValid || configureHostsResult.isLoading}
+              isDisabled={!form.isDirty || !form.isValid || configureHostsResult.isLoading}
               onClick={() => {
                 if (form.isValid) {
                   configureHosts(form.values);
@@ -106,7 +106,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
         <Button
           key="confirm"
           variant="primary"
-          isDisabled={!form.isValid || configureHostsResult.isLoading}
+          isDisabled={!form.isDirty || !form.isValid || configureHostsResult.isLoading}
           onClick={() => {
             if (form.isValid) {
               configureHosts(form.values);
@@ -115,7 +115,12 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
         >
           Add
         </Button>,
-        <Button key="cancel" variant="link" onClick={onClose}>
+        <Button
+          key="cancel"
+          variant="link"
+          onClick={onClose}
+          isDisabled={configureHostsResult.isLoading}
+        >
           Cancel
         </Button>,
       ]}

--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -37,6 +37,7 @@ export const usePrefillHostConfigEffect = (
   hostConfigs: IHostConfig[],
   provider: IVMwareProvider
 ): IPrefillHostConfigEffect => {
+  const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
   const [isDonePrefilling, setIsDonePrefilling] = React.useState(false);
   const existingHostConfigs = getExistingHostConfigs(selectedHosts, hostConfigs, provider);
   const existingSecretName =
@@ -46,7 +47,8 @@ export const usePrefillHostConfigEffect = (
     null;
   const secretQuery = useSecretQuery(existingSecretName);
   React.useEffect(() => {
-    if (!form.isDirty && (!existingSecretName || secretQuery.isSuccess)) {
+    if (!isStartedPrefilling && (!existingSecretName || secretQuery.isSuccess)) {
+      setIsStartedPrefilling(true);
       const existingIpAddresses = existingHostConfigs.map((config) => config?.spec.ipAddress);
       const allOnSameIp = Array.from(new Set(existingIpAddresses)).length === 1;
       const preselectedAdapter =
@@ -72,6 +74,7 @@ export const usePrefillHostConfigEffect = (
       }, 0);
     }
   }, [
+    isStartedPrefilling,
     selectedHosts,
     existingHostConfigs,
     existingSecretName,

--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -59,14 +59,11 @@ export const usePrefillHostConfigEffect = (
         null;
       const secret = secretQuery.data;
       if (preselectedAdapter) {
-        form.fields.selectedNetworkAdapter.setValue(preselectedAdapter);
-        form.fields.selectedNetworkAdapter.setIsTouched(true);
+        form.fields.selectedNetworkAdapter.setInitialValue(preselectedAdapter);
       }
       if (secret) {
-        form.fields.adminUsername.setValue(atob(secret.data.user || ''));
-        form.fields.adminUsername.setIsTouched(true);
-        form.fields.adminPassword.setValue(atob(secret.data.password || ''));
-        form.fields.adminPassword.setIsTouched(true);
+        form.fields.adminUsername.setInitialValue(atob(secret.data.user || ''));
+        form.fields.adminPassword.setInitialValue(atob(secret.data.password || ''));
       }
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {


### PR DESCRIPTION
Resolves #329

- Bumps @konveyor/lib-ui
- Removes "setTouched" from form pre-filling for providers
- Use `useFormState` `isTouched` for the providers: This actually works until the use touch a field (position the pointer and leaves (unblur) that field because it marks the field as touched.

So to make it work, I believe we need to have preffiling happen during the useFormState object creation by passing the initialValues returned from backend.

Edited by @mturley:

Solved by adding a `setInitialValue` function to each field in useFormState in lib-ui. This allows us to prefill values without marking the form `isDirty`, and use the `isDirty` value to manage the disabled state of the submit button. Implemented it for all other prefilled forms (plans, mappings, hosts)