### PR TITLE
Add unique id on provider select toggle buttons

### DIFF
--- a/src/app/common/components/ProviderSelect.tsx
+++ b/src/app/common/components/ProviderSelect.tsx
@@ -75,6 +75,7 @@ const ProviderSelect = <T extends InventoryProvider>({
       >
         <SimpleSelect
           id={`provider-select-${providerType}`}
+          toggleId={`provider-select-${providerType}-toggle`}
           aria-label={label}
           options={options}
           value={[options.find((option) => option.value.metadata.name === field.value?.name)]}


### PR DESCRIPTION
Unblocks @ibragins, QE tests were blocked on not being able to uniquely distinguish source and target provider dropdowns.

To select the toggle button for opening the dropdowns, you can now use ids:
```
#provider-select-vsphere-toggle
#provider-select-openshift-toggle
```
Once opened, you can select the list of provider options with these ids:
```
#provider-select-vsphere
#provider-select-openshift
```

We were passing only the `id` prop to the Select component when we should also have been using the `toggleId` prop.