### PR TITLE
Add unique ids to confirm and cancel buttons on all modals (for QE)

### DIFF
--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -127,6 +127,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
           />
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <Button
+              id="modal-confirm-button"
               key="confirm"
               variant="primary"
               onClick={() => {
@@ -147,6 +148,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
               {!mappingBeingEdited ? 'Create' : 'Save'}
             </Button>
             <Button
+              id="modal-cancel-button"
               key="cancel"
               variant="link"
               onClick={onClose}

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -129,6 +129,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
           />
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <Button
+              id="modal-confirm-button"
               key="confirm"
               variant="primary"
               isDisabled={!isFormDirty || !isFormValid || mutateProviderResult.isLoading}
@@ -139,6 +140,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
               {!providerBeingEdited ? 'Add' : 'Save'}
             </Button>
             <Button
+              id="modal-cancel-button"
               key="cancel"
               variant="link"
               onClick={onClose}

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -98,6 +98,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
           />
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <Button
+              id="modal-confirm-button"
               key="confirm"
               variant="primary"
               isDisabled={!form.isDirty || !form.isValid || configureHostsResult.isLoading}
@@ -110,6 +111,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
               Save
             </Button>
             <Button
+              id="modal-cancel-button"
               key="cancel"
               variant="link"
               onClick={onClose}

--- a/src/app/common/components/ConfirmModal.tsx
+++ b/src/app/common/components/ConfirmModal.tsx
@@ -48,6 +48,7 @@ const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
           />
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <Button
+              id="modal-confirm-button"
               key="confirm"
               variant="primary"
               onClick={mutateFn}
@@ -56,6 +57,7 @@ const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
               {confirmButtonText}
             </Button>
             <Button
+              id="modal-cancel-button"
               key="cancel"
               variant="link"
               onClick={toggleOpen}

--- a/src/app/common/components/SelectOpenShiftNetworkModal.tsx
+++ b/src/app/common/components/SelectOpenShiftNetworkModal.tsx
@@ -92,6 +92,7 @@ const SelectOpenShiftNetworkModal: React.FunctionComponent<ISelectOpenShiftNetwo
           ) : null}
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <Button
+              id="modal-confirm-button"
               key="confirm"
               variant="primary"
               isDisabled={!form.isDirty || !form.isValid || mutationResult?.isLoading}
@@ -102,6 +103,7 @@ const SelectOpenShiftNetworkModal: React.FunctionComponent<ISelectOpenShiftNetwo
               Select
             </Button>
             <Button
+              id="modal-cancel-button"
               key="cancel"
               variant="link"
               onClick={onClose}


### PR DESCRIPTION
Resolves #435 

Applies to:
* Add/edit provider modal
* Confirmation modal when removing a provider
* Modal for selecting VMware host transfer network
* Modal for selecting OpenShift transfer network on the provider page
* Modal for selecting OpenShift transfer network in the plan wizard
* Add/edit mapping modal
* Confirmation modal when deleting a mapping
* Confirmation modal when deleting a plan
* Confirmation modal when canceling migrations