### PR TITLE
Fix incorrect status display when the first pipeline step has not started yet

### DIFF
--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -182,16 +182,10 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
       buttonType = null;
       title = PlanStatusDisplayType.Executing;
     } else if (hasCondition(conditions, PlanStatusType.Succeeded)) {
-      const allVMsCanceled =
-        plan.status?.migration?.vms?.every(
-          (vm) => !!vm.conditions?.find((condition) => condition.type === 'Canceled')
-        ) || false;
-      if (allVMsCanceled) {
-        title = PlanStatusDisplayType.Canceled;
-      } else {
-        title = PlanStatusDisplayType.Succeeded;
-        variant = ProgressVariant.success;
-      }
+      title = PlanStatusDisplayType.Succeeded;
+      variant = ProgressVariant.success;
+    } else if (hasCondition(conditions, PlanStatusType.Canceled)) {
+      title = PlanStatusDisplayType.Canceled;
     } else if (hasCondition(conditions, PlanStatusType.Failed)) {
       buttonType = ActionButtonType.Restart;
       title = PlanStatusDisplayType.Failed;

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -35,6 +35,7 @@ export enum PlanStatusType {
   Executing = 'Executing',
   Succeeded = 'Succeeded',
   Failed = 'Failed',
+  Canceled = 'Canceled',
 }
 
 export enum PlanStatusDisplayType {

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -57,11 +57,16 @@ export const findCurrentStep = (
   pipeline: IStep[]
 ): { currentStep: IStep | undefined; currentStepIndex: number } => {
   if (pipeline.length === 0) return { currentStep: undefined, currentStepIndex: 0 };
-  const currentStep =
-    pipeline
-      .slice(0)
-      .reverse()
-      .find((step) => !!step.error || !!step.started) || pipeline[pipeline.length - 1];
+  let currentStep: IStep;
+  if (!pipeline[0].started) {
+    currentStep = pipeline[0];
+  } else {
+    currentStep =
+      pipeline
+        .slice(0)
+        .reverse()
+        .find((step) => !!step.error || !!step.started) || pipeline[pipeline.length - 1];
+  }
   const currentStepIndex = currentStep ? pipeline.indexOf(currentStep) : 0;
   return { currentStep, currentStepIndex };
 };


### PR DESCRIPTION
Also fixes a corner case with the plan-level status display when all VMs in a plan are canceled.

Sorry again @fdupont-redhat ... trying to move on from the cancel feature and left a few things out in the rush :)