### PR TITLE
Correctly use namespace from meta.json instead of hard-coded 'openshift-migration' when adding providers

### DIFF
--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -144,7 +144,7 @@ export const convertFormValuesToProvider = (
     kind: 'Provider',
     metadata: {
       name,
-      namespace: 'openshift-migration',
+      namespace: META.namespace,
     },
     spec: {
       type: values.providerType,


### PR DESCRIPTION
The namespace `openshift-rhmtv` is now being used downstream, but the `openshift-migration` namespace was hard-coded for the API request to add providers. This caused a 400 error when submitting the add provider form.

This PR fixes it by using the same `META.namespace` value we use in all other API requests so that it can be configured per deployment.