### PR TITLE
[Backport] Use selfLink instead of name to uniquely identify VMs in selection state (#412)

### DIFF
--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -154,7 +154,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
 
   const { isItemSelected, toggleItemSelected, selectAll } = useSelectionState<IVMwareVM>({
     items: sortedItems,
-    isEqual: (a, b) => a.name === b.name,
+    isEqual: (a, b) => a.selfLink === b.selfLink,
     externalState: [form.fields.selectedVMs.value, form.fields.selectedVMs.setValue],
   });
 
@@ -163,7 +163,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
     IVMwareVM
   >({
     items: sortedItems,
-    isEqual: (a, b) => a.name === b.name,
+    isEqual: (a, b) => a.selfLink === b.selfLink,
   });
   */
 


### PR DESCRIPTION
Backports https://github.com/konveyor/forklift-ui/pull/412.