### PR TITLE
Add a message in the Target Namespace dropdown that you can type to create a new namespace

### DIFF
--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { Form, FormGroup, TextArea, Title } from '@patternfly/react-core';
+import { Form, FormGroup, Select, SelectOption, TextArea, Title } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { getFormGroupProps, ValidatedTextInput } from '@konveyor/lib-ui';
 
-import SimpleSelect from '@app/common/components/SimpleSelect';
+import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
 import { IPlan } from '@app/queries/types';
 import { useClusterProvidersQuery, useInventoryProvidersQuery } from '@app/queries';
 import { PlanWizardFormState } from './PlanWizard';
@@ -28,6 +28,8 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   const inventoryProvidersQuery = useInventoryProvidersQuery();
   const clusterProvidersQuery = useClusterProvidersQuery();
   const namespacesQuery = useNamespacesQuery(form.values.targetProvider);
+
+  const [isNamespaceSelectOpen, setIsNamespaceSelectOpen] = React.useState(false);
 
   return (
     <ResolvedQueries
@@ -79,17 +81,27 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             spinnerProps={{ className: spacing.mXs }}
             spinnerMode={QuerySpinnerMode.Inline}
           >
-            <SimpleSelect
+            <Select
+              placeholderText="Select a namespace"
+              isOpen={isNamespaceSelectOpen}
+              onToggle={setIsNamespaceSelectOpen}
+              onSelect={(_event, selection) => {
+                form.fields.targetNamespace.setValue(selection as string);
+                setIsNamespaceSelectOpen(false);
+              }}
+              selections={form.values.targetNamespace}
               variant="typeahead"
               isCreatable
               id="target-namespace"
               aria-label="Target namespace"
-              options={namespacesQuery.data?.map((namespace) => namespace.name) || []}
-              value={form.values.targetNamespace}
-              onChange={(selection) => form.fields.targetNamespace.setValue(selection as string)}
-              placeholderText="Select a namespace"
               isDisabled={!form.values.targetProvider}
-            />
+            >
+              {(namespacesQuery.data?.map((namespace) => namespace.name) || []).map(
+                (option, index) => (
+                  <SelectOption key={`${index}-${option.toString()}`} value={option} />
+                )
+              )}
+            </Select>
           </ResolvedQuery>
         </FormGroup>
       </Form>

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -106,7 +106,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
               isDisabled={!form.values.targetProvider}
             >
               {[
-                <SelectGroup key="group" label="Type to search or to create a new namespace">
+                <SelectGroup key="group" label="Select or type to create a namespace">
                   {namespaceOptions.map((option) => (
                     <SelectOption key={option.toString()} value={option} />
                   ))}

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react';
-import { Form, FormGroup, Select, SelectOption, TextArea, Title } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  Select,
+  SelectGroup,
+  SelectOption,
+  TextArea,
+  Title,
+} from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { getFormGroupProps, ValidatedTextInput } from '@konveyor/lib-ui';
 
-import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
 import { IPlan } from '@app/queries/types';
 import { useClusterProvidersQuery, useInventoryProvidersQuery } from '@app/queries';
 import { PlanWizardFormState } from './PlanWizard';
@@ -30,6 +37,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   const namespacesQuery = useNamespacesQuery(form.values.targetProvider);
 
   const [isNamespaceSelectOpen, setIsNamespaceSelectOpen] = React.useState(false);
+  const namespaceOptions = namespacesQuery.data?.map((namespace) => namespace.name) || [];
 
   return (
     <ResolvedQueries
@@ -92,15 +100,18 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
               selections={form.values.targetNamespace}
               variant="typeahead"
               isCreatable
+              isGrouped
               id="target-namespace"
               aria-label="Target namespace"
               isDisabled={!form.values.targetProvider}
             >
-              {(namespacesQuery.data?.map((namespace) => namespace.name) || []).map(
-                (option, index) => (
-                  <SelectOption key={`${index}-${option.toString()}`} value={option} />
-                )
-              )}
+              {[
+                <SelectGroup key="group" label="Type to search or to create a new namespace">
+                  {namespaceOptions.map((option) => (
+                    <SelectOption key={option.toString()} value={option} />
+                  ))}
+                </SelectGroup>,
+              ]}
             </Select>
           </ResolvedQuery>
         </FormGroup>


### PR DESCRIPTION
Resolves #395 (https://bugzilla.redhat.com/show_bug.cgi?id=1918069)

This places all the namespace Select options in a SelectGroup so that we can place a non-clickable header above them reading "Type to search or to create a new namespace".

![Screen Shot 2021-01-20 at 2 08 52 PM](https://user-images.githubusercontent.com/811963/105223133-5f902100-5b29-11eb-8131-da7515262f09.png)

When you start typing, the "Create" option appears alongside any existing namespaces that partially match what you've typed.

![Screen Shot 2021-01-20 at 2 12 15 PM](https://user-images.githubusercontent.com/811963/105223289-949c7380-5b29-11eb-97da-5b1f1d970c26.png)


Note: because we have limited control over the implementation details of the PatternFly Select component's `isCreatable` mode, this group header cannot be applied to the dynamic "Create ___" option that appears. So if you type something that does not partially match any existing namespaces, the only thing that appears is the "Create ____" option (the new header disappears). There's not much I can do about that at this time.

![Screen Shot 2021-01-20 at 2 09 03 PM](https://user-images.githubusercontent.com/811963/105223362-aaaa3400-5b29-11eb-8cb7-504a837c357a.png)
