### PR TITLE
Bug 1929731: Allow partial string matches when filtering target namespace

### DIFF
--- a/src/app/Plans/components/Wizard/GeneralForm.css
+++ b/src/app/Plans/components/Wizard/GeneralForm.css
@@ -1,3 +1,0 @@
-.highlight-match {
-  background-color: var(--pf-global--palette--gold-100);
-}

--- a/src/app/Plans/components/Wizard/GeneralForm.css
+++ b/src/app/Plans/components/Wizard/GeneralForm.css
@@ -1,0 +1,3 @@
+.highlight-match {
+  background-color: var(--pf-global--palette--gold-100);
+}

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -40,7 +40,20 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   const namespacesQuery = useNamespacesQuery(form.values.targetProvider);
 
   const [isNamespaceSelectOpen, setIsNamespaceSelectOpen] = React.useState(false);
-  const namespaceOptions = namespacesQuery.data?.map((namespace) => namespace.name) || [];
+
+  const getFilteredOptions = (searchText?: string) => {
+    const namespaceOptions = namespacesQuery.data?.map((namespace) => namespace.name) || [];
+    const filteredNamespaces = !searchText
+      ? namespaceOptions
+      : namespaceOptions.filter((option) => !!option.toLowerCase().match(searchText.toLowerCase()));
+    return [
+      <SelectGroup key="group" label="Select or type to create a namespace">
+        {filteredNamespaces.map((option) => (
+          <SelectOption key={option.toString()} value={option} />
+        ))}
+      </SelectGroup>,
+    ];
+  };
 
   return (
     <ResolvedQueries
@@ -100,6 +113,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
                 form.fields.targetNamespace.setValue(selection as string);
                 setIsNamespaceSelectOpen(false);
               }}
+              onFilter={(event) => getFilteredOptions(event.target.value)}
               selections={form.values.targetNamespace}
               variant="typeahead"
               isCreatable
@@ -108,13 +122,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
               aria-label="Target namespace"
               isDisabled={!form.values.targetProvider}
             >
-              {[
-                <SelectGroup key="group" label="Select or type to create a namespace">
-                  {namespaceOptions.map((option) => (
-                    <SelectOption key={option.toString()} value={option} />
-                  ))}
-                </SelectGroup>,
-              ]}
+              {getFilteredOptions()}
             </Select>
           </ResolvedQuery>
         </FormGroup>

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -23,7 +23,6 @@ import {
 import ProviderSelect from '@app/common/components/ProviderSelect';
 import { ProviderType } from '@app/common/constants';
 import { usePausedPollingEffect } from '@app/common/context';
-import './GeneralForm.css';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
@@ -49,27 +48,9 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
       : namespaceOptions.filter((option) => !!option.toLowerCase().match(searchText.toLowerCase()));
     return [
       <SelectGroup key="group" label="Select or type to create a namespace">
-        {filteredNamespaces.map((option) => {
-          let renderedOption: (string | React.ReactNode)[] = [option];
-          if (searchText) {
-            const fragments = option.split(searchText);
-            renderedOption = option.split(searchText).flatMap((fragment, index) =>
-              index === fragments.length - 1
-                ? [fragment]
-                : [
-                    fragment,
-                    <span className="highlight-match" key={index}>
-                      {searchText}
-                    </span>,
-                  ]
-            );
-          }
-          return (
-            <SelectOption key={option} value={option}>
-              {renderedOption}
-            </SelectOption>
-          );
-        })}
+        {filteredNamespaces.map((option) => (
+          <SelectOption key={option.toString()} value={option} />
+        ))}
       </SelectGroup>,
     ];
   };

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -23,6 +23,7 @@ import {
 import ProviderSelect from '@app/common/components/ProviderSelect';
 import { ProviderType } from '@app/common/constants';
 import { usePausedPollingEffect } from '@app/common/context';
+import './GeneralForm.css';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
@@ -48,9 +49,27 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
       : namespaceOptions.filter((option) => !!option.toLowerCase().match(searchText.toLowerCase()));
     return [
       <SelectGroup key="group" label="Select or type to create a namespace">
-        {filteredNamespaces.map((option) => (
-          <SelectOption key={option.toString()} value={option} />
-        ))}
+        {filteredNamespaces.map((option) => {
+          let renderedOption: (string | React.ReactNode)[] = [option];
+          if (searchText) {
+            const fragments = option.split(searchText);
+            renderedOption = option.split(searchText).flatMap((fragment, index) =>
+              index === fragments.length - 1
+                ? [fragment]
+                : [
+                    fragment,
+                    <span className="highlight-match" key={index}>
+                      {searchText}
+                    </span>,
+                  ]
+            );
+          }
+          return (
+            <SelectOption key={option} value={option}>
+              {renderedOption}
+            </SelectOption>
+          );
+        })}
       </SelectGroup>,
     ];
   };


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1929731

When selecting a target namespace in the plan wizard, partial matches are now supported in the filter.
