### PR TITLE
[Backport] Rename master to main in workflow files and README (#375)

### DIFF
--- a/.github/workflows/deploy-main-preview.yaml
+++ b/.github/workflows/deploy-main-preview.yaml
@@ -1,8 +1,8 @@
-name: Deploy master preview
+name: Deploy main branch preview
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test-and-release:

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -36,5 +36,5 @@ jobs:
       - name: Post URL as PR comment
         uses: mshick/add-pr-comment@v1
         with:
-          message: "🚀 Deployed Preview: http://${{steps.surge-url.outputs.result}} ✨\n\nCompare with current master: http://konveyor-forklift-ui-preview.surge.sh"
+          message: "🚀 Deployed Preview: http://${{steps.surge-url.outputs.result}} ✨\n\nCompare with current main branch: http://konveyor-forklift-ui-preview.surge.sh"
           repo-token: ${{ steps.token.outputs.GH_TOKEN }}

--- a/.github/workflows/tests-ci.yaml
+++ b/.github/workflows/tests-ci.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - release*
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ cd forklift-ui
 npm install
 ```
 
-Create a meta.dev.json file in the config directory using [`config/meta.dev.example.json`](https://github.com/konveyor/forklift-ui/blob/master/config/meta.example.json) as a template. Set the `inventoryApi` property to the root URL of your forklift-controller inventory API, and set the `clusterApi` property to the root URL of your host OpenShift cluster API. And also to be able to use VMware provider data to be analysed by Migration Analytics set the `inventoryPayloadApi` property to the root URL of your forklift-controller inventory Payload API.
+Create a meta.dev.json file in the config directory using [`config/meta.dev.example.json`](https://github.com/konveyor/forklift-ui/blob/main/config/meta.example.json) as a template. Set the `inventoryApi` property to the root URL of your forklift-controller inventory API, and set the `clusterApi` property to the root URL of your host OpenShift cluster API. And also to be able to use VMware provider data to be analysed by Migration Analytics set the `inventoryPayloadApi` property to the root URL of your forklift-controller inventory Payload API.
 
-**Optional**: If you plan to run webpack directly or run in production mode, you can create a file named `.env` in the repository root, using [`.env.example`](https://github.com/konveyor/forklift-ui/blob/master/.env.example) as a template. Here you can set persistent environment variables:
+**Optional**: If you plan to run webpack directly or run in production mode, you can create a file named `.env` in the repository root, using [`.env.example`](https://github.com/konveyor/forklift-ui/blob/main/.env.example) as a template. Here you can set persistent environment variables:
 
 - `DATA_SOURCE` - either `mock` or `remote`
   (unnecessary if you use `npm run [start:dev|build]:[mock|remote]` scripts)


### PR DESCRIPTION
Backports #375

This has no effect for the user, but I want to keep the 2 branches in sync as much as possible until code freeze.