### PR TITLE
[Backport] Correctly use namespace from meta.json instead of hard-coded 'openshift-migration' when adding providers (#414)

### DIFF
--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -144,7 +144,7 @@ export const convertFormValuesToProvider = (
     kind: 'Provider',
     metadata: {
       name,
-      namespace: 'openshift-migration',
+      namespace: META.namespace,
     },
     spec: {
       type: values.providerType,


### PR DESCRIPTION
Backports #414