### PR TITLE
[Backport] Forms to have disabled save button unless really changed (#365)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,9 +1036,9 @@
       }
     },
     "@konveyor/lib-ui": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-1.10.5.tgz",
-      "integrity": "sha512-iAKeroSJdFR3SSGReEjYl3wgUkUCP/lE+0VKEv91SYzTy7Dz7KgRcOF/lqapsJFxBqEQIclXqNsxzo23QUh0Cg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-1.11.0.tgz",
+      "integrity": "sha512-RLL1RvsGL5tnoSY9/3n6qDbAmaz21/T+MHnaqWsg49U39rxVcPdxjxhuDTiN4AaMFY6IZgluHlr62Z5TQMKQfA==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "yup": "^0.29.3"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "webpack-merge": "^4.1.4"
   },
   "dependencies": {
-    "@konveyor/lib-ui": "^1.10.5",
+    "@konveyor/lib-ui": "^1.11.0",
     "@patternfly/react-core": "^4.79.2",
     "@patternfly/react-icons": "^4.7.18",
     "@patternfly/react-styles": "^4.7.16",

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -141,7 +141,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                   mutateMapping(generatedMapping);
                 }
               }}
-              isDisabled={!form.isValid || mutationResult.isLoading}
+              isDisabled={!form.isDirty || !form.isValid || mutationResult.isLoading}
             >
               {!mappingBeingEdited ? 'Create' : 'Save'}
             </Button>

--- a/src/app/Mappings/components/helpers.ts
+++ b/src/app/Mappings/components/helpers.ts
@@ -70,25 +70,24 @@ export const useEditingMappingPrefillEffect = (
   providersQuery: QueryResult<IProvidersByType>,
   mappingResourceQueries: IMappingResourcesResult
 ): { isDonePrefilling: boolean } => {
+  const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
   const [isDonePrefilling, setIsDonePrefilling] = React.useState(!mappingBeingEdited);
   React.useEffect(() => {
     if (
+      !isStartedPrefilling &&
       mappingBeingEdited &&
-      !form.isDirty &&
       providersQuery.isSuccess &&
       mappingResourceQueries.status === QueryStatus.Success
     ) {
+      setIsStartedPrefilling(true);
       const { sourceProvider, targetProvider } = mappingBeingEditedProviders;
       const { availableSources, availableTargets } = mappingResourceQueries;
 
-      form.fields.name.setValue(mappingBeingEdited.metadata.name);
-      form.fields.name.setIsTouched(true);
-      form.fields.sourceProvider.setValue(sourceProvider);
-      form.fields.sourceProvider.setIsTouched(true);
-      form.fields.targetProvider.setValue(targetProvider);
-      form.fields.targetProvider.setIsTouched(true);
+      form.fields.name.setInitialValue(mappingBeingEdited.metadata.name);
+      form.fields.sourceProvider.setInitialValue(sourceProvider);
+      form.fields.targetProvider.setInitialValue(targetProvider);
 
-      form.fields.builderItems.setValue(
+      form.fields.builderItems.setInitialValue(
         getBuilderItemsFromMapping(
           mappingBeingEdited,
           mappingType,
@@ -96,7 +95,6 @@ export const useEditingMappingPrefillEffect = (
           availableTargets
         )
       );
-      form.fields.builderItems.setIsTouched(true);
 
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {
@@ -104,8 +102,8 @@ export const useEditingMappingPrefillEffect = (
       }, 0);
     }
   }, [
+    isStartedPrefilling,
     form.fields,
-    form.isDirty,
     mappingBeingEdited,
     mappingBeingEditedProviders,
     mappingResourceQueries,

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -102,6 +102,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
   const providerType = providerTypeField.value;
   const formValues = providerType ? forms[providerType].values : vmwareForm.values;
   const isFormValid = providerType ? forms[providerType].isValid : false;
+  const isFormDirty = providerType ? forms[providerType].isDirty : false;
 
   const [createProvider, createProviderResult] = useCreateProviderMutation(providerType, onClose);
   const [patchProvider, patchProviderResult] = usePatchProviderMutation(
@@ -130,7 +131,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
             <Button
               key="confirm"
               variant="primary"
-              isDisabled={!isFormValid || mutateProviderResult.isLoading}
+              isDisabled={!isFormDirty || !isFormValid || mutateProviderResult.isLoading}
               onClick={() => {
                 mutateProvider(formValues);
               }}

--- a/src/app/Providers/components/AddEditProviderModal/helpers.ts
+++ b/src/app/Providers/components/AddEditProviderModal/helpers.ts
@@ -13,45 +13,40 @@ export const useEditProviderPrefillEffect = (
   forms: AddProviderFormState,
   providerBeingEdited: IProviderObject | null
 ): IEditProviderPrefillEffect => {
+  const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
   const [isDonePrefilling, setIsDonePrefilling] = React.useState(!providerBeingEdited);
   const secretQuery = useSecretQuery(providerBeingEdited?.spec.secret?.name || null);
   React.useEffect(() => {
-    if (
-      providerBeingEdited &&
-      !forms.vsphere.isDirty &&
-      !forms.openshift.isDirty &&
-      secretQuery.isSuccess
-    ) {
+    if (!isStartedPrefilling && providerBeingEdited && secretQuery.isSuccess) {
+      setIsStartedPrefilling(true);
       const secret = secretQuery.data;
       if (providerBeingEdited.spec.type === ProviderType.vsphere) {
         const { fields } = forms.vsphere;
-        fields.providerType.setValue(providerBeingEdited.spec.type);
-        fields.providerType.setIsTouched(true);
-        fields.name.setValue(providerBeingEdited.metadata.name);
-        fields.name.setIsTouched(true);
-        fields.hostname.setValue(vmwareUrlToHostname(providerBeingEdited.spec.url || ''));
-        fields.hostname.setIsTouched(true);
-        fields.username.setValue(atob(secret?.data.user || ''));
-        fields.username.setIsTouched(true);
-        fields.password.setValue(atob(secret?.data.password || ''));
-        fields.fingerprint.setValue(atob(secret?.data.thumbprint || ''));
-        fields.fingerprint.setIsTouched(true);
+        fields.providerType.setInitialValue(providerBeingEdited.spec.type);
+        fields.name.setInitialValue(providerBeingEdited.metadata.name);
+        fields.hostname.setInitialValue(vmwareUrlToHostname(providerBeingEdited.spec.url || ''));
+        fields.username.setInitialValue(atob(secret?.data.user || ''));
+        fields.password.setInitialValue(atob(secret?.data.password || ''));
+        fields.fingerprint.setInitialValue(atob(secret?.data.thumbprint || ''));
       } else if (providerBeingEdited.spec.type === ProviderType.openshift) {
         const { fields } = forms.openshift;
-        fields.providerType.setValue(providerBeingEdited.spec.type);
-        fields.providerType.setIsTouched(true);
-        fields.name.setValue(providerBeingEdited.metadata.name);
-        fields.name.setIsTouched(true);
-        fields.url.setValue(providerBeingEdited.spec.url || '');
-        fields.url.setIsTouched(true);
-        fields.saToken.setValue(atob(secret?.data.token || ''));
-        fields.saToken.setIsTouched(true);
+        fields.providerType.setInitialValue(providerBeingEdited.spec.type);
+        fields.name.setInitialValue(providerBeingEdited.metadata.name);
+        fields.url.setInitialValue(providerBeingEdited.spec.url || '');
+        fields.saToken.setInitialValue(atob(secret?.data.token || ''));
       }
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {
         setIsDonePrefilling(true);
       }, 0);
     }
-  }, [forms, providerBeingEdited, secretQuery.data, secretQuery.isSuccess]);
+  }, [
+    isStartedPrefilling,
+    forms.openshift,
+    forms.vsphere,
+    providerBeingEdited,
+    secretQuery.data,
+    secretQuery.isSuccess,
+  ]);
   return { isDonePrefilling };
 };

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -82,7 +82,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
             <Button
               key="confirm"
               variant="primary"
-              isDisabled={!form.isValid || configureHostsResult.isLoading}
+              isDisabled={!form.isDirty || !form.isValid || configureHostsResult.isLoading}
               onClick={() => {
                 if (form.isValid) {
                   configureHosts(form.values);
@@ -106,7 +106,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
         <Button
           key="confirm"
           variant="primary"
-          isDisabled={!form.isValid || configureHostsResult.isLoading}
+          isDisabled={!form.isDirty || !form.isValid || configureHostsResult.isLoading}
           onClick={() => {
             if (form.isValid) {
               configureHosts(form.values);
@@ -115,7 +115,12 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
         >
           Add
         </Button>,
-        <Button key="cancel" variant="link" onClick={onClose}>
+        <Button
+          key="cancel"
+          variant="link"
+          onClick={onClose}
+          isDisabled={configureHostsResult.isLoading}
+        >
           Cancel
         </Button>,
       ]}

--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -37,6 +37,7 @@ export const usePrefillHostConfigEffect = (
   hostConfigs: IHostConfig[],
   provider: IVMwareProvider
 ): IPrefillHostConfigEffect => {
+  const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
   const [isDonePrefilling, setIsDonePrefilling] = React.useState(false);
   const existingHostConfigs = getExistingHostConfigs(selectedHosts, hostConfigs, provider);
   const existingSecretName =
@@ -46,7 +47,8 @@ export const usePrefillHostConfigEffect = (
     null;
   const secretQuery = useSecretQuery(existingSecretName);
   React.useEffect(() => {
-    if (!form.isDirty && (!existingSecretName || secretQuery.isSuccess)) {
+    if (!isStartedPrefilling && (!existingSecretName || secretQuery.isSuccess)) {
+      setIsStartedPrefilling(true);
       const existingIpAddresses = existingHostConfigs.map((config) => config?.spec.ipAddress);
       const allOnSameIp = Array.from(new Set(existingIpAddresses)).length === 1;
       const preselectedAdapter =
@@ -57,14 +59,11 @@ export const usePrefillHostConfigEffect = (
         null;
       const secret = secretQuery.data;
       if (preselectedAdapter) {
-        form.fields.selectedNetworkAdapter.setValue(preselectedAdapter);
-        form.fields.selectedNetworkAdapter.setIsTouched(true);
+        form.fields.selectedNetworkAdapter.setInitialValue(preselectedAdapter);
       }
       if (secret) {
-        form.fields.adminUsername.setValue(atob(secret.data.user || ''));
-        form.fields.adminUsername.setIsTouched(true);
-        form.fields.adminPassword.setValue(atob(secret.data.password || ''));
-        form.fields.adminPassword.setIsTouched(true);
+        form.fields.adminUsername.setInitialValue(atob(secret.data.user || ''));
+        form.fields.adminPassword.setInitialValue(atob(secret.data.password || ''));
       }
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {
@@ -72,6 +71,7 @@ export const usePrefillHostConfigEffect = (
       }, 0);
     }
   }, [
+    isStartedPrefilling,
     selectedHosts,
     existingHostConfigs,
     existingSecretName,


### PR DESCRIPTION
Backports #365

* Bump @konveyor/lib-ui

* Do not set isTouched in useEditProviderPrefillEffect();

* Disable Provider form if form is touched

* Prefill provider form within useAddProviderFormState

* Revert "Prefill provider form within useAddProviderFormState"

This reverts commit 930406d23484b0d663a4a85da8fb061e565bfb87.

* Bump lib-ui again

* Use setInitialValue and isDirty to handle prefilling state in the providers form

* Use isStartedPrefilling instead of isDirty to prevent useEffect from running more than once

* Fix prefilling for hosts, mappings and plans

Co-authored-by: Mike Turley <mike.turley@alum.cs.umass.edu>