### PR TITLE
Add Status column to Mappings tables, handle invalid mappings (missing sources/targets)

### DIFF
--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.css
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.css
@@ -5,3 +5,7 @@
 .mapping-view-arrow-cell {
   padding-top: 12px;
 }
+
+.missing-item {
+  color: var(--pf-global--danger-color--100);
+}

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -73,7 +73,7 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
                     return (
                       <li key={sourceName}>
                         <TruncatedText>
-                          {sourceName || <span className="missing-item">[missing]</span>}
+                          {sourceName || <span className="missing-item">Not available</span>}
                         </TruncatedText>
                       </li>
                     );
@@ -85,7 +85,7 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
               </GridItem>
               <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
                 <TruncatedText>
-                  {targetName || <span className="missing-item">[missing]</span>}
+                  {targetName || <span className="missing-item">Not available</span>}
                 </TruncatedText>
               </GridItem>
             </Grid>

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -3,17 +3,13 @@ import { Grid, GridItem } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { Mapping, MappingType } from '@app/queries/types';
 import LineArrow from '@app/common/components/LineArrow';
+import { useResourceQueriesForMapping } from '@app/queries';
+import TruncatedText from '@app/common/components/TruncatedText';
+import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { getMappingSourceById, getMappingSourceTitle, getMappingTargetTitle } from '../helpers';
 import { getMappingItemTargetName, groupMappingItemsByTarget } from './helpers';
 
 import './MappingDetailView.css';
-import {
-  findProvidersByRefs,
-  useMappingResourceQueries,
-  useInventoryProvidersQuery,
-} from '@app/queries';
-import TruncatedText from '@app/common/components/TruncatedText';
-import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 
 interface IMappingDetailViewProps {
   mappingType: MappingType;
@@ -26,21 +22,12 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
   mapping,
   className = '',
 }: IMappingDetailViewProps) => {
-  const providersQuery = useInventoryProvidersQuery();
-  const { sourceProvider, targetProvider } = findProvidersByRefs(
-    mapping?.spec.provider || null,
-    providersQuery
-  );
-  const mappingResourceQueries = useMappingResourceQueries(
-    sourceProvider,
-    targetProvider,
-    mappingType
-  );
+  const mappingResourceQueries = useResourceQueriesForMapping(mappingType, mapping);
   const mappingItemGroups = groupMappingItemsByTarget(mapping?.spec.map || [], mappingType);
 
   return (
     <ResolvedQueries
-      results={[providersQuery, ...mappingResourceQueries.queries]}
+      results={mappingResourceQueries.queries}
       errorTitles={[
         'Error loading providers',
         'Error loading source provider resources',

--- a/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -23,7 +23,11 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
   className = '',
 }: IMappingDetailViewProps) => {
   const mappingResourceQueries = useResourceQueriesForMapping(mappingType, mapping);
-  const mappingItemGroups = groupMappingItemsByTarget(mapping?.spec.map || [], mappingType);
+  const mappingItemGroups = groupMappingItemsByTarget(
+    mapping?.spec.map || [],
+    mappingType,
+    mappingResourceQueries.availableTargets
+  );
 
   return (
     <ResolvedQueries
@@ -50,7 +54,11 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
           </GridItem>
         </Grid>
         {mappingItemGroups.map((items, index) => {
-          const targetName = getMappingItemTargetName(items[0], mappingType);
+          const targetName = getMappingItemTargetName(
+            items[0],
+            mappingType,
+            mappingResourceQueries.availableTargets
+          );
           const isLastGroup = index === mappingItemGroups.length - 1;
           return (
             <Grid key={targetName} className={!isLastGroup ? spacing.mbLg : ''}>
@@ -64,7 +72,9 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
                     const sourceName = source ? source.name : '';
                     return (
                       <li key={sourceName}>
-                        <TruncatedText>{sourceName}</TruncatedText>
+                        <TruncatedText>
+                          {sourceName || <span className="missing-item">[missing]</span>}
+                        </TruncatedText>
                       </li>
                     );
                   })}
@@ -74,7 +84,9 @@ const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps> = ({
                 <LineArrow />
               </GridItem>
               <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
-                <TruncatedText>{targetName}</TruncatedText>
+                <TruncatedText>
+                  {targetName || <span className="missing-item">[missing]</span>}
+                </TruncatedText>
               </GridItem>
             </Grid>
           );

--- a/src/app/Mappings/components/MappingDetailView/helpers.ts
+++ b/src/app/Mappings/components/MappingDetailView/helpers.ts
@@ -9,8 +9,14 @@ import {
   MappingType,
   POD_NETWORK,
 } from '@app/queries/types';
+import { doesTargetExist } from '../helpers';
 
-export const getMappingItemTargetName = (item: MappingItem, mappingType: MappingType): string => {
+export const getMappingItemTargetName = (
+  item: MappingItem,
+  mappingType: MappingType,
+  availableTargets: MappingTarget[]
+): string => {
+  if (!doesTargetExist(mappingType, availableTargets, item)) return '';
   if (mappingType === MappingType.Network) {
     const networkItem = item as INetworkMappingItem;
     if (networkItem.destination.type === 'pod') return POD_NETWORK.name;
@@ -21,13 +27,18 @@ export const getMappingItemTargetName = (item: MappingItem, mappingType: Mapping
 
 export const groupMappingItemsByTarget = (
   mappingItems: MappingItem[],
-  mappingType: MappingType
+  mappingType: MappingType,
+  availableTargets: MappingTarget[]
 ): MappingItem[][] => {
   const targetNames: string[] = Array.from(
-    new Set(mappingItems.map((item) => getMappingItemTargetName(item, mappingType)))
+    new Set(
+      mappingItems.map((item) => getMappingItemTargetName(item, mappingType, availableTargets))
+    )
   );
   return targetNames.map((targetName) =>
-    mappingItems.filter((item) => getMappingItemTargetName(item, mappingType) === targetName)
+    mappingItems.filter(
+      (item) => getMappingItemTargetName(item, mappingType, availableTargets) === targetName
+    )
   );
 };
 

--- a/src/app/Mappings/components/MappingStatus.css
+++ b/src/app/Mappings/components/MappingStatus.css
@@ -1,0 +1,3 @@
+span.pf-c-spinner.status-spinner {
+  --pf-c-spinner--diameter: 1em;
+}

--- a/src/app/Mappings/components/MappingStatus.tsx
+++ b/src/app/Mappings/components/MappingStatus.tsx
@@ -13,9 +13,6 @@ interface IMappingStatusProps {
   mapping: Mapping;
 }
 
-// TODO if invalid, prevent selecting in the wizard with a tooltip
-// TODO if invalid, either prevent expandable content or edit MappingDetailView so it can show "missing" in place of the missing items.
-
 const MappingStatus: React.FunctionComponent<IMappingStatusProps> = ({
   mappingType,
   mapping,

--- a/src/app/Mappings/components/MappingStatus.tsx
+++ b/src/app/Mappings/components/MappingStatus.tsx
@@ -1,14 +1,70 @@
-import { MappingType, Mapping } from '@app/queries/types';
 import * as React from 'react';
+import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
+import { useResourceQueriesForMapping } from '@app/queries';
+import { isSameResource } from '@app/queries/helpers';
+import {
+  MappingType,
+  Mapping,
+  MappingItem,
+  IStorageMappingItem,
+  INetworkMappingItem,
+} from '@app/queries/types';
+
+import './MappingStatus.css';
 
 interface IMappingStatusProps {
   mappingType: MappingType;
   mapping: Mapping;
 }
 
+// TODO if invalid, prevent editing.
+// TODO if invalid, prevent selecting in the wizard and show a warning?
+// TODO if invalid, either prevent expandable content or edit MappingDetailView so it can show "missing" in place of the missing items.
+// TODO factor out any shared logic between this, MappingActionsDropdown, and MappingDetailView.
+
 const MappingStatus: React.FunctionComponent<IMappingStatusProps> = ({
   mappingType,
   mapping,
-}: IMappingStatusProps) => <>TODO!</>;
+}: IMappingStatusProps) => {
+  const { availableSources, availableTargets, queries } = useResourceQueriesForMapping(
+    mappingType,
+    mapping
+  );
+  const isMappingValid = (mapping.spec.map as MappingItem[]).every(
+    (mappingItem) =>
+      availableSources.some((source) => source.id === mappingItem.source.id) &&
+      availableTargets.some((target) => {
+        if (mappingType === MappingType.Storage) {
+          return target.name === (mappingItem as IStorageMappingItem).destination.storageClass;
+        }
+        if (mappingType === MappingType.Network) {
+          const item = mappingItem as INetworkMappingItem;
+          return item.destination.type === 'pod' || isSameResource(target, item.destination);
+        }
+        return false;
+      })
+  );
+  return (
+    <ResolvedQueries
+      results={queries}
+      errorTitles={[
+        'Error loading providers',
+        'Error loading source provider resources',
+        'Error loading target provider resources',
+      ]}
+      spinnerMode={QuerySpinnerMode.Inline}
+      spinnerProps={{
+        size: 'md',
+        className: 'status-spinner',
+      }}
+    >
+      <StatusIcon
+        status={isMappingValid ? StatusType.Ok : StatusType.Error}
+        label={isMappingValid ? 'OK' : 'Invalid'}
+      />
+    </ResolvedQueries>
+  );
+};
 
 export default MappingStatus;

--- a/src/app/Mappings/components/MappingStatus.tsx
+++ b/src/app/Mappings/components/MappingStatus.tsx
@@ -1,0 +1,14 @@
+import { MappingType, Mapping } from '@app/queries/types';
+import * as React from 'react';
+
+interface IMappingStatusProps {
+  mappingType: MappingType;
+  mapping: Mapping;
+}
+
+const MappingStatus: React.FunctionComponent<IMappingStatusProps> = ({
+  mappingType,
+  mapping,
+}: IMappingStatusProps) => <>TODO!</>;
+
+export default MappingStatus;

--- a/src/app/Mappings/components/MappingStatus.tsx
+++ b/src/app/Mappings/components/MappingStatus.tsx
@@ -13,7 +13,6 @@ interface IMappingStatusProps {
   mapping: Mapping;
 }
 
-// TODO if invalid, prevent editing with a tooltip
 // TODO if invalid, prevent selecting in the wizard with a tooltip
 // TODO if invalid, either prevent expandable content or edit MappingDetailView so it can show "missing" in place of the missing items.
 

--- a/src/app/Mappings/components/MappingsActionsDropdown.tsx
+++ b/src/app/Mappings/components/MappingsActionsDropdown.tsx
@@ -54,7 +54,7 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
               !areProvidersReady
                 ? 'This mapping cannot be edited because the inventory data for its associated providers is not ready'
                 : !isValid
-                ? 'This mapping cannot be edited because it includes missing source or target resources'
+                ? 'This mapping cannot be edited because it includes missing source or target resources. Delete and recreate the mapping.'
                 : ''
             }
           >

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -18,6 +18,7 @@ import { Mapping, MappingType } from '@app/queries/types';
 import MappingsActionsDropdown from './MappingsActionsDropdown';
 import MappingDetailView from './MappingDetailView';
 import CreateMappingButton from './CreateMappingButton';
+import MappingStatus from './MappingStatus';
 
 interface IMappingsTableProps {
   mappings: Mapping[];
@@ -81,7 +82,9 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
         name,
         provider.source.name,
         provider.destination.name,
-        'TODO',
+        {
+          title: <MappingStatus mappingType={mappingType} mapping={mapping} />,
+        },
         {
           title: (
             <MappingsActionsDropdown

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -42,6 +42,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
       name,
       provider.source.name,
       provider.destination.name,
+      '', // Status column  -- TODO can we even get a sort value for this?
       '', // Action column
     ];
   };
@@ -62,6 +63,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
     { title: 'Name', transforms: [sortable], cellFormatters: [expandable] },
     { title: 'Source provider', transforms: [sortable] },
     { title: 'Target provider', transforms: [sortable] },
+    { title: 'Status' },
     { title: '', columnTransforms: [classNamesTransform(tableStyles.tableAction)] },
   ];
 
@@ -79,6 +81,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
         name,
         provider.source.name,
         provider.destination.name,
+        'TODO',
         {
           title: (
             <MappingsActionsDropdown

--- a/src/app/Mappings/components/helpers.ts
+++ b/src/app/Mappings/components/helpers.ts
@@ -114,6 +114,22 @@ export const useEditingMappingPrefillEffect = (
   return { isDonePrefilling };
 };
 
+export const doesTargetExist = (
+  mappingType: MappingType,
+  availableTargets: MappingTarget[],
+  mappingItem: MappingItem
+): boolean =>
+  availableTargets.some((target) => {
+    if (mappingType === MappingType.Storage) {
+      return target.name === (mappingItem as IStorageMappingItem).destination.storageClass;
+    }
+    if (mappingType === MappingType.Network) {
+      const item = mappingItem as INetworkMappingItem;
+      return item.destination.type === 'pod' || isSameResource(target, item.destination);
+    }
+    return false;
+  });
+
 export const isMappingValid = (
   mappingType: MappingType,
   mapping: Mapping,
@@ -123,14 +139,5 @@ export const isMappingValid = (
   (mapping.spec.map as MappingItem[]).every(
     (mappingItem) =>
       availableSources.some((source) => source.id === mappingItem.source.id) &&
-      availableTargets.some((target) => {
-        if (mappingType === MappingType.Storage) {
-          return target.name === (mappingItem as IStorageMappingItem).destination.storageClass;
-        }
-        if (mappingType === MappingType.Network) {
-          const item = mappingItem as INetworkMappingItem;
-          return item.destination.type === 'pod' || isSameResource(target, item.destination);
-        }
-        return false;
-      })
+      doesTargetExist(mappingType, availableTargets, mappingItem)
   );

--- a/src/app/Mappings/components/helpers.ts
+++ b/src/app/Mappings/components/helpers.ts
@@ -7,6 +7,7 @@ import {
   IStorageMappingItem,
   IVMwareProvider,
   Mapping,
+  MappingItem,
   MappingSource,
   MappingTarget,
   MappingType,
@@ -112,3 +113,24 @@ export const useEditingMappingPrefillEffect = (
   ]);
   return { isDonePrefilling };
 };
+
+export const isMappingValid = (
+  mappingType: MappingType,
+  mapping: Mapping,
+  availableSources: MappingSource[],
+  availableTargets: MappingTarget[]
+): boolean =>
+  (mapping.spec.map as MappingItem[]).every(
+    (mappingItem) =>
+      availableSources.some((source) => source.id === mappingItem.source.id) &&
+      availableTargets.some((target) => {
+        if (mappingType === MappingType.Storage) {
+          return target.name === (mappingItem as IStorageMappingItem).destination.storageClass;
+        }
+        if (mappingType === MappingType.Network) {
+          const item = mappingItem as INetworkMappingItem;
+          return item.destination.type === 'pod' || isSameResource(target, item.destination);
+        }
+        return false;
+      })
+  );

--- a/src/app/Plans/components/Wizard/MappingForm.css
+++ b/src/app/Plans/components/Wizard/MappingForm.css
@@ -1,3 +1,8 @@
 #mappingSelect .pf-c-select__menu-group .pf-c-select__menu-item {
   padding-left: var(--pf-global--spacer--xl);
 }
+
+#mappingSelect .pf-c-select__menu-item.pf-m-disabled.disabled-with-pointer-events > div {
+  display: inline-block;
+  padding-left: 0;
+}

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -60,7 +60,32 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  MOCK_STORAGE_MAPPINGS = [storageMapping1, storageMapping2];
+  const invalidStorageMapping: IStorageMapping = {
+    apiVersion: CLUSTER_API_VERSION,
+    kind: 'StorageMap',
+    metadata: {
+      name: 'vcenter1-invalid-storage-mapping',
+      namespace: META.namespace,
+    },
+    spec: {
+      provider: {
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[2]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+      },
+      map: [
+        {
+          source: {
+            id: 'invalid-id',
+          },
+          destination: {
+            storageClass: MOCK_STORAGE_CLASSES_BY_PROVIDER['ocpv-1'][1].name,
+          },
+        },
+      ],
+    },
+  };
+
+  MOCK_STORAGE_MAPPINGS = [storageMapping1, storageMapping2, invalidStorageMapping];
 
   const networkMapping1: INetworkMapping = {
     apiVersion: CLUSTER_API_VERSION,
@@ -114,11 +139,11 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  const networkMapping3: INetworkMapping = {
+  const invalidNetworkMapping: INetworkMapping = {
     apiVersion: CLUSTER_API_VERSION,
-    kind: 'StorageMap',
+    kind: 'NetworkMap',
     metadata: {
-      name: 'vcenter1-netstore-to-pod',
+      name: 'vcenter3-invalid-network-map',
       namespace: META.namespace,
     },
     spec: {
@@ -132,12 +157,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             id: MOCK_VMWARE_NETWORKS[1].id,
           },
           destination: {
-            type: 'pod',
+            type: 'multus',
+            name: 'missing-network',
+            namespace: 'doesnt-matter',
           },
         },
       ],
     },
   };
 
-  MOCK_NETWORK_MAPPINGS = [networkMapping1, networkMapping2, networkMapping3];
+  MOCK_NETWORK_MAPPINGS = [networkMapping1, networkMapping2, invalidNetworkMapping];
 }


### PR DESCRIPTION
Resolves #208.

Adds a Status column to the mappings table which will show OK or Invalid (if the mapping references any missing inventory resources). If an invalid mapping is expanded, the missing items are pointed out with red "Not available" text:

![Screen Shot 2021-01-21 at 2 17 45 PM](https://user-images.githubusercontent.com/811963/105400847-769b4580-5bf3-11eb-8db4-b6793e3d4bd6.png)


Adds a popover on the Invalid status value to explain why it's invalid:

![Screen Shot 2021-01-21 at 1 15 13 PM](https://user-images.githubusercontent.com/811963/105398905-e5c36a80-5bf0-11eb-9480-cf7f93be3c23.png)

Prevents an invalid mapping from being edited with a tooltip explaining why:

![Screen Shot 2021-01-21 at 1 57 08 PM](https://user-images.githubusercontent.com/811963/105398973-f96ed100-5bf0-11eb-8913-da7ad238dd1c.png)

Prevents an invalid mapping from being selected in the plan wizard with a tooltip explaining why:

![Screen Shot 2021-01-21 at 1 39 23 PM](https://user-images.githubusercontent.com/811963/105399035-0ee3fb00-5bf1-11eb-8035-30969fcfda96.png)

Adds mock data to reproduce these cases in preview mode.