### PR TITLE
[BZ#1908020] Remove redundant link from Providers text in hosts page breadcrumb bar

### DIFF
--- a/src/app/Providers/HostsPage.tsx
+++ b/src/app/Providers/HostsPage.tsx
@@ -45,9 +45,7 @@ export const HostsPage: React.FunctionComponent = () => {
         <Level>
           <LevelItem>
             <Breadcrumb>
-              <BreadcrumbItem>
-                <Link to={`/providers`}>Providers</Link>
-              </BreadcrumbItem>
+              <BreadcrumbItem>Providers</BreadcrumbItem>
               <BreadcrumbItem>
                 <Link to={`/providers/vsphere`}>VMware</Link>
               </BreadcrumbItem>


### PR DESCRIPTION
Addressing feedback on https://bugzilla.redhat.com/show_bug.cgi?id=1908020