### PR TITLE
If a pipeline step is missing a completed time and the VM has one, default to the VM completed time

### DIFF
--- a/src/app/Plans/components/VMStatusTable.tsx
+++ b/src/app/Plans/components/VMStatusTable.tsx
@@ -63,10 +63,7 @@ const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
         },
         {
           title: (
-            <TickingElapsedTime
-              start={step.started}
-              end={step.completed || (status.error ? status.completed : undefined)}
-            />
+            <TickingElapsedTime start={step.started} end={step.completed || status.completed} />
           ),
         },
         {

--- a/src/app/common/components/TickingElapsedTime.tsx
+++ b/src/app/common/components/TickingElapsedTime.tsx
@@ -30,6 +30,8 @@ const TickingElapsedTime: React.FunctionComponent<ITickingElapsedTimeProps> = ({
     return stopTicking;
   }, [end]);
 
+  if (!start) return null;
+
   return <>{formatDuration(start, endTime)}</>;
 };
 


### PR DESCRIPTION
Minor fix that should have been in https://github.com/konveyor/forklift-ui/pull/400. Sorry @fdupont-redhat !