### PR TITLE
Disable inline codecov annotations in pull request reviews (temporarily?)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+    annotations: false


### PR DESCRIPTION
Disables these annotations when reviewing pull request changes:

<img width="755" alt="Screen Shot 2021-02-03 at 12 16 40 PM" src="https://user-images.githubusercontent.com/811963/106783678-88301480-6619-11eb-972f-89a926374719.png">

They are extra noise that makes the code more difficult to read, at least for now while we haven't been able to prioritize unit testing. We can consider re-enabling them when the coverage is higher, but it's just as easy to look at the coverage report directly and my preference would be to keep the code view less cluttered.

See https://docs.codecov.io/docs/github-checks-beta#disabling-github-checks-patch-annotations-via-yaml

