### PR TITLE
Pipeline summary: handle special case where the VM has an error but the current step does not

### DIFF
--- a/src/app/Plans/components/Step.tsx
+++ b/src/app/Plans/components/Step.tsx
@@ -6,7 +6,6 @@ import {
 } from '@patternfly/react-icons';
 import {
   global_danger_color_100 as dangerColor,
-  global_warning_color_100 as warningColor,
   global_disabled_color_200 as disabledColor,
   global_info_color_100 as infoColor,
   global_success_color_100 as successColor,
@@ -39,7 +38,7 @@ const Step: React.FunctionComponent<IStepProps> = ({ vmStatus, type, error }: IS
         className={spacing.mlSm}
         height="1em"
         width="1em"
-        color={error ? dangerColor.value : vmStatus.error ? warningColor.value : infoColor.value}
+        color={error || vmStatus.error ? dangerColor.value : infoColor.value}
       />
     );
   }

--- a/src/app/Plans/components/Step.tsx
+++ b/src/app/Plans/components/Step.tsx
@@ -6,19 +6,22 @@ import {
 } from '@patternfly/react-icons';
 import {
   global_danger_color_100 as dangerColor,
+  global_warning_color_100 as warningColor,
   global_disabled_color_200 as disabledColor,
   global_info_color_100 as infoColor,
   global_success_color_100 as successColor,
 } from '@patternfly/react-tokens';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { StepType } from '@app/common/constants';
+import { IVMStatus } from '@app/queries/types';
 
 interface IStepProps {
+  vmStatus: IVMStatus;
   type: StepType;
   error?: boolean;
 }
 
-const Step: React.FunctionComponent<IStepProps> = ({ type, error }: IStepProps) => {
+const Step: React.FunctionComponent<IStepProps> = ({ vmStatus, type, error }: IStepProps) => {
   let step: React.ReactElement | null = null;
   if (type === StepType.Full) {
     step = (
@@ -36,7 +39,7 @@ const Step: React.FunctionComponent<IStepProps> = ({ type, error }: IStepProps) 
         className={spacing.mlSm}
         height="1em"
         width="1em"
-        color={error ? dangerColor.value : infoColor.value}
+        color={error ? dangerColor.value : vmStatus.error ? warningColor.value : infoColor.value}
       />
     );
   }

--- a/src/app/Plans/components/VMStatusTable.tsx
+++ b/src/app/Plans/components/VMStatusTable.tsx
@@ -42,7 +42,11 @@ const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
             flexWrap={{ default: 'nowrap' }}
           >
             <FlexItem>
-              <Step type={getStepType(status, index)} error={isStepOnError(status, index)} />
+              <Step
+                vmStatus={status}
+                type={getStepType(status, index)}
+                error={isStepOnError(status, index)}
+              />
             </FlexItem>
             <FlexItem>
               <Text>{step.description ? step.description.replace(/\.$/, '') : ''}</Text>

--- a/src/app/Plans/components/VMStatusTable.tsx
+++ b/src/app/Plans/components/VMStatusTable.tsx
@@ -13,7 +13,7 @@ import {
 import Step from './Step';
 import { IVMStatus, IStep } from '@app/queries/types';
 import TickingElapsedTime from '@app/common/components/TickingElapsedTime';
-import { getStepType, isStepOnError } from '@app/common/helpers';
+import { findCurrentStep, getStepType, isStepOnError } from '@app/common/helpers';
 
 interface IVMStatusTableProps {
   status: IVMStatus;
@@ -31,45 +31,56 @@ const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
     { title: 'State', cellTransforms: [truncate] },
   ];
 
-  const rows: IRow[] = status.pipeline.map((step: IStep, index) => ({
-    meta: { step },
-    cells: [
-      {
-        title: (
-          <Flex
-            spaceItems={{ default: 'spaceItemsSm' }}
-            alignContent={{ default: 'alignContentFlexStart' }}
-            flexWrap={{ default: 'nowrap' }}
-          >
-            <FlexItem>
-              <Step
-                vmStatus={status}
-                type={getStepType(status, index)}
-                error={isStepOnError(status, index)}
-              />
-            </FlexItem>
-            <FlexItem>
-              <Text>{step.description ? step.description.replace(/\.$/, '') : ''}</Text>
-            </FlexItem>
-          </Flex>
-        ),
-      },
-      {
-        title: <TickingElapsedTime start={step.started} end={step.completed} />,
-      },
-      {
-        title: step.error ? (
-          <Popover headerContent={step.phase} bodyContent={step.error?.reasons}>
-            <Button variant="link" isInline>
-              {step.phase}
-            </Button>
-          </Popover>
-        ) : (
-          step.phase
-        ),
-      },
-    ],
-  }));
+  const { currentStepIndex } = findCurrentStep(status.pipeline);
+
+  const rows: IRow[] = status.pipeline.map((step: IStep, index) => {
+    const isCurrentStep = currentStepIndex === index;
+    const error = step.error || (isCurrentStep && status.error);
+    return {
+      meta: { step },
+      cells: [
+        {
+          title: (
+            <Flex
+              spaceItems={{ default: 'spaceItemsSm' }}
+              alignContent={{ default: 'alignContentFlexStart' }}
+              flexWrap={{ default: 'nowrap' }}
+            >
+              <FlexItem>
+                <Step
+                  vmStatus={status}
+                  type={getStepType(status, index)}
+                  error={isStepOnError(status, index)}
+                />
+              </FlexItem>
+              <FlexItem>
+                <Text>{step.description ? step.description.replace(/\.$/, '') : ''}</Text>
+              </FlexItem>
+            </Flex>
+          ),
+        },
+        {
+          title: (
+            <TickingElapsedTime
+              start={step.started}
+              end={step.completed || (status.error ? status.completed : undefined)}
+            />
+          ),
+        },
+        {
+          title: error ? (
+            <Popover headerContent={error.phase} bodyContent={error?.reasons}>
+              <Button variant="link" isInline>
+                {step.phase || error?.reasons}
+              </Button>
+            </Popover>
+          ) : (
+            step.phase
+          ),
+        },
+      ],
+    };
+  });
 
   return (
     <>

--- a/src/app/common/components/PipelineSummary.tsx
+++ b/src/app/common/components/PipelineSummary.tsx
@@ -7,6 +7,7 @@ import {
 } from '@patternfly/react-icons';
 import {
   global_danger_color_100 as dangerColor,
+  global_warning_color_100 as warningColor,
   global_disabled_color_200 as disabledColor,
   global_info_color_100 as infoColor,
   global_success_color_100 as successColor,
@@ -52,6 +53,7 @@ const GetStepTypeIcon: React.FunctionComponent<IGetStepTypeIcon> = ({
   index,
 }: IGetStepTypeIcon) => {
   const res = getStepType(status, index);
+  const { currentStepIndex } = findCurrentStep(status.pipeline);
   let icon: React.ReactNode;
   if (res === StepType.Full) {
     icon = (
@@ -62,7 +64,13 @@ const GetStepTypeIcon: React.FunctionComponent<IGetStepTypeIcon> = ({
   } else if (res === StepType.Half) {
     icon = (
       <ResourcesAlmostFullIcon
-        color={isStepOnError(status, index) ? dangerColor.value : infoColor.value}
+        color={
+          isStepOnError(status, index)
+            ? dangerColor.value
+            : status.error
+            ? warningColor.value
+            : infoColor.value
+        }
       />
     );
   } else {
@@ -71,7 +79,7 @@ const GetStepTypeIcon: React.FunctionComponent<IGetStepTypeIcon> = ({
   return (
     <>
       {icon}
-      {index < status.pipeline.length - 1 ? <Dash isReached={true} /> : null}
+      {index < status.pipeline.length - 1 ? <Dash isReached={index < currentStepIndex} /> : null}
     </>
   );
 };

--- a/src/app/common/components/PipelineSummary.tsx
+++ b/src/app/common/components/PipelineSummary.tsx
@@ -7,7 +7,6 @@ import {
 } from '@patternfly/react-icons';
 import {
   global_danger_color_100 as dangerColor,
-  global_warning_color_100 as warningColor,
   global_disabled_color_200 as disabledColor,
   global_info_color_100 as infoColor,
   global_success_color_100 as successColor,
@@ -64,13 +63,7 @@ const GetStepTypeIcon: React.FunctionComponent<IGetStepTypeIcon> = ({
   } else if (res === StepType.Half) {
     icon = (
       <ResourcesAlmostFullIcon
-        color={
-          isStepOnError(status, index)
-            ? dangerColor.value
-            : status.error
-            ? warningColor.value
-            : infoColor.value
-        }
+        color={isStepOnError(status, index) || status.error ? dangerColor.value : infoColor.value}
       />
     );
   } else {

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -88,11 +88,8 @@ export const formatDuration = (
 export const getStepType = (status: IVMStatus, index: number): StepType => {
   const { currentStepIndex } = findCurrentStep(status.pipeline);
   const step = status.pipeline[index];
-  if (status.completed || step?.completed || index < currentStepIndex) return StepType.Full;
-  if (status.started && index === currentStepIndex) {
-    if (status.error) return StepType.Full;
-    return StepType.Half;
-  }
+  if (step?.completed || index < currentStepIndex) return StepType.Full;
+  if (status.started && index === currentStepIndex) return StepType.Half;
   return StepType.Empty;
 };
 

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -200,7 +200,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
         progress: { total: 1024 * 64, completed: 0 },
-        phase: 'Mock Step Phase',
         annotations: { unit: 'MB' },
         started: '2020-10-10T14:21:10Z',
       },

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -91,7 +91,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       },
       {
         name: 'PostHook',
-        description: 'Pre hook',
+        description: 'Post hook',
         progress: { total: 1, completed: 0 },
         phase: 'Mock Step Phase',
       },
@@ -199,7 +199,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
-        progress: { total: 1024 * 64, completed: 1024 * 64 },
+        progress: { total: 1024 * 64, completed: 0 },
         phase: 'Mock Step Phase',
         annotations: { unit: 'MB' },
         started: '2020-10-10T14:21:10Z',
@@ -212,7 +212,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       },
       {
         name: 'PostHook',
-        description: 'Pre hook',
+        description: 'Post hook',
         progress: { total: 1, completed: 0 },
         phase: 'Mock Step Phase',
       },

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -185,6 +185,44 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
+  const vmStatusWithYellow: IVMStatus = {
+    id: vm2.id,
+    pipeline: [
+      {
+        name: 'PreHook',
+        description: 'Pre hook',
+        progress: { total: 1, completed: 1 },
+        phase: 'Mock Step Phase',
+        started: '2020-10-10T14:04:10Z',
+        completed: '2020-10-10T14:21:10Z',
+      },
+      {
+        name: 'DiskTransfer',
+        description: 'Transfer disks.',
+        progress: { total: 1024 * 64, completed: 1024 * 64 },
+        phase: 'Mock Step Phase',
+        annotations: { unit: 'MB' },
+        started: '2020-10-10T14:21:10Z',
+      },
+      {
+        name: 'ImageConversion',
+        description: 'Convert image to kubevirt.',
+        progress: { total: 1, completed: 0 },
+        phase: 'Mock Step Phase',
+      },
+      {
+        name: 'PostHook',
+        description: 'Pre hook',
+        progress: { total: 1, completed: 0 },
+        phase: 'Mock Step Phase',
+      },
+    ],
+    phase: 'Mock VM Phase',
+    started: '2020-10-10T14:04:10Z',
+    completed: '2020-10-11T14:04:10Z',
+    error: { phase: 'ImportCreated', reasons: ['Import CR not found.'] },
+  };
+
   const plan1: IPlan = {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
@@ -329,7 +367,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       migration: {
         active: '',
         started: '2020-10-10T14:04:10Z',
-        vms: [vmStatus1, vmStatus2, vmStatus3, vmStatus4],
+        vms: [vmStatus1, vmStatusWithYellow, vmStatus3, vmStatus4],
       },
     },
   };


### PR DESCRIPTION
Resolves #390. (https://bugzilla.redhat.com/show_bug.cgi?id=1916963)

There is a special corner case we were not covering, which can be caused by a user suddenly deleting the VM Import CR after the migration starts (among other potential causes). In this case, the migration fails (and so the VM-level status has an error) but the pipeline step is still in a state of being started, not being completed, and not having an error. Because the VM was marked complete and no pipeline steps had errors, they were all showing green icons. And because the step during which the error happened was never marked complete, its elapsed time was continuing to tick forever.

This PR handles this case by making the current step icon red if there is a VM-level error even if there is not a pipeline step-level error. In this case, the VM-level error is displayed in the pipeline status column and the elapsed time is set to the difference between the step start time and the VM completed time.

![Screen Shot 2021-01-18 at 5 24 27 PM](https://user-images.githubusercontent.com/811963/104967714-094ca200-59b2-11eb-81c0-9f0e7dd0287f.png)
