### PR TITLE
Add support for warm migration (selection in wizard, status info on plans table and migration details table, cutover action)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13555,9 +13555,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tsutils": {
       "version": "3.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1181,9 +1181,9 @@
       }
     },
     "@konveyor/lib-ui": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-1.11.0.tgz",
-      "integrity": "sha512-RLL1RvsGL5tnoSY9/3n6qDbAmaz21/T+MHnaqWsg49U39rxVcPdxjxhuDTiN4AaMFY6IZgluHlr62Z5TQMKQfA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-2.1.0.tgz",
+      "integrity": "sha512-fXwtGaTm34ywHiLxmJfHPI4kK1x44lKplytVRyxaaxkwnRngKUL02jDMzIpnMB35E0PDHSysRfdBYyB0RPBMWA==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "yup": "^0.29.3"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ts-jest": "^26.4.4",
     "ts-loader": "^7.0.5",
     "tsconfig-paths-webpack-plugin": "^3.3.0",
-    "tslib": "^2.0.0",
+    "tslib": "^2.1.0",
     "typescript": "^3.9.3",
     "url-loader": "^4.1.0",
     "webpack": "^5.17.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "webpack-merge": "^5.7.3"
   },
   "dependencies": {
-    "@konveyor/lib-ui": "^1.11.0",
+    "@konveyor/lib-ui": "^2.1.0",
     "@patternfly/react-core": "^4.79.2",
     "@patternfly/react-icons": "^4.7.18",
     "@patternfly/react-styles": "^4.7.16",

--- a/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
 import {
   IAnnotatedStorageClass,
@@ -92,7 +92,7 @@ const MappingTargetSelect: React.FunctionComponent<IMappingTargetSelectProps> = 
             <div>
               {hasNoProvisionerWarning ? (
                 <>
-                  <StatusIcon status={StatusType.Warning} className={spacing.mrSm} />
+                  <StatusIcon status="Warning" className={spacing.mrSm} />
                   <TruncatedText className="inline-option-text">{name}</TruncatedText>
                 </>
               ) : (

--- a/src/app/Mappings/components/MappingStatus.tsx
+++ b/src/app/Mappings/components/MappingStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { useResourceQueriesForMapping } from '@app/queries';
 import { MappingType, Mapping } from '@app/queries/types';
@@ -22,12 +22,7 @@ const MappingStatus: React.FunctionComponent<IMappingStatusProps> = ({
     mapping
   );
   const isValid = isMappingValid(mappingType, mapping, availableSources, availableTargets);
-  const icon = (
-    <StatusIcon
-      status={isValid ? StatusType.Ok : StatusType.Error}
-      label={isValid ? 'OK' : 'Invalid'}
-    />
-  );
+  const icon = <StatusIcon status={isValid ? 'Ok' : 'Error'} label={isValid ? 'OK' : 'Invalid'} />;
   return (
     <ResolvedQueries
       results={queries}

--- a/src/app/Plans/components/PlansTable.css
+++ b/src/app/Plans/components/PlansTable.css
@@ -13,3 +13,16 @@
 .pf-c-table.plans-table tbody > tr > td.pf-c-table__toggle .pf-c-button {
   margin-top: 0;
 }
+
+.pf-c-table.plans-table table.expanded-content tr {
+  border-bottom: 0;
+}
+
+.pf-c-table.plans-table table.expanded-content tr:not(:first-child) > * {
+  padding-top: var(--pf-global--spacer--xs);
+}
+
+.pf-c-table.plans-table table.expanded-content tr > th {
+  padding-left: 0;
+  font-weight: bold;
+}

--- a/src/app/Plans/components/PlansTable.css
+++ b/src/app/Plans/components/PlansTable.css
@@ -14,15 +14,11 @@
   margin-top: 0;
 }
 
-.pf-c-table.plans-table table.expanded-content tr {
-  border-bottom: 0;
-}
-
-.pf-c-table.plans-table table.expanded-content tr:not(:first-child) > * {
-  padding-top: var(--pf-global--spacer--xs);
-}
-
 .pf-c-table.plans-table table.expanded-content tr > th {
   padding-left: 0;
   font-weight: bold;
+}
+
+.pf-c-table.plans-table table.expanded-content tr > td {
+  padding-left: var(--pf-global--spacer--xl);
 }

--- a/src/app/Plans/components/PlansTable.css
+++ b/src/app/Plans/components/PlansTable.css
@@ -5,3 +5,11 @@
 .pf-c-table.plans-table tbody > tr > * {
   vertical-align: middle;
 }
+
+.pf-c-table.plans-table tbody > tr > td.pf-c-table__toggle {
+  padding-bottom: var(--pf-c-table--tbody--cell--PaddingBottom);
+}
+
+.pf-c-table.plans-table tbody > tr > td.pf-c-table__toggle .pf-c-button {
+  margin-top: 0;
+}

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -23,6 +23,11 @@ import {
   expandable,
   classNames,
   cellWidth,
+  TableComposable,
+  Tbody,
+  Td,
+  Th,
+  Tr,
 } from '@patternfly/react-table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignment';
@@ -309,22 +314,27 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
         cells: [
           {
             title: (
-              <table className="expanded-content">
-                <tbody>
-                  <tr>
-                    <th>Source provider</th>
-                    <td>{sourceProvider?.name || ''}</td>
-                  </tr>
-                  <tr>
-                    <th>Target provider</th>
-                    <td>{targetProvider?.name || ''}</td>
-                  </tr>
-                  <tr>
-                    <th>VMs</th>
-                    <td>{plan.spec.vms.length}</td>
-                  </tr>
-                </tbody>
-              </table>
+              <TableComposable
+                aria-label={`Expanded details of plan ${plan.metadata.name}`}
+                variant="compact"
+                borders={false}
+                className="expanded-content"
+              >
+                <Tbody>
+                  <Tr>
+                    <Th modifier="fitContent">Source provider</Th>
+                    <Td>{sourceProvider?.name || ''}</Td>
+                  </Tr>
+                  <Tr>
+                    <Th modifier="fitContent">Target provider</Th>
+                    <Td>{targetProvider?.name || ''}</Td>
+                  </Tr>
+                  <Tr>
+                    <Th modifier="fitContent">VMs</Th>
+                    <Td>{plan.spec.vms.length}</Td>
+                  </Tr>
+                </Tbody>
+              </TableComposable>
             ),
           },
         ],

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -245,8 +245,6 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
       !!latestMigration &&
       ((plan.status?.migration?.vms?.length || 0) === 0 || warmState === 'Starting');
 
-    console.log(plan.metadata.name, warmState);
-
     rows.push({
       meta: { plan },
       isOpen: isExpanded,

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -242,6 +242,8 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
 
     const warmState = getWarmPlanState(plan, latestMigration);
 
+    console.log(plan.metadata.name, warmState);
+
     rows.push({
       meta: { plan },
       isOpen: isExpanded,

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -261,25 +261,24 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
         },
         plan.spec.warm ? 'Warm' : 'Cold',
         {
-          title:
-            isPending || warmState === 'Starting' ? (
-              <StatusIcon status={StatusType.Loading} label={PlanStatusDisplayType.Pending} />
-            ) : !plan.status?.migration?.started || warmState === 'NotStarted' ? (
-              <StatusCondition status={plan.status} />
-            ) : warmState === 'Copying' ? (
-              'Running - performing incremental data copies'
-            ) : warmState === 'StartingCutover' ? (
-              'Running - preparing for cutover'
-            ) : (
-              <Progress
-                title={title}
-                value={statusValue}
-                label={statusMessage}
-                valueText={statusMessage}
-                variant={variant}
-                measureLocation={ProgressMeasureLocation.top}
-              />
-            ),
+          title: isPending ? (
+            <StatusIcon status={StatusType.Loading} label={PlanStatusDisplayType.Pending} />
+          ) : !plan.status?.migration?.started || warmState === 'NotStarted' ? (
+            <StatusCondition status={plan.status} />
+          ) : warmState === 'Starting' || warmState === 'Copying' ? (
+            'Running - performing incremental data copies'
+          ) : warmState === 'StartingCutover' ? (
+            'Running - preparing for cutover'
+          ) : (
+            <Progress
+              title={title}
+              value={statusValue}
+              label={statusMessage}
+              valueText={statusMessage}
+              variant={variant}
+              measureLocation={ProgressMeasureLocation.top}
+            />
+          ),
         },
         {
           title: buttonType ? (

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -257,6 +257,8 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
           ) : !plan.status?.migration?.started ? (
             <StatusCondition status={plan.status} />
           ) : (
+            //) : isWarmAndNotInCutover ? (
+            //  <div>TODO</div>
             <Progress
               title={title}
               value={statusValue}

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -32,7 +32,7 @@ import {
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignment';
 import { Link } from 'react-router-dom';
-import { StatusIcon, StatusType, useSelectionState } from '@konveyor/lib-ui';
+import { useSelectionState } from '@konveyor/lib-ui';
 
 import PlanActionsDropdown from './PlanActionsDropdown';
 import { useSortState, usePaginationState } from '@app/common/hooks';

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -72,6 +72,19 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
       },
     },
     {
+      key: 'type',
+      title: 'Type',
+      type: FilterType.select,
+      placeholderText: 'Filter by type...',
+      selectOptions: [
+        { key: 'Cold', value: 'Cold' },
+        { key: 'Warm', value: 'Warm' },
+      ],
+      getItemValue: (item) => {
+        return item.spec.warm ? 'Warm' : 'Cold';
+      },
+    },
+    {
       key: 'sourceProvider',
       title: 'Source provider',
       type: FilterType.search,
@@ -121,6 +134,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     );
     return [
       plan.metadata.name,
+      plan.spec.warm,
       sourceProvider?.name || '',
       targetProvider?.name || '',
       plan.spec.vms.length,
@@ -150,6 +164,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
 
   const columns: ICell[] = [
     { title: 'Name', transforms: [sortable, wrappable] },
+    { title: 'Type', transforms: [sortable] },
     { title: 'Source provider', transforms: [sortable, wrappable] },
     { title: 'Target provider', transforms: [sortable, wrappable] },
     { title: 'VMs', transforms: [sortable] },
@@ -216,6 +231,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
             </>
           ),
         },
+        plan.spec.warm ? 'Warm' : 'Cold',
         sourceProvider?.name || '',
         targetProvider?.name || '',
         plan.spec.vms.length,

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -238,11 +238,12 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
 
     const isExpanded = isPlanExpanded(plan);
 
+    const warmState = getWarmPlanState(plan, latestMigration);
     // TODO this is redundant with getWarmPlanState's 'Starting' case, maybe generalize that helper.
     // TODO what's the difference between isBeingStarted and isPending?
-    const isBeingStarted = !!latestMigration && (plan.status?.migration?.vms?.length || 0) === 0;
-
-    const warmState = getWarmPlanState(plan, latestMigration);
+    const isBeingStarted =
+      !!latestMigration &&
+      ((plan.status?.migration?.vms?.length || 0) === 0 || warmState === 'Starting');
 
     console.log(plan.metadata.name, warmState);
 
@@ -292,9 +293,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
                 flexWrap={{ default: 'nowrap' }}
               >
                 <FlexItem align={{ default: 'alignRight' }}>
-                  {createMigrationResult.isLoading ||
-                  isBeingStarted ||
-                  setCutoverResult.isLoading ? (
+                  {isBeingStarted ? (
                     <Spinner size="md" className={spacing.mxLg} />
                   ) : (
                     <Button
@@ -306,7 +305,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
                           setCutover({ plan, cutover: new Date().toISOString() });
                         }
                       }}
-                      isDisabled={createMigrationResult.isLoading}
+                      isDisabled={createMigrationResult.isLoading || setCutoverResult.isLoading}
                     >
                       {buttonType}
                     </Button>

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -310,18 +310,20 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
           {
             title: (
               <table className="expanded-content">
-                <tr>
-                  <th>Source provider</th>
-                  <td>{sourceProvider?.name || ''}</td>
-                </tr>
-                <tr>
-                  <th>Target provider</th>
-                  <td>{targetProvider?.name || ''}</td>
-                </tr>
-                <tr>
-                  <th>VMs</th>
-                  <td>{plan.spec.vms.length}</td>
-                </tr>
+                <tbody>
+                  <tr>
+                    <th>Source provider</th>
+                    <td>{sourceProvider?.name || ''}</td>
+                  </tr>
+                  <tr>
+                    <th>Target provider</th>
+                    <td>{targetProvider?.name || ''}</td>
+                  </tr>
+                  <tr>
+                    <th>VMs</th>
+                    <td>{plan.spec.vms.length}</td>
+                  </tr>
+                </tbody>
               </table>
             ),
           },

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -128,21 +128,13 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
   ];
 
   const { filterValues, setFilterValues, filteredItems } = useFilterState(plans, filterCategories);
-  const getSortValues = (plan: IPlan) => {
-    const { sourceProvider, targetProvider } = findProvidersByRefs(
-      plan.spec.provider,
-      providersQuery
-    );
-    return [
-      plan.metadata.name,
-      plan.spec.warm,
-      sourceProvider?.name || '',
-      targetProvider?.name || '',
-      plan.spec.vms.length,
-      getPlanStatusTitle(plan),
-      '', // Action column
-    ];
-  };
+  const getSortValues = (plan: IPlan) => [
+    '', // Expand/collapse column
+    plan.metadata.name,
+    plan.spec.warm,
+    getPlanStatusTitle(plan),
+    '', // Action column
+  ];
 
   const { sortBy, onSort, sortedItems } = useSortState(filteredItems, getSortValues);
   const { currentPageItems, setPageNumber, paginationProps } = usePaginationState(sortedItems, 10);
@@ -174,9 +166,6 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
   const columns: ICell[] = [
     { title: 'Name', transforms: [sortable, wrappable], cellFormatters: [expandable] },
     { title: 'Type', transforms: [sortable] },
-    { title: 'Source provider', transforms: [sortable, wrappable] },
-    { title: 'Target provider', transforms: [sortable, wrappable] },
-    { title: 'VMs', transforms: [sortable] },
     { title: 'Plan status', transforms: [sortable, cellWidth(30)] },
     {
       title: '',
@@ -244,9 +233,6 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
           ),
         },
         plan.spec.warm ? 'Warm' : 'Cold',
-        sourceProvider?.name || '',
-        targetProvider?.name || '',
-        plan.spec.vms.length,
         {
           title: isPending ? (
             <StatusIcon status={StatusType.Loading} label={PlanStatusDisplayType.Pending} />
@@ -301,14 +287,24 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     if (isExpanded) {
       rows.push({
         parent: rows.length - 1,
-        fullWidth: true,
         cells: [
           {
-            title: <h1>TODO</h1>,
-            props: {
-              colSpan: columns.length + 1,
-              // className: tableStyles.modifiers.noPadding,
-            },
+            title: (
+              <table className="expanded-content">
+                <tr>
+                  <th>Source provider</th>
+                  <td>{sourceProvider?.name || ''}</td>
+                </tr>
+                <tr>
+                  <th>Target provider</th>
+                  <td>{targetProvider?.name || ''}</td>
+                </tr>
+                <tr>
+                  <th>VMs</th>
+                  <td>{plan.spec.vms.length}</td>
+                </tr>
+              </table>
+            ),
           },
         ],
       });

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -262,10 +262,12 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
         plan.spec.warm ? 'Warm' : 'Cold',
         {
           title: isPending ? (
-            <StatusIcon status={StatusType.Loading} label={PlanStatusDisplayType.Pending} />
+            'Running - preparing for migration'
+          ) : warmState === 'Starting' ? (
+            'Running - preparing for incremental data copies'
           ) : !plan.status?.migration?.started || warmState === 'NotStarted' ? (
             <StatusCondition status={plan.status} />
-          ) : warmState === 'Starting' || warmState === 'Copying' ? (
+          ) : warmState === 'Copying' ? (
             'Running - performing incremental data copies'
           ) : warmState === 'StartingCutover' ? (
             'Running - preparing for cutover'

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -215,7 +215,6 @@ const VMMigrationDetails: React.FunctionComponent = () => {
   const cancelableVMs = !hasCondition(plan?.status?.conditions || [], PlanStatusType.Executing)
     ? []
     : (vmStatuses as IVMStatus[]).filter((vm) => !vm.completed && !isVMCanceled(vm));
-  /// TODO one of the precopy VMs is showing as not cancelable?
   const selectAllCancelable = (isSelected: boolean) =>
     isSelected ? setSelectedItems(cancelableVMs) : setSelectedItems([]);
 

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -215,6 +215,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
   const cancelableVMs = !hasCondition(plan?.status?.conditions || [], PlanStatusType.Executing)
     ? []
     : (vmStatuses as IVMStatus[]).filter((vm) => !vm.completed && !isVMCanceled(vm));
+  /// TODO one of the precopy VMs is showing as not cancelable?
   const selectAllCancelable = (isSelected: boolean) =>
     isSelected ? setSelectedItems(cancelableVMs) : setSelectedItems([]);
 

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -99,14 +99,17 @@ const VMMigrationDetails: React.FunctionComponent = () => {
 
   const latestMigration = useLatestMigrationQuery(plan || null);
   const warmPlanState = getWarmPlanState(plan || null, latestMigration);
-  const isWarmCopying =
-    !!plan?.spec.warm && (warmPlanState === 'Starting' || warmPlanState === 'Copying');
+  const isShowingPrecopyView =
+    !!plan?.spec.warm &&
+    (warmPlanState === 'Starting' ||
+      warmPlanState === 'Copying' ||
+      warmPlanState === 'AbortedCopying');
 
   const getSortValues = (vmStatus: IVMStatus) => {
     return [
       '', // Expand/collapse control column
       findVMById(vmStatus.id, vmsQuery)?.name || '',
-      ...(!isWarmCopying
+      ...(!isShowingPrecopyView
         ? [
             vmStatus.started || '',
             vmStatus.completed || '',
@@ -130,7 +133,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
         return findVMById(item.id, vmsQuery)?.name || '';
       },
     },
-    ...(!isWarmCopying
+    ...(!isShowingPrecopyView
       ? [
           {
             key: 'begin',
@@ -220,7 +223,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
       transforms: [sortable, wrappable],
       cellFormatters: planStarted ? [expandable] : [],
     },
-    ...(!isWarmCopying
+    ...(!isShowingPrecopyView
       ? [
           { title: 'Start time', transforms: [sortable], cellTransforms: [truncate] },
           { title: 'End time', transforms: [sortable], cellTransforms: [truncate] },
@@ -255,7 +258,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
       isOpen: planStarted ? isExpanded : undefined,
       cells: [
         findVMById(vmStatus.id, vmsQuery)?.name || '',
-        ...(!isWarmCopying
+        ...(!isShowingPrecopyView
           ? [
               formatTimestamp(vmStatus.started),
               formatTimestamp(vmStatus.completed),
@@ -276,7 +279,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
         fullWidth: true,
         cells: [
           {
-            title: !isWarmCopying ? (
+            title: !isShowingPrecopyView ? (
               <VMStatusPipelineTable status={vmStatus} isCanceled={isCanceled} />
             ) : (
               <VMStatusPrecopyTable status={vmStatus} isCanceled={isCanceled} />

--- a/src/app/Plans/components/VMStatusPipelineTable.tsx
+++ b/src/app/Plans/components/VMStatusPipelineTable.tsx
@@ -15,15 +15,15 @@ import { IVMStatus, IStep } from '@app/queries/types';
 import TickingElapsedTime from '@app/common/components/TickingElapsedTime';
 import { findCurrentStep, getStepType, isStepOnError } from '@app/common/helpers';
 
-interface IVMStatusTableProps {
+interface IVMStatusPipelineTableProps {
   status: IVMStatus;
   isCanceled: boolean;
 }
 
-const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
+const VMStatusPipelineTable: React.FunctionComponent<IVMStatusPipelineTableProps> = ({
   status,
   isCanceled,
-}: IVMStatusTableProps) => {
+}: IVMStatusPipelineTableProps) => {
   const columns: ICell[] = [
     {
       title: 'Step',
@@ -97,4 +97,4 @@ const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
   );
 };
 
-export default VMStatusTable;
+export default VMStatusPipelineTable;

--- a/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { Text, TextContent } from '@patternfly/react-core';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  ICell,
+  IRow,
+  textCenter,
+  fitContent,
+} from '@patternfly/react-table';
+
+import { IVMStatus } from '@app/queries/types';
+import TickingElapsedTime from '@app/common/components/TickingElapsedTime';
+import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+
+interface IVMStatusPrecopyTableProps {
+  status: IVMStatus;
+  isCanceled: boolean;
+}
+
+const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> = ({
+  status,
+  isCanceled,
+}: IVMStatusPrecopyTableProps) => {
+  if (!status.warm || status.warm.precopies.length === 0) {
+    return (
+      <TextContent>
+        <Text component="p">Preparing to start incremental copies</Text>
+      </TextContent>
+    );
+  }
+
+  const sortedPrecopies = status.warm.precopies.sort((a, b) => {
+    // Most recent first
+    if (a.start < b.start) return 1;
+    if (a.start > b.start) return -1;
+    return 0;
+  });
+
+  const columns: ICell[] = [
+    {
+      title: 'Copy number',
+      columnTransforms: [textCenter, fitContent],
+    },
+    { title: 'Elapsed time' },
+    { title: 'Status' },
+  ];
+
+  const rows: IRow[] = sortedPrecopies.map((precopy, index) => {
+    return {
+      meta: { precopy },
+      cells: [
+        sortedPrecopies.length - index,
+        {
+          title: <TickingElapsedTime start={precopy.start} end={precopy.end || status.completed} />,
+        },
+        {
+          title:
+            status.error && index === 0 ? (
+              <StatusIcon status={StatusType.Error} label="Failed" />
+            ) : isCanceled ? (
+              <StatusIcon status={StatusType.Info} label="Canceled" />
+            ) : !precopy.end ? (
+              <StatusIcon status={StatusType.Loading} label="Copying data" />
+            ) : (
+              <StatusIcon status={StatusType.Ok} label="Complete" />
+            ),
+        },
+      ],
+    };
+  });
+
+  return (
+    <>
+      <Table
+        className="migration-inner-vmStatus-table"
+        variant="compact"
+        aria-label="VM status table for migration plan"
+        cells={columns}
+        rows={rows}
+      >
+        <TableHeader />
+        <TableBody />
+      </Table>
+    </>
+  );
+};
+
+export default VMStatusPrecopyTable;

--- a/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -56,16 +56,15 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
           title: <TickingElapsedTime start={precopy.start} end={precopy.end || status.completed} />,
         },
         {
-          title:
-            status.error && index === 0 ? (
-              <StatusIcon status={StatusType.Error} label="Failed" />
-            ) : isCanceled ? (
-              <StatusIcon status={StatusType.Info} label="Canceled" />
-            ) : !precopy.end ? (
-              <StatusIcon status={StatusType.Loading} label="Copying data" />
-            ) : (
-              <StatusIcon status={StatusType.Ok} label="Complete" />
-            ),
+          title: precopy.end ? (
+            <StatusIcon status={StatusType.Ok} label="Complete" />
+          ) : status.error && index === 0 ? (
+            <StatusIcon status={StatusType.Error} label="Failed" />
+          ) : isCanceled ? (
+            <StatusIcon status={StatusType.Info} label="Canceled" />
+          ) : (
+            <StatusIcon status={StatusType.Loading} label="Copying data" />
+          ),
         },
       ],
     };

--- a/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -48,6 +48,7 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
   ];
 
   const rows: IRow[] = sortedPrecopies.map((precopy, index) => {
+    const consecutiveFailures = (index === 0 && status.warm?.consecutiveFailures) || 0;
     return {
       meta: { precopy },
       cells: [
@@ -63,7 +64,12 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
           ) : isCanceled ? (
             <StatusIcon status="Info" label="Canceled" />
           ) : (
-            <StatusIcon status="Loading" label="Copying data" />
+            <StatusIcon
+              status="Loading"
+              label={`Copying data${
+                consecutiveFailures > 0 ? ` - Retrying after ${consecutiveFailures} failures` : ''
+              }`}
+            />
           ),
         },
       ],

--- a/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -12,7 +12,7 @@ import {
 
 import { IVMStatus } from '@app/queries/types';
 import TickingElapsedTime from '@app/common/components/TickingElapsedTime';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 
 interface IVMStatusPrecopyTableProps {
   status: IVMStatus;
@@ -57,13 +57,13 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
         },
         {
           title: precopy.end ? (
-            <StatusIcon status={StatusType.Ok} label="Complete" />
+            <StatusIcon status="Ok" label="Complete" />
           ) : status.error && index === 0 ? (
-            <StatusIcon status={StatusType.Error} label="Failed" />
+            <StatusIcon status="Error" label="Failed" />
           ) : isCanceled ? (
-            <StatusIcon status={StatusType.Info} label="Canceled" />
+            <StatusIcon status="Info" label="Canceled" />
           ) : (
-            <StatusIcon status={StatusType.Loading} label="Copying data" />
+            <StatusIcon status="Loading" label="Copying data" />
           ),
         },
       ],

--- a/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { IVMStatus } from '@app/queries/types';
+import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { Button, Popover } from '@patternfly/react-core';
+
+interface IWarmVMCopyState {
+  state: 'Starting' | 'Copying' | 'Idle' | 'Failed' | 'Warning';
+  status: StatusType;
+  label: string;
+}
+
+export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
+  if (vmStatus.error) {
+    return {
+      state: 'Failed',
+      status: StatusType.Error,
+      label: 'Failed',
+    };
+  }
+  if (!vmStatus.warm || vmStatus.warm.precopies.length === 0) {
+    return {
+      state: 'Starting',
+      status: StatusType.Loading,
+      label: 'Preparing for incremental copies.',
+    };
+  }
+  const { precopies } = vmStatus.warm;
+  if (precopies.some((copy) => !!copy.start && !copy.end)) {
+    return {
+      state: 'Copying',
+      status: StatusType.Loading,
+      label: 'Performing incremental data copy.',
+    };
+  }
+  if (precopies.every((copy) => !!copy.start && !!copy.end)) {
+    return {
+      state: 'Idle',
+      status: StatusType.Info, // TODO add an Idle status type to lib-ui
+      label: `Idle - Next incremental copy will begin in X minutes.`, // TODO
+    };
+  }
+  return {
+    state: 'Warning',
+    status: StatusType.Warning,
+    label: 'Unknown',
+  };
+};
+
+interface IVMWarmCopyStatusProps {
+  vmStatus: IVMStatus;
+}
+
+const VMWarmCopyStatus: React.FunctionComponent<IVMWarmCopyStatusProps> = ({
+  vmStatus,
+}: IVMWarmCopyStatusProps) => {
+  if (vmStatus.error) {
+    return (
+      <Popover hasAutoWidth bodyContent={<>{vmStatus.error.reasons.join('; ')}</>}>
+        <Button variant="link" isInline>
+          <StatusIcon status={StatusType.Error} label="Failed" />
+        </Button>
+      </Popover>
+    );
+  }
+  const { status, label } = getWarmVMCopyState(vmStatus);
+  return <StatusIcon status={status} label={label} />;
+};
+
+export default VMWarmCopyStatus;

--- a/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -22,7 +22,7 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
     return {
       state: 'Starting',
       status: 'Loading',
-      label: 'Preparing for incremental copies.',
+      label: 'Preparing for incremental copies',
     };
   }
   const { precopies, nextPrecopyAt } = vmStatus.warm;
@@ -30,7 +30,7 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
     return {
       state: 'Copying',
       status: 'Loading',
-      label: 'Performing incremental data copy.',
+      label: 'Performing incremental data copy',
     };
   }
   if (precopies.every((copy) => !!copy.start && !!copy.end)) {
@@ -38,8 +38,8 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
       state: 'Idle',
       status: 'Paused',
       label: nextPrecopyAt
-        ? `Idle - Next incremental copy will begin in ${getMinutesUntil(nextPrecopyAt)}.`
-        : 'Idle - Waiting for next incremental copy.',
+        ? `Idle - Next incremental copy will begin in ${getMinutesUntil(nextPrecopyAt)}`
+        : 'Idle - Waiting for next incremental copy',
     };
   }
   return {

--- a/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { IVMStatus } from '@app/queries/types';
 import { StatusIcon, StatusType } from '@konveyor/lib-ui';
 import { Button, Popover } from '@patternfly/react-core';
+import { getMinutesUntil } from '@app/common/helpers';
 
 interface IWarmVMCopyState {
   state: 'Starting' | 'Copying' | 'Idle' | 'Failed' | 'Warning';
@@ -24,7 +25,7 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
       label: 'Preparing for incremental copies.',
     };
   }
-  const { precopies } = vmStatus.warm;
+  const { precopies, nextPrecopyAt } = vmStatus.warm;
   if (precopies.some((copy) => !!copy.start && !copy.end)) {
     return {
       state: 'Copying',
@@ -36,7 +37,9 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
     return {
       state: 'Idle',
       status: 'Paused',
-      label: `Idle - Next incremental copy will begin in X minutes.`, // TODO
+      label: nextPrecopyAt
+        ? `Idle - Next incremental copy will begin in ${getMinutesUntil(nextPrecopyAt)}.`
+        : 'Idle - Waiting for next incremental copy.',
     };
   }
   return {

--- a/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -13,14 +13,14 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
   if (vmStatus.error) {
     return {
       state: 'Failed',
-      status: StatusType.Error,
+      status: 'Error',
       label: 'Failed',
     };
   }
   if (!vmStatus.warm || vmStatus.warm.precopies.length === 0) {
     return {
       state: 'Starting',
-      status: StatusType.Loading,
+      status: 'Loading',
       label: 'Preparing for incremental copies.',
     };
   }
@@ -28,20 +28,20 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
   if (precopies.some((copy) => !!copy.start && !copy.end)) {
     return {
       state: 'Copying',
-      status: StatusType.Loading,
+      status: 'Loading',
       label: 'Performing incremental data copy.',
     };
   }
   if (precopies.every((copy) => !!copy.start && !!copy.end)) {
     return {
       state: 'Idle',
-      status: StatusType.Info, // TODO add an Idle status type to lib-ui
+      status: 'Paused',
       label: `Idle - Next incremental copy will begin in X minutes.`, // TODO
     };
   }
   return {
     state: 'Warning',
-    status: StatusType.Warning,
+    status: 'Warning',
     label: 'Unknown',
   };
 };
@@ -57,7 +57,7 @@ const VMWarmCopyStatus: React.FunctionComponent<IVMWarmCopyStatusProps> = ({
     return (
       <Popover hasAutoWidth bodyContent={<>{vmStatus.error.reasons.join('; ')}</>}>
         <Button variant="link" isInline>
-          <StatusIcon status={StatusType.Error} label="Failed" />
+          <StatusIcon status="Error" label="Failed" />
         </Button>
       </Popover>
     );

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -28,6 +28,7 @@ import {
   IVMwareVM,
   Mapping,
   MappingType,
+  PlanType,
   VMwareTree,
   VMwareTreeType,
 } from '@app/queries/types';
@@ -50,6 +51,7 @@ import { dnsLabelNameSchema } from '@app/common/constants';
 import { IKubeList } from '@app/client/types';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
+import TypeForm from './TypeForm';
 
 const useMappingFormState = (mappingsQuery: QueryResult<IKubeList<Mapping>>) => {
   const isSaveNewMapping = useFormField(false, yup.boolean().required());
@@ -104,6 +106,9 @@ const usePlanWizardFormState = (
     }),
     networkMapping: useMappingFormState(networkMappingsQuery),
     storageMapping: useMappingFormState(storageMappingsQuery),
+    type: useFormState({
+      type: useFormField<PlanType>('Cold', yup.string().oneOf(['Cold', 'Warm']).required()),
+    }),
   };
 
   return {
@@ -150,6 +155,7 @@ const PlanWizard: React.FunctionComponent = () => {
     SelectVMs,
     NetworkMapping,
     StorageMapping,
+    Type,
     Review,
   }
 
@@ -303,6 +309,17 @@ const PlanWizard: React.FunctionComponent = () => {
       ),
       enableNext: forms.storageMapping.isValid,
       canJumpTo: stepIdReached >= StepId.StorageMapping,
+    },
+    {
+      id: StepId.Type,
+      name: 'Type',
+      component: (
+        <WizardStepContainer title="Migration type">
+          <TypeForm form={forms.type} />
+        </WizardStepContainer>
+      ),
+      enableNext: forms.type.isValid,
+      canJumpTo: stepIdReached >= StepId.Type,
     },
     {
       id: StepId.Review,

--- a/src/app/Plans/components/Wizard/TypeForm.tsx
+++ b/src/app/Plans/components/Wizard/TypeForm.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { List, ListItem, Radio } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { PlanWizardFormState } from './PlanWizard';
+
+interface ITypeFormProps {
+  form: PlanWizardFormState['type'];
+}
+
+const TypeForm: React.FunctionComponent<ITypeFormProps> = ({ form }: ITypeFormProps) => (
+  <>
+    <Radio
+      id="migration-type-cold"
+      name="migration-type"
+      label="Cold migration"
+      description={
+        <List>
+          <ListItem>Source VMs are shut down while all of the VM data is migrated.</ListItem>
+        </List>
+      }
+      isChecked={form.values.type === 'Cold'}
+      onChange={() => form.fields.type.setValue('Cold')}
+      className={spacing.mbMd}
+    />
+    <Radio
+      id="migration-type-warm"
+      name="migration-type"
+      label="Warm migration"
+      description={
+        <List>
+          <ListItem>VM data is incrementally copied, leaving source VMs running.</ListItem>
+          <ListItem>
+            A final cutover, which shuts down the source VMs while VM data and metadata are copied,
+            is run later.
+          </ListItem>
+        </List>
+      }
+      isChecked={form.values.type === 'Warm'}
+      onChange={() => form.fields.type.setValue('Warm')}
+    />
+  </>
+);
+
+export default TypeForm;

--- a/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 import { TextContent, Text, List, ListItem, Flex, FlexItem } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PRODUCT_DOCO_LINK } from '@app/common/constants';
@@ -53,7 +53,7 @@ const VMConcernsDescription: React.FunctionComponent<IVMConcernsDescriptionProps
                   }
                 >
                   <FlexItem>
-                    <StatusIcon status={getVMConcernStatusType(concern) || StatusType.Warning} />
+                    <StatusIcon status={getVMConcernStatusType(concern) || 'Warning'} />
                   </FlexItem>
                   <FlexItem>
                     <strong>{concern.label}:</strong> {concern.assessment}

--- a/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IVMwareVM } from '@app/queries/types';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 
 import { getMostSevereVMConcern, getVMConcernStatusLabel, getVMConcernStatusType } from './helpers';
 interface IVMConcernsIconProps {
@@ -11,7 +11,7 @@ const VMConcernsIcon: React.FunctionComponent<IVMConcernsIconProps> = ({
   vm,
 }: IVMConcernsIconProps) => {
   if (vm.revisionValidated !== vm.revision) {
-    return <StatusIcon status={StatusType.Loading} label="Analyzing" />;
+    return <StatusIcon status="Loading" label="Analyzing" />;
   }
   const worstConcern = getMostSevereVMConcern(vm);
   const statusType = getVMConcernStatusType(worstConcern);

--- a/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -130,6 +130,11 @@ describe('<AddEditProviderModal />', () => {
     await waitFor(() => expect(nextButton).toBeEnabled());
     userEvent.click(nextButton);
 
+    expect(screen.getByRole('heading', { name: /Migration type/ })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Cold migration/)).toHaveAttribute('checked');
+    await waitFor(() => expect(nextButton).toBeEnabled());
+    userEvent.click(nextButton);
+
     // Review step
     expect(screen.getByRole('heading', { name: /Review the migration plan/ })).toBeInTheDocument();
     expect(screen.getByText(/my 2nd plan/i)).toBeInTheDocument();

--- a/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -71,7 +71,7 @@ describe('<AddEditProviderModal />', () => {
 
   it('allows to edit a plan', async () => {
     const history = createMemoryHistory();
-    history.push('/plans/plantest-2/edit');
+    history.push('/plans/plantest-02/edit');
     render(
       <NetworkContextProvider>
         <Router history={history}>
@@ -85,14 +85,14 @@ describe('<AddEditProviderModal />', () => {
         'Migration plans'
       );
       expect(screen.getByRole('navigation', { name: /Breadcrumb/ })).toHaveTextContent(
-        'plantest-2'
+        'plantest-02'
       );
       expect(screen.getByRole('navigation', { name: /Breadcrumb/ })).toHaveTextContent('Edit');
       expect(screen.getByRole('link', { name: /Migration plans/ })).toBeInTheDocument();
       expect(screen.getByRole('heading', { name: /Edit migration plan/ })).toBeInTheDocument();
 
       expect(screen.getByRole('heading', { name: /General settings/ })).toBeInTheDocument();
-      expect(screen.getByText(/plantest-2/i)).toBeInTheDocument();
+      expect(screen.getByText(/plantest-02/i)).toBeInTheDocument();
       expect(screen.getByText(/my 2nd plan/i)).toBeInTheDocument();
       expect(screen.getByText(/vcenter-1/i)).toBeInTheDocument();
       expect(screen.getByText(/ocpv-1/i)).toBeInTheDocument();

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -287,13 +287,13 @@ export const getMostSevereVMConcern = (vm: IVMwareVM): IVMwareVMConcern | null =
 
 export const getVMConcernStatusType = (concern: IVMwareVMConcern | null): StatusType | null =>
   !concern
-    ? StatusType.Ok
+    ? 'Ok'
     : concern.category === 'Critical'
-    ? StatusType.Error
+    ? 'Error'
     : concern.category === 'Warning'
-    ? StatusType.Warning
+    ? 'Warning'
     : concern.category === 'Information' || concern.category === 'Advisory'
-    ? StatusType.Info
+    ? 'Info'
     : null;
 
 export const getVMConcernStatusLabel = (concern: IVMwareVMConcern | null): string =>

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -370,6 +370,7 @@ export const generatePlan = (
       storage: storageMappingRef,
     },
     vms: forms.selectVMs.values.selectedVMs.map((vm) => ({ id: vm.id })),
+    warm: forms.type.values.type === 'Warm',
   },
 });
 

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -510,6 +510,8 @@ export const useEditingPlanPrefillEffect = (
       );
       forms.storageMapping.fields.isPrefilled.setInitialValue(true);
 
+      forms.type.fields.type.setValue(planBeingEdited.spec.warm ? 'Warm' : 'Cold');
+
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {
         setIsDonePrefilling(true);

--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -11,3 +11,12 @@ export const getPlanStatusTitle = (plan: IPlan): string => {
   );
   return condition ? PlanStatusDisplayType[condition.type] : '';
 };
+
+/*
+interface IWarmMigrationStatus {
+  // whether it's warm, whether it's in cutover, whether there are errors etc
+  // TODO or maybe just have a union type for states of a warm plan
+}
+
+export const getWarmMigrationStatus = (plan: IPlan) => {};
+*/

--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -26,9 +26,15 @@ export const getWarmPlanState = (
   if (!!migration && (plan.status?.migration?.vms?.length || 0) === 0) return 'Starting';
   const conditions = plan.status?.conditions || [];
   if (hasCondition(conditions, PlanStatusType.Executing)) {
-    if (plan.status?.migration?.vms?.some((vm) => vm.started)) return 'Cutover';
-    if (plan.status?.migration?.vms?.some((vm) => (vm.warm?.precopies.length || 0) > 0))
+    if (
+      !!migration.spec.cutover &&
+      plan.status?.migration?.vms?.some((vm) => vm.pipeline.some((step) => !!step.started))
+    ) {
+      return 'Cutover';
+    }
+    if (plan.status?.migration?.vms?.some((vm) => (vm.warm?.precopies.length || 0) > 0)) {
       return 'Copying';
+    }
     return 'Starting';
   }
   if (

--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -24,10 +24,10 @@ type WarmPlanState =
   | 'Finished';
 
 export const getWarmPlanState = (
-  plan: IPlan,
+  plan: IPlan | null,
   migration: IMigration | null
 ): WarmPlanState | null => {
-  if (!plan.spec.warm) return null;
+  if (!plan || !plan.spec.warm) return null;
   if (!migration) return 'NotStarted';
   if (!!migration && (plan.status?.migration?.vms?.length || 0) === 0) return 'Starting';
   const conditions = plan.status?.conditions || [];

--- a/src/app/common/components/StatusCondition.tsx
+++ b/src/app/common/components/StatusCondition.tsx
@@ -14,19 +14,19 @@ const StatusCondition: React.FunctionComponent<IStatusConditionProps> = ({
   status = {},
   unknownFallback = null,
 }: IStatusConditionProps) => {
-  const getStatusType = (severity: string) => {
+  const getStatusType = (severity: string): StatusType => {
     if (status) {
       if (severity === PlanStatusType.Ready) {
-        return StatusType.Ok;
+        return 'Ok';
       }
       if (severity === StatusCategoryType.Advisory) {
-        return StatusType.Info;
+        return 'Info';
       }
       if (severity === StatusCategoryType.Critical || severity === StatusCategoryType.Error) {
-        return StatusType.Error;
+        return 'Error';
       }
     }
-    return StatusType.Warning;
+    return 'Warning';
   };
 
   if (status) {

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -119,3 +119,10 @@ export const getObjectRef = (cr: ICR): IObjectReference => ({
   namespace: cr.metadata.namespace,
   uid: cr.metadata.uid,
 });
+
+export const getMinutesUntil = (timestamp: Date | string): string => {
+  const minutes = dayjs(timestamp).diff(dayjs(), 'minute');
+  if (minutes <= 0) return 'less than 1 minute';
+  if (minutes === 1) return '1 minute';
+  return `${minutes} minutes`;
+};

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -46,7 +46,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         {
           apiVersion: CLUSTER_API_VERSION,
           kind: 'Plan',
-          name: 'plantest-1',
+          name: 'plantest-01',
           namespace: 'openshift-migration',
           uid: '28fde094-b667-4d21-8f29-27c18f22178c',
         },
@@ -150,7 +150,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         {
           apiVersion: CLUSTER_API_VERSION,
           kind: 'Plan',
-          name: 'plantest-1',
+          name: 'plantest-01',
           namespace: 'openshift-migration',
           uid: '28fde094-b667-4d21-8f29-27c18f22178c',
         },

--- a/src/app/queries/mocks/migrations.mock.ts
+++ b/src/app/queries/mocks/migrations.mock.ts
@@ -6,7 +6,7 @@ import { MOCK_PLANS } from './plans.mock';
 export let MOCK_MIGRATIONS: IMigration[];
 
 if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-  const runningPlanIndexes = [0, 2, 3, 4, 6, 7, 8];
+  const runningPlanIndexes = [0, 2, 3, 4, 6, 7, 8, 9];
   MOCK_MIGRATIONS = runningPlanIndexes.map((index) => ({
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Migration',
@@ -20,7 +20,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     status: MOCK_PLANS[index].status?.migration,
   }));
 
-  // plantest-3 (plan index 2) has a canceled VM
+  // plantest-03 (plan index 2) has a canceled VM
   MOCK_MIGRATIONS[1].spec.cancel = [
     {
       id: 'vm-1630',

--- a/src/app/queries/mocks/migrations.mock.ts
+++ b/src/app/queries/mocks/migrations.mock.ts
@@ -6,72 +6,28 @@ import { MOCK_PLANS } from './plans.mock';
 export let MOCK_MIGRATIONS: IMigration[];
 
 if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-  MOCK_MIGRATIONS = [
-    {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-0-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[0].metadata),
-      },
-      status: MOCK_PLANS[0].status?.migration,
+  const runningPlanIndexes = [0, 2, 3, 4, 6, 7, 8];
+  MOCK_MIGRATIONS = runningPlanIndexes.map((index) => ({
+    apiVersion: CLUSTER_API_VERSION,
+    kind: 'Migration',
+    metadata: {
+      name: `plan-${index}-mock-migration`,
+      namespace: META.namespace,
     },
-    {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-1-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[1].metadata),
-      },
-      status: MOCK_PLANS[1].status?.migration,
+    spec: {
+      plan: nameAndNamespace(MOCK_PLANS[index].metadata),
     },
+    status: MOCK_PLANS[index].status?.migration,
+  }));
+
+  // plantest-3 (plan index 2) has a canceled VM
+  MOCK_MIGRATIONS[1].spec.cancel = [
     {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-2-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[2].metadata),
-        cancel: [
-          {
-            id: 'vm-1630',
-            name: 'fdupont-test-migration',
-          },
-        ],
-      },
-      status: MOCK_PLANS[2].status?.migration,
-    },
-    {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-3-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[3].metadata),
-      },
-      status: MOCK_PLANS[3].status?.migration,
-    },
-    {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-4-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[4].metadata),
-      },
-      status: MOCK_PLANS[4].status?.migration,
+      id: 'vm-1630',
+      name: 'fdupont-test-migration',
     },
   ];
+
+  // plantest-9 (plan index 8) is in cutover
+  MOCK_MIGRATIONS[6].spec.cutover = '2021-03-16T18:31:30Z';
 }

--- a/src/app/queries/mocks/migrations.mock.ts
+++ b/src/app/queries/mocks/migrations.mock.ts
@@ -6,7 +6,7 @@ import { MOCK_PLANS } from './plans.mock';
 export let MOCK_MIGRATIONS: IMigration[];
 
 if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-  const runningPlanIndexes = [0, 2, 3, 4, 6, 7, 8, 9];
+  const runningPlanIndexes = [0, 2, 3, 4, 6, 7, 8];
   MOCK_MIGRATIONS = runningPlanIndexes.map((index) => ({
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Migration',
@@ -28,6 +28,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   ];
 
-  // plantest-9 (plan index 8) is in cutover
-  MOCK_MIGRATIONS[6].spec.cutover = '2021-03-16T18:31:30Z';
+  // plantest-8 (plan index 7) is in cutover
+  MOCK_MIGRATIONS[5].spec.cutover = '2021-03-16T18:31:30Z';
 }

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -590,6 +590,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
 
   const warmVmIdle: IVMStatus = {
     ...vmStatus3,
+    completed: undefined,
     pipeline: warmVmPrecopying.pipeline,
     warm: {
       consecutiveFailures: 0,

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -585,6 +585,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
 
   const warmVmPrecopyingWithError: IVMStatus = {
     ...warmVmPrecopying,
+    completed: '2021-03-16T19:13:48Z',
     error: { phase: 'Mock Error', reasons: ['Something went wrong with a precopy?'] },
   };
 

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -282,9 +282,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     ...vmStatus1,
     pipeline: [
       vmStatus1.pipeline[0],
-      vmStatus1.pipeline[1],
-      { ...vmStatus1.pipeline[2], completed: '2020-10-10T17:34:10Z' },
-      vmStatus1.pipeline[3],
+      { ...vmStatus1.pipeline[1], completed: '2020-10-10T17:34:10Z' },
     ],
     conditions: [
       {
@@ -423,16 +421,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const vmStatus1WithError: IVMStatus = {
     ...vmStatus1,
     pipeline: [
-      vmStatus1.pipeline[0],
       {
-        ...vmStatus1.pipeline[1],
+        ...vmStatus1.pipeline[0],
         error: {
           phase: 'DiskTransferFailed',
           reasons: ['Error transferring disks'],
         },
       },
-      { ...vmStatus1.pipeline[2], started: undefined },
-      vmStatus1.pipeline[3],
+      { ...vmStatus1.pipeline[1], started: undefined },
     ],
     error: {
       phase: 'DiskTransfer',
@@ -444,16 +440,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     ...vmStatus1,
     pipeline: [
       vmStatus1.pipeline[0],
-      vmStatus1.pipeline[1],
       {
-        ...vmStatus1.pipeline[2],
+        ...vmStatus1.pipeline[1],
         completed: '2020-10-10T15:58:10Z',
         error: {
           phase: 'ImageConversionFailed',
           reasons: ['Error converting image'],
         },
       },
-      vmStatus1.pipeline[3],
     ],
     error: {
       phase: 'ImageConversion',

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -605,91 +605,155 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  // TODO make this plan running precopies
+  const warmVmPrecopying: IVMStatus = {
+    ...vmStatus1,
+    pipeline: vmStatus1.pipeline.map((step) => {
+      // Remove started/completed/progress
+      const { name, description, phase, annotations } = step;
+      return {
+        name,
+        description,
+        progress: { ...step.progress, completed: 0 },
+        phase,
+        annotations,
+      };
+    }),
+    warm: {
+      consecutiveFailures: 0,
+      failures: 0,
+      precopies: [
+        {
+          start: '2021-03-16T17:28:48Z',
+        },
+      ],
+      successes: 0,
+    },
+  };
+
+  const warmVmIdle: IVMStatus = {
+    ...warmVmPrecopying,
+    warm: {
+      consecutiveFailures: 0,
+      failures: 0,
+      nextPrecopyAt: '2021-03-16T18:29:20Z',
+      precopies: [
+        {
+          start: '2021-03-16T17:28:48Z',
+          end: '2021-03-16T17:29:42Z',
+        },
+        {
+          start: '2021-03-16T18:29:20Z',
+          end: '2021-03-16T18:30:38Z',
+        },
+        {
+          start: '2021-03-16T18:30:38Z',
+          end: '2021-03-16T18:31:48Z',
+        },
+      ],
+      successes: 3,
+    },
+  };
+
+  const warmVmCuttingOver: IVMStatus = {
+    ...vmStatus1,
+    warm: warmVmIdle.warm,
+  };
+
   const plan7: IPlan = {
-    apiVersion: CLUSTER_API_VERSION,
-    kind: 'Plan',
-    metadata: {
-      name: 'plantest-7',
-      namespace: 'openshift-migration',
-      generation: 2,
-      resourceVersion: '30825024',
-      selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-7',
-      uid: '28fde094-b667-4d21-8f29-27c18f22178c',
-      creationTimestamp: '2020-08-27T19:40:49Z',
-    },
-    spec: {
-      description: '',
-      provider: {
-        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),
-      },
-      targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
-      map: {
-        network: nameAndNamespace(MOCK_NETWORK_MAPPINGS[0].metadata),
-        storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
-      },
-      vms: [vm1],
-      warm: true,
-    },
+    ...plan1,
+    metadata: { ...plan1.metadata, name: 'plantest-7' },
+    spec: { ...plan1.spec, description: '', warm: true },
     status: {
       conditions: [
         {
           category: 'Info',
           lastTransitionTime: '2020-09-18T16:04:10Z',
-          message: 'Ready for migration',
+          message: 'In progress',
           reason: 'Valid',
           status: 'True',
-          type: 'Ready',
+          type: 'Executing',
         },
       ],
       observedGeneration: 2,
+      migration: {
+        active: '',
+        started: '2020-10-10T14:04:10Z',
+        vms: [warmVmPrecopying],
+        history: [
+          {
+            conditions: [],
+            migration: {
+              name: 'plan-6-mock-migration',
+              namespace: META.namespace,
+            },
+            plan: {
+              name: 'plantest-7',
+              namespace: 'openshift-migration',
+            },
+            provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+          },
+        ],
+      },
     },
   };
 
-  // TODO make this plan running cutover
   const plan8: IPlan = {
-    apiVersion: CLUSTER_API_VERSION,
-    kind: 'Plan',
-    metadata: {
-      name: 'plantest-8',
-      namespace: 'openshift-migration',
-      generation: 2,
-      resourceVersion: '30825024',
-      selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-8',
-      uid: '28fde094-b667-4d21-8f29-27c18f22178c',
-      creationTimestamp: '2020-08-27T19:40:49Z',
-    },
-    spec: {
-      description: '',
-      provider: {
-        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
-        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),
-      },
-      targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
-      map: {
-        network: nameAndNamespace(MOCK_NETWORK_MAPPINGS[0].metadata),
-        storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
-      },
-      vms: [vm1],
-      warm: true,
-    },
+    ...plan1,
+    metadata: { ...plan1.metadata, name: 'plantest-8' },
+    spec: { ...plan1.spec, description: '', warm: true },
     status: {
-      conditions: [
-        {
-          category: 'Info',
-          lastTransitionTime: '2020-09-18T16:04:10Z',
-          message: 'Ready for migration',
-          reason: 'Valid',
-          status: 'True',
-          type: 'Ready',
-        },
-      ],
+      conditions: plan7.status?.conditions || [],
       observedGeneration: 2,
+      migration: {
+        active: '',
+        started: '2020-10-10T14:04:10Z',
+        vms: [warmVmIdle],
+        history: [
+          {
+            conditions: [],
+            migration: {
+              name: 'plan-7-mock-migration',
+              namespace: META.namespace,
+            },
+            plan: {
+              name: 'plantest-8',
+              namespace: 'openshift-migration',
+            },
+            provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+          },
+        ],
+      },
     },
   };
 
-  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6, plan7, plan8];
+  const plan9: IPlan = {
+    ...plan1,
+    metadata: { ...plan1.metadata, name: 'plantest-9' },
+    spec: { ...plan1.spec, description: '', warm: true },
+    status: {
+      conditions: plan7.status?.conditions || [],
+      observedGeneration: 2,
+      migration: {
+        active: '',
+        started: '2020-10-10T14:04:10Z',
+        vms: [warmVmCuttingOver],
+        history: [
+          {
+            conditions: [],
+            migration: {
+              name: 'plan-8-mock-migration',
+              namespace: META.namespace,
+            },
+            plan: {
+              name: 'plantest-9',
+              namespace: 'openshift-migration',
+            },
+            provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+          },
+        ],
+      },
+    },
+  };
+
+  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6, plan7, plan8, plan9];
 }

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -28,14 +28,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     id: vm1.id,
     pipeline: [
       {
-        name: 'PreHook',
-        description: 'Pre hook',
-        progress: { total: 2, completed: 2 },
-        phase: 'Mock Step Phase',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
-      {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
         progress: { total: 1024 * 64, completed: 1024 * 30 },
@@ -51,12 +43,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         phase: 'Mock Step Phase',
         started: '2020-10-10T15:57:10Z',
       },
-      {
-        name: 'PostHook',
-        description: 'Post hook',
-        progress: { total: 2, completed: 0 },
-        phase: 'Mock Step Phase',
-      },
     ],
     phase: 'Mock VM Phase',
     started: '2020-10-10T14:04:10Z',
@@ -65,14 +51,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const vmStatus2: IVMStatus = {
     id: vm2.id,
     pipeline: [
-      {
-        name: 'PreHook',
-        description: 'Pre hook',
-        progress: { total: 1, completed: 1 },
-        phase: 'Mock Step Phase',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
       {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
@@ -89,12 +67,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         phase: 'Mock Step Phase',
         started: '2020-10-10T15:57:10Z',
       },
-      {
-        name: 'PostHook',
-        description: 'Post hook',
-        progress: { total: 1, completed: 0 },
-        phase: 'Mock Step Phase',
-      },
     ],
     phase: 'Mock VM Phase',
     started: '2020-10-10T14:04:10Z',
@@ -103,14 +75,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const vmStatus3: IVMStatus = {
     id: vm3.id,
     pipeline: [
-      {
-        name: 'PreHook',
-        description: 'Pre hook',
-        progress: { total: 2, completed: 2 },
-        phase: 'Latest message from controller',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
       {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
@@ -138,14 +102,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     id: vm4.id,
     pipeline: [
       {
-        name: 'PreHook',
-        description: 'Pre Hook',
-        progress: { total: 2, completed: 2 },
-        phase: 'Latest message from controller',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
-      {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
         progress: { total: 1024 * 64, completed: 1024 * 64 },
@@ -167,12 +123,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           ],
         },
       },
-      {
-        name: 'PostHook',
-        description: 'Post Hook',
-        progress: { total: 1, completed: 0 },
-        phase: 'Mock Step Phase',
-      },
     ],
     phase: 'Mock VM Phase',
     started: '2020-10-10T14:04:10Z',
@@ -189,14 +139,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     id: vm2.id,
     pipeline: [
       {
-        name: 'PreHook',
-        description: 'Pre hook',
-        progress: { total: 1, completed: 1 },
-        phase: 'Mock Step Phase',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
-      {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
         progress: { total: 1024 * 64, completed: 0 },
@@ -206,12 +148,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       {
         name: 'ImageConversion',
         description: 'Convert image to kubevirt.',
-        progress: { total: 1, completed: 0 },
-        phase: 'Mock Step Phase',
-      },
-      {
-        name: 'PostHook',
-        description: 'Post hook',
         progress: { total: 1, completed: 0 },
         phase: 'Mock Step Phase',
       },

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -162,12 +162,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-1',
+      name: 'plantest-01',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-1',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-01',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -225,7 +225,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-1',
+              name: 'plantest-01',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -239,12 +239,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-2',
+      name: 'plantest-02',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-2',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-02',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -301,12 +301,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-3',
+      name: 'plantest-03',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825023',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-3',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-03',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -348,7 +348,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-3',
+              name: 'plantest-03',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -362,12 +362,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-4',
+      name: 'plantest-04',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-4',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-04',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -410,7 +410,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-4',
+              name: 'plantest-04',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -463,7 +463,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
 
   const plan5: IPlan = {
     ...plan1,
-    metadata: { ...plan1.metadata, name: 'plantest-5' },
+    metadata: { ...plan1.metadata, name: 'plantest-05' },
     spec: { ...plan1.spec, description: 'completed with errors' },
     status: {
       conditions: [
@@ -489,7 +489,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-5',
+              name: 'plantest-05',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -503,12 +503,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-6',
+      name: 'plantest-06',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-6',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-06',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -566,6 +566,11 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
+  const warmVmPrecopyingWithError: IVMStatus = {
+    ...warmVmPrecopying,
+    error: { phase: 'Mock Error', reasons: ['Something went wrong with a precopy?'] },
+  };
+
   const warmVmIdle: IVMStatus = {
     ...warmVmPrecopying,
     warm: {
@@ -597,8 +602,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
 
   const plan7: IPlan = {
     ...plan1,
-    metadata: { ...plan1.metadata, name: 'plantest-7' },
-    spec: { ...plan1.spec, description: '', warm: true },
+    metadata: { ...plan1.metadata, name: 'plantest-07' },
+    spec: { ...plan1.spec, description: '', warm: true, vms: [vm1] },
     status: {
       conditions: [
         {
@@ -623,7 +628,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-7',
+              name: 'plantest-07',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -635,8 +640,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
 
   const plan8: IPlan = {
     ...plan1,
-    metadata: { ...plan1.metadata, name: 'plantest-8' },
-    spec: { ...plan1.spec, description: '', warm: true },
+    metadata: { ...plan1.metadata, name: 'plantest-08' },
+    spec: plan7.spec,
     status: {
       conditions: plan7.status?.conditions || [],
       observedGeneration: 2,
@@ -652,7 +657,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-8',
+              name: 'plantest-08',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -664,8 +669,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
 
   const plan9: IPlan = {
     ...plan1,
-    metadata: { ...plan1.metadata, name: 'plantest-9' },
-    spec: { ...plan1.spec, description: '', warm: true },
+    metadata: { ...plan1.metadata, name: 'plantest-09' },
+    spec: plan7.spec,
     status: {
       conditions: plan7.status?.conditions || [],
       observedGeneration: 2,
@@ -681,7 +686,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-9',
+              name: 'plantest-09',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -691,5 +696,44 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6, plan7, plan8, plan9];
+  const plan10: IPlan = {
+    ...plan1,
+    metadata: { ...plan1.metadata, name: 'plantest-10' },
+    spec: plan7.spec,
+    status: {
+      conditions: [
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-10-10T15:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Failed',
+        },
+      ],
+      observedGeneration: 2,
+      migration: {
+        active: '',
+        started: '2020-10-10T14:04:10Z',
+        completed: '2020-10-10T15:04:10Z',
+        vms: [warmVmPrecopyingWithError],
+        history: [
+          {
+            conditions: [],
+            migration: {
+              name: 'plan-9-mock-migration',
+              namespace: META.namespace,
+            },
+            plan: {
+              name: 'plantest-10',
+              namespace: 'openshift-migration',
+            },
+            provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+          },
+        ],
+      },
+    },
+  };
+
+  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6, plan7, plan8, plan9, plan10];
 }

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -513,7 +513,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
     spec: {
-      description: '',
+      description: 'newly created warm plan',
       provider: {
         source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -572,7 +572,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-2',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-6',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -605,5 +605,91 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6];
+  // TODO make this plan running precopies
+  const plan7: IPlan = {
+    apiVersion: CLUSTER_API_VERSION,
+    kind: 'Plan',
+    metadata: {
+      name: 'plantest-7',
+      namespace: 'openshift-migration',
+      generation: 2,
+      resourceVersion: '30825024',
+      selfLink:
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-7',
+      uid: '28fde094-b667-4d21-8f29-27c18f22178c',
+      creationTimestamp: '2020-08-27T19:40:49Z',
+    },
+    spec: {
+      description: '',
+      provider: {
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),
+      },
+      targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
+      map: {
+        network: nameAndNamespace(MOCK_NETWORK_MAPPINGS[0].metadata),
+        storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
+      },
+      vms: [vm1],
+      warm: true,
+    },
+    status: {
+      conditions: [
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
+        },
+      ],
+      observedGeneration: 2,
+    },
+  };
+
+  // TODO make this plan running cutover
+  const plan8: IPlan = {
+    apiVersion: CLUSTER_API_VERSION,
+    kind: 'Plan',
+    metadata: {
+      name: 'plantest-8',
+      namespace: 'openshift-migration',
+      generation: 2,
+      resourceVersion: '30825024',
+      selfLink:
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-8',
+      uid: '28fde094-b667-4d21-8f29-27c18f22178c',
+      creationTimestamp: '2020-08-27T19:40:49Z',
+    },
+    spec: {
+      description: '',
+      provider: {
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),
+      },
+      targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
+      map: {
+        network: nameAndNamespace(MOCK_NETWORK_MAPPINGS[0].metadata),
+        storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
+      },
+      vms: [vm1],
+      warm: true,
+    },
+    status: {
+      conditions: [
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
+        },
+      ],
+      observedGeneration: 2,
+    },
+  };
+
+  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6, plan7, plan8];
 }

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -247,6 +247,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm1, vm2],
+      warm: false,
     },
     status: {
       conditions: [
@@ -324,6 +325,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm1],
+      warm: false,
     },
     status: {
       conditions: [
@@ -384,6 +386,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm1, vm2, vm3, vm4],
+      warm: false,
     },
     status: {
       conditions: [
@@ -444,6 +447,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm3],
+      warm: false,
     },
     status: {
       conditions: [
@@ -573,7 +577,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
     spec: {
-      description: 'has a non-ready provider',
+      description: '',
       provider: {
         source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),
@@ -584,6 +588,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm1],
+      warm: true,
     },
     status: {
       conditions: [

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -603,7 +603,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const plan7: IPlan = {
     ...plan1,
     metadata: { ...plan1.metadata, name: 'plantest-07' },
-    spec: { ...plan1.spec, description: '', warm: true, vms: [vm1] },
+    spec: { ...plan1.spec, description: 'running first copy', warm: true, vms: [vm1] },
     status: {
       conditions: [
         {
@@ -641,7 +641,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const plan8: IPlan = {
     ...plan1,
     metadata: { ...plan1.metadata, name: 'plantest-08' },
-    spec: plan7.spec,
+    spec: { ...plan7.spec, description: 'idle between copies' },
     status: {
       conditions: plan7.status?.conditions || [],
       observedGeneration: 2,
@@ -670,7 +670,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const plan9: IPlan = {
     ...plan1,
     metadata: { ...plan1.metadata, name: 'plantest-09' },
-    spec: plan7.spec,
+    spec: { ...plan7.spec, description: 'cutover started' },
     status: {
       conditions: plan7.status?.conditions || [],
       observedGeneration: 2,
@@ -699,7 +699,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const plan10: IPlan = {
     ...plan1,
     metadata: { ...plan1.metadata, name: 'plantest-10' },
-    spec: plan7.spec,
+    spec: { ...plan7.spec, description: 'failed before cutover' },
     status: {
       conditions: [
         {

--- a/src/app/queries/types/migrations.types.ts
+++ b/src/app/queries/types/migrations.types.ts
@@ -12,6 +12,7 @@ export interface IMigration extends ICR {
   spec: {
     plan: INameNamespaceRef;
     cancel?: ICanceledVM[];
+    cutover?: string; // ISO timestamp
   };
   status?: IPlanStatus['migration'];
 }

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -74,7 +74,7 @@ export interface IPlan extends ICR {
     };
     vms: IPlanVM[];
     warm: boolean;
-    cutover?: string; // ISO timestamp
+    cutover?: string; // ISO timestamp -- default for all migrations of this plan?
   };
   status?: IPlanStatus;
 }

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -34,6 +34,16 @@ export interface IVMStatus {
   started?: string;
   completed?: string;
   conditions?: IStatusCondition[];
+  warm?: {
+    consecutiveFailures: number;
+    failures: number;
+    successes: number;
+    nextPrecopyAt?: string; // ISO timestamp
+    precopies: {
+      start: string;
+      end?: string;
+    }[];
+  };
 }
 
 export interface IPlanVM {

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -76,3 +76,5 @@ export interface IPlan extends ICR {
   };
   status?: IPlanStatus;
 }
+
+export type PlanType = 'Cold' | 'Warm';

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -73,6 +73,8 @@ export interface IPlan extends ICR {
       storage: INameNamespaceRef;
     };
     vms: IPlanVM[];
+    warm: boolean;
+    cutover?: string; // ISO timestamp
   };
   status?: IPlanStatus;
 }


### PR DESCRIPTION
Resolves kubev2v/forklift-ui#308.

This implements everything for warm migration except blocking incompatible VMs (https://github.com/konveyor/forklift-ui/issues/454).
I also originally planned to address https://github.com/konveyor/forklift-ui/issues/423 here but I am saving that for a followup PR.

- [x] Add Type step to plan wizard with cold/warm selection
- [x] Wire up cold/warm selection to spec property when creating plan
- [x] Add Type column to plans table
- [x] Move source/target provider and VMs columns into expandable rows to make more table space
- [x] Display plan-level status information for warm migrations ([mockup](https://docs.google.com/presentation/d/1eSywOXFByvQ2dtKDl-4QyaVv8OxY7xyHgQ6ZeIB3DwQ/edit?ts=6030101f#slide=id.gbafff68d14_0_27))
- [x] Implement Cutover button
- [x] Add warm migration variant of plan details table before cutover (different columns -- [mockup](https://docs.google.com/presentation/d/1eSywOXFByvQ2dtKDl-4QyaVv8OxY7xyHgQ6ZeIB3DwQ/edit?ts=6030101f#slide=id.gbafff68d14_0_37))
- [x] Add expanded table detailing each incremental copy instead of pipeline steps ([mockup](https://docs.google.com/presentation/d/1eSywOXFByvQ2dtKDl-4QyaVv8OxY7xyHgQ6ZeIB3DwQ/edit?ts=6030101f#slide=id.gbafff68d14_0_37))
- [x] Handle corner cases and transient states

Screenshots were taken in mock mode, ignore the unrealistic elapsed times. Mock mode is calculating the difference between an old static timestamp and the current time.

New Type step in the plan wizard:

![Screen Shot 2021-03-05 at 4 40 07 PM](https://user-images.githubusercontent.com/811963/110177320-c82e1700-7dd2-11eb-8b40-99c5d4faae3e.png)

New layout for plans table:

![Screen Shot 2021-03-19 at 3 14 49 PM](https://user-images.githubusercontent.com/811963/111831495-dcd7d800-88c5-11eb-915e-e20acddbeb7e.png)

Warm migration states in the plans table:

![Screen Shot 2021-03-19 at 3 17 54 PM](https://user-images.githubusercontent.com/811963/111831837-4f48b800-88c6-11eb-82e5-918b11d84118.png)

New layout for migration details table in the pre-copy stage:

![Screen Shot 2021-03-19 at 3 16 25 PM](https://user-images.githubusercontent.com/811963/111831765-304a2600-88c6-11eb-8aa5-83325d744202.png)

The migration details table layout for cold migrations is unchanged, and when a warm migration starts its cutover the page layout changes to the original cold migration pipeline layout.

If a migration has a fatal error before cutover starts, the latest pre-copy shows as failed and the error message can be seen by clicking on the "Failed" text in the Status column of the VM list:

![Screen Shot 2021-03-19 at 3 22 39 PM](https://user-images.githubusercontent.com/811963/111832293-faf20800-88c6-11eb-8a12-c1348b000569.png)
