### PR TITLE
Bug 1929050: Allow deleting a Host CR by selecting the Management Network option

### DIFF
--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -15,11 +15,24 @@ export const findSelectedNetworkAdapter = (
   hostConfig: IHostConfig | null
 ): IHostNetworkAdapter | null => {
   const managementNetwork =
-    host.networkAdapters.find((adapter) => adapter.name === 'Management Network') || null;
+    host.networkAdapters.find((adapter) => adapter.ipAddress === host.managementServerIp) || null;
   if (!hostConfig) return managementNetwork;
   return (
     host.networkAdapters.find((adapter) => adapter.ipAddress === hostConfig?.spec.ipAddress) ||
     managementNetwork
+  );
+};
+
+export const isManagementNetworkSelected = (
+  selectedHosts: IHost[],
+  selectedNetwork: IHostNetworkAdapter | null
+): boolean => {
+  const allHostsHaveSameManagementNetwork = selectedHosts.every(
+    (host) => host.managementServerIp === selectedHosts[0].managementServerIp
+  );
+  return (
+    allHostsHaveSameManagementNetwork &&
+    selectedNetwork?.ipAddress === selectedHosts[0].managementServerIp
   );
 };
 

--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -14,9 +14,12 @@ export const findSelectedNetworkAdapter = (
   host: IHost,
   hostConfig: IHostConfig | null
 ): IHostNetworkAdapter | null => {
-  if (!hostConfig) return null;
+  const managementNetwork =
+    host.networkAdapters.find((adapter) => adapter.name === 'Management Network') || null;
+  if (!hostConfig) return managementNetwork;
   return (
-    host.networkAdapters.find((adapter) => adapter.ipAddress === hostConfig?.spec.ipAddress) || null
+    host.networkAdapters.find((adapter) => adapter.ipAddress === hostConfig?.spec.ipAddress) ||
+    managementNetwork
   );
 };
 

--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -17,6 +17,7 @@ import { SelectNetworkFormValues } from '@app/Providers/components/VMwareProvide
 import { secretResource, ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
 import { CLUSTER_API_VERSION, META } from '@app/common/constants';
 import { getObjectRef } from '@app/common/helpers';
+import { isManagementNetworkSelected } from '@app/Providers/components/VMwareProviderHostsTable/helpers';
 
 export const hostConfigResource = new ForkliftResource(ForkliftResourceKind.Host, META.namespace);
 
@@ -145,12 +146,16 @@ export const useConfigureHostsMutation = (
 
   const configureHosts = (values: SelectNetworkFormValues) => {
     const existingHostConfigs = getExistingHostConfigs(selectedHosts, allHostConfigs, provider);
+    const isMgmtSelected = isManagementNetworkSelected(
+      selectedHosts,
+      values.selectedNetworkAdapter
+    );
     return Promise.all(
       selectedHosts.map(async (host, index) => {
         const existingConfig = existingHostConfigs[index] || null;
         const existingSecret = existingConfig?.spec.secret || null;
 
-        if (values.selectedNetworkAdapter?.name === 'Management Network') {
+        if (isMgmtSelected) {
           if (existingConfig) {
             return client.delete<IHostConfig>(hostConfigResource, existingConfig.metadata.name);
           }

--- a/src/app/queries/mocks/hosts.mock.ts
+++ b/src/app/queries/mocks/hosts.mock.ts
@@ -14,6 +14,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     name: 'esx12.v2v.bos.redhat.com',
     selfLink: '/namespaces/openshift-migration/providers/vsphere/test/hosts/host-44',
     inMaintenance: false,
+    managementServerIp: '10.19.2.12',
     thumbprint: 'D3:47:18:B1:11:39:87:25:F4:52:B2:04:EC:85:88:FA:9D:78:73:11',
     cpuSockets: 2,
     cpuCores: 16,
@@ -165,10 +166,34 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       { kind: 'VM', id: 'vm-2849' },
     ],
     networkAdapters: [
-      { name: 'VM_Migration', ipAddress: '192.168.79.12', linkSpeed: 10000, mtu: 9000 },
-      { name: 'VMkernel', ipAddress: '172.31.2.12', linkSpeed: 10000, mtu: 1500 },
-      { name: 'vDS-1', ipAddress: '192.168.61.12', linkSpeed: 10000, mtu: 1500 },
-      { name: 'Management Network', ipAddress: '10.19.2.12', linkSpeed: 1000, mtu: 1500 },
+      {
+        name: 'VM_Migration',
+        ipAddress: '192.168.79.12',
+        linkSpeed: 10000,
+        mtu: 9000,
+        subnetMask: '0.0.0.0',
+      },
+      {
+        name: 'VMkernel',
+        ipAddress: '172.31.2.12',
+        linkSpeed: 10000,
+        mtu: 1500,
+        subnetMask: '0.0.0.0',
+      },
+      {
+        name: 'vDS-1',
+        ipAddress: '192.168.61.12',
+        linkSpeed: 10000,
+        mtu: 1500,
+        subnetMask: '0.0.0.0',
+      },
+      {
+        name: 'Management Network',
+        ipAddress: '10.19.2.12',
+        linkSpeed: 1000,
+        mtu: 1500,
+        subnetMask: '0.0.0.0',
+      },
     ],
   };
 

--- a/src/app/queries/types/hosts.types.ts
+++ b/src/app/queries/types/hosts.types.ts
@@ -3,6 +3,7 @@ import { ICR, INameNamespaceRef, IStatusCondition, IVMwareObjRef } from './commo
 export interface IHostNetworkAdapter {
   name: string;
   ipAddress: string;
+  subnetMask: string;
   linkSpeed: number;
   mtu: number;
 }
@@ -14,6 +15,7 @@ export interface IHost {
   name: string;
   selfLink: string;
   inMaintenance: boolean;
+  managementServerIp: string;
   thumbprint: string;
   cpuSockets: number;
   cpuCores: number;


### PR DESCRIPTION
Resolves #421 (https://bugzilla.redhat.com/show_bug.cgi?id=1929050)
Also resolves #292 (https://bugzilla.redhat.com/show_bug.cgi?id=1908034)

When selecting a migration network for VMware hosts, if the user chooses the management network (and the management network has the same IP for all selected hosts), the credential fields will be disabled (with a tooltip explaining they aren't needed) and upon submission the relevant Host CRs will be deleted, if any.

![Screen Shot 2021-02-16 at 2 55 39 PM](https://user-images.githubusercontent.com/811963/108115848-b45f8280-7068-11eb-8f79-e46a46b3ae2f.png)

Also, a host without a CR will now display "Management Network" with its correct bandwidth and MTU in the table instead of just "(default)".

![Screen Shot 2021-02-16 at 3 06 16 PM](https://user-images.githubusercontent.com/811963/108115861-b88ba000-7068-11eb-81d0-7bfbd61f53b9.png)
