### PR TITLE
Add filter by Analysis condition text in Select VMs step of plan wizard

### DIFF
--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -93,6 +93,19 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
       },
     },
     {
+      key: 'analysisCondition',
+      title: 'Analysis condition',
+      type: FilterType.search,
+      placeholderText: 'Filter by analysis condition...',
+      getItemValue: (item) => {
+        // Mash all the concerns together to match against them as a continuous string
+        const concernStrings = item.concerns.map(
+          (concern) => `${concern.category} - ${concern.label} - ${concern.assessment}`
+        );
+        return concernStrings.join(' ; ');
+      },
+    },
+    {
       key: 'dataCenter',
       title: 'Datacenter',
       type: FilterType.search,

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -194,7 +194,8 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
         toggleVMExpanded(firstMatchingVM);
       }
     }
-  }, [filterValues.analysisCondition, isVMExpanded, sortedItems, toggleVMExpanded]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterValues.analysisCondition]);
 
   const columns: ICell[] = [
     {

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -29,6 +29,7 @@ import {
   getMostSevereVMConcern,
   getVMConcernStatusLabel,
   getVMTreePathInfoByVM,
+  vmMatchesConcernFilter,
 } from './helpers';
 import { useVMwareTreeQuery, useVMwareVMsQuery } from '@app/queries';
 import TableEmptyState from '@app/common/components/TableEmptyState';
@@ -178,12 +179,22 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   });
 
   const {
-    toggleItemSelected: toggleVMsExpanded,
+    toggleItemSelected: toggleVMExpanded,
     isItemSelected: isVMExpanded,
   } = useSelectionState<IVMwareVM>({
     items: sortedItems,
     isEqual: (a, b) => a.selfLink === b.selfLink,
   });
+
+  React.useEffect(() => {
+    if (filterValues.analysisCondition) {
+      const filterText = filterValues.analysisCondition[0];
+      const firstMatchingVM = sortedItems.find((vm) => vmMatchesConcernFilter(vm, filterText));
+      if (firstMatchingVM && !isVMExpanded(firstMatchingVM)) {
+        toggleVMExpanded(firstMatchingVM);
+      }
+    }
+  }, [filterValues.analysisCondition, isVMExpanded, sortedItems, toggleVMExpanded]);
 
   const columns: ICell[] = [
     {
@@ -289,7 +300,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
                 }
               }}
               onCollapse={(_event, _rowKey, _isOpen, rowData) => {
-                toggleVMsExpanded(rowData.meta.vm);
+                toggleVMExpanded(rowData.meta.vm);
               }}
             >
               <TableHeader />

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -100,7 +100,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
       getItemValue: (item) => {
         // Mash all the concerns together to match against them as a continuous string
         const concernStrings = item.concerns.map(
-          (concern) => `${concern.category} - ${concern.label} - ${concern.assessment}`
+          (concern) => `${concern.category} - ${concern.label}: ${concern.assessment}`
         );
         return concernStrings.join(' ; ');
       },
@@ -151,6 +151,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
     availableVMs,
     filterCategories
   );
+
   const getSortValues = (vm: IVMwareVM) => {
     const { datacenter, cluster, host, folderPathStr } = treePathInfoByVM[vm.selfLink];
     return [
@@ -221,7 +222,17 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
         parent: rows.length - 1,
         fullWidth: true,
         cells: [
-          { title: <VMConcernsDescription vm={vm} />, props: { colSpan: columns.length + 2 } },
+          {
+            title: (
+              <VMConcernsDescription
+                vm={vm}
+                filterText={
+                  (filterValues.analysisCondition && filterValues.analysisCondition[0]) || ''
+                }
+              />
+            ),
+            props: { colSpan: columns.length + 2 },
+          },
         ],
       });
     }

--- a/src/app/Plans/components/Wizard/VMConcernsDescription.css
+++ b/src/app/Plans/components/Wizard/VMConcernsDescription.css
@@ -1,0 +1,3 @@
+.matches-analysis-filter {
+  background-color: var(--pf-global--palette--gold-100);
+}

--- a/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
@@ -5,13 +5,16 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PRODUCT_DOCO_LINK } from '@app/common/constants';
 import { IVMwareVM } from '@app/queries/types';
 import { getMostSevereVMConcern, getVMConcernStatusType } from './helpers';
+import './VMConcernsDescription.css';
 
 interface IVMConcernsDescriptionProps {
   vm: IVMwareVM;
+  filterText?: string;
 }
 
 const VMConcernsDescription: React.FunctionComponent<IVMConcernsDescriptionProps> = ({
   vm,
+  filterText,
 }: IVMConcernsDescriptionProps) => {
   const worstConcern = getMostSevereVMConcern(vm);
   const conditionsText = !worstConcern ? (
@@ -39,22 +42,30 @@ const VMConcernsDescription: React.FunctionComponent<IVMConcernsDescriptionProps
         <Text component="p">{conditionsText}</Text>
         {vm.concerns && vm.concerns.length > 0 ? (
           <List style={{ listStyle: 'none' }}>
-            {vm.concerns.map((concern, index) => (
-              <ListItem key={`${index}-${concern.label}`}>
-                <Flex
-                  spaceItems={{ default: 'spaceItemsSm' }}
-                  alignItems={{ default: 'alignItemsFlexStart' }}
-                  flexWrap={{ default: 'nowrap' }}
-                >
-                  <FlexItem>
-                    <StatusIcon status={getVMConcernStatusType(concern) || StatusType.Warning} />
-                  </FlexItem>
-                  <FlexItem>
-                    <strong>{concern.label}:</strong> {concern.assessment}
-                  </FlexItem>
-                </Flex>
-              </ListItem>
-            ))}
+            {vm.concerns.map((concern, index) => {
+              const matchesFilter =
+                filterText &&
+                `${concern.label}: ${concern.assessment}`
+                  .toLowerCase()
+                  .indexOf(filterText.toLowerCase()) !== -1;
+              return (
+                <ListItem key={`${index}-${concern.label}`}>
+                  <Flex
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                    alignItems={{ default: 'alignItemsFlexStart' }}
+                    flexWrap={{ default: 'nowrap' }}
+                    className={matchesFilter ? 'matches-analysis-filter' : ''}
+                  >
+                    <FlexItem>
+                      <StatusIcon status={getVMConcernStatusType(concern) || StatusType.Warning} />
+                    </FlexItem>
+                    <FlexItem>
+                      <strong>{concern.label}:</strong> {concern.assessment}
+                    </FlexItem>
+                  </Flex>
+                </ListItem>
+              );
+            })}
           </List>
         ) : null}
         <Text component="p">

--- a/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
@@ -4,7 +4,7 @@ import { TextContent, Text, List, ListItem, Flex, FlexItem } from '@patternfly/r
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PRODUCT_DOCO_LINK } from '@app/common/constants';
 import { IVMwareVM } from '@app/queries/types';
-import { getMostSevereVMConcern, getVMConcernStatusType } from './helpers';
+import { concernMatchesFilter, getMostSevereVMConcern, getVMConcernStatusType } from './helpers';
 import './VMConcernsDescription.css';
 
 interface IVMConcernsDescriptionProps {
@@ -42,30 +42,25 @@ const VMConcernsDescription: React.FunctionComponent<IVMConcernsDescriptionProps
         <Text component="p">{conditionsText}</Text>
         {vm.concerns && vm.concerns.length > 0 ? (
           <List style={{ listStyle: 'none' }}>
-            {vm.concerns.map((concern, index) => {
-              const matchesFilter =
-                filterText &&
-                `${concern.label}: ${concern.assessment}`
-                  .toLowerCase()
-                  .indexOf(filterText.toLowerCase()) !== -1;
-              return (
-                <ListItem key={`${index}-${concern.label}`}>
-                  <Flex
-                    spaceItems={{ default: 'spaceItemsSm' }}
-                    alignItems={{ default: 'alignItemsFlexStart' }}
-                    flexWrap={{ default: 'nowrap' }}
-                    className={matchesFilter ? 'matches-analysis-filter' : ''}
-                  >
-                    <FlexItem>
-                      <StatusIcon status={getVMConcernStatusType(concern) || StatusType.Warning} />
-                    </FlexItem>
-                    <FlexItem>
-                      <strong>{concern.label}:</strong> {concern.assessment}
-                    </FlexItem>
-                  </Flex>
-                </ListItem>
-              );
-            })}
+            {vm.concerns.map((concern, index) => (
+              <ListItem key={`${index}-${concern.label}`}>
+                <Flex
+                  spaceItems={{ default: 'spaceItemsSm' }}
+                  alignItems={{ default: 'alignItemsFlexStart' }}
+                  flexWrap={{ default: 'nowrap' }}
+                  className={
+                    concernMatchesFilter(concern, filterText) ? 'matches-analysis-filter' : ''
+                  }
+                >
+                  <FlexItem>
+                    <StatusIcon status={getVMConcernStatusType(concern) || StatusType.Warning} />
+                  </FlexItem>
+                  <FlexItem>
+                    <strong>{concern.label}:</strong> {concern.assessment}
+                  </FlexItem>
+                </Flex>
+              </ListItem>
+            ))}
           </List>
         ) : null}
         <Text component="p">

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -498,3 +498,10 @@ export const useEditingPlanPrefillEffect = (
     prefillErrorTitles: errorTitles,
   };
 };
+
+export const concernMatchesFilter = (concern: IVMwareVMConcern, filterText?: string): boolean =>
+  !!filterText &&
+  `${concern.label}: ${concern.assessment}`.toLowerCase().indexOf(filterText.toLowerCase()) !== -1;
+
+export const vmMatchesConcernFilter = (vm: IVMwareVM, filterText?: string): boolean =>
+  !!filterText && vm.concerns.some((concern) => concernMatchesFilter(concern, filterText));


### PR DESCRIPTION
A nice-to-have feature requested by @vconzola. When selecting VMs in the plan wizard, you can now search them by some string found in the text of their analysis conditions. When this filter is applied, the matching analysis conditions will be highlighted in the expanded rows. To make it clear that these highlights are present, the first matching VM row is automatically expanded when the filter is applied.

![Screen Shot 2021-02-16 at 11 28 50 AM](https://user-images.githubusercontent.com/811963/108093316-933c6900-704b-11eb-86b6-87e4fa36036f.png)
