### PR TITLE
[Backport] Remove redundant link from Providers text in hosts page breadcrumb bar (#378)

### DIFF
--- a/src/app/Providers/HostsPage.tsx
+++ b/src/app/Providers/HostsPage.tsx
@@ -45,9 +45,7 @@ export const HostsPage: React.FunctionComponent = () => {
         <Level>
           <LevelItem>
             <Breadcrumb>
-              <BreadcrumbItem>
-                <Link to={`/providers`}>Providers</Link>
-              </BreadcrumbItem>
+              <BreadcrumbItem>Providers</BreadcrumbItem>
               <BreadcrumbItem>
                 <Link to={`/providers/vsphere`}>VMware</Link>
               </BreadcrumbItem>


### PR DESCRIPTION
Backports #378