### PR TITLE
Warm migration followup: warn when selecting warm with incompatible VMs, show migration type in the Review step of the wizard

### DIFF
--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -117,7 +117,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
             getTotalCopiedRatio(vmStatus).completed,
             getPipelineSummaryTitle(vmStatus),
           ]
-        : [vmStatus.warm?.precopies.length || 0, getWarmVMCopyState(vmStatus).state]),
+        : [vmStatus.warm?.precopies?.length || 0, getWarmVMCopyState(vmStatus).state]),
     ];
   };
 
@@ -281,7 +281,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
               { title: <PipelineSummary status={vmStatus} isCanceled={isCanceled} /> },
             ]
           : [
-              vmStatus.warm?.precopies.length || 0,
+              vmStatus.warm?.precopies?.length || 0,
               { title: <VMWarmCopyStatus vmStatus={vmStatus} /> },
             ]),
       ],

--- a/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -23,7 +23,7 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
   status,
   isCanceled,
 }: IVMStatusPrecopyTableProps) => {
-  if (!status.warm || status.warm.precopies.length === 0) {
+  if (!status.warm || status.warm.precopies?.length === 0) {
     return (
       <TextContent>
         <Text component="p">Preparing to start incremental copies</Text>
@@ -31,7 +31,7 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
     );
   }
 
-  const sortedPrecopies = status.warm.precopies.sort((a, b) => {
+  const sortedPrecopies = (status.warm.precopies || []).sort((a, b) => {
     // Most recent first
     if (a.start < b.start) return 1;
     if (a.start > b.start) return -1;

--- a/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -18,7 +18,7 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
       label: 'Failed',
     };
   }
-  if (!vmStatus.warm || vmStatus.warm.precopies.length === 0) {
+  if (!vmStatus.warm || (vmStatus.warm.precopies || []).length === 0) {
     return {
       state: 'Starting',
       status: 'Loading',
@@ -26,14 +26,14 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
     };
   }
   const { precopies, nextPrecopyAt } = vmStatus.warm;
-  if (precopies.some((copy) => !!copy.start && !copy.end)) {
+  if ((precopies || []).some((copy) => !!copy.start && !copy.end)) {
     return {
       state: 'Copying',
       status: 'Loading',
       label: 'Performing incremental data copy',
     };
   }
-  if (precopies.every((copy) => !!copy.start && !!copy.end)) {
+  if ((precopies || []).every((copy) => !!copy.start && !!copy.end)) {
     return {
       state: 'Idle',
       status: 'Paused',

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -164,7 +164,8 @@ const PlanWizard: React.FunctionComponent = () => {
   if (forms.filterVMs.isValid) stepIdReached = StepId.SelectVMs;
   if (forms.selectVMs.isValid) stepIdReached = StepId.NetworkMapping;
   if (forms.networkMapping.isValid) stepIdReached = StepId.StorageMapping;
-  if (forms.storageMapping.isValid) stepIdReached = StepId.Review;
+  if (forms.storageMapping.isValid) stepIdReached = StepId.Type;
+  if (forms.type.isValid) stepIdReached = StepId.Review;
 
   const isFirstRender = React.useRef(true);
 
@@ -315,7 +316,7 @@ const PlanWizard: React.FunctionComponent = () => {
       name: 'Type',
       component: (
         <WizardStepContainer title="Migration type">
-          <TypeForm form={forms.type} />
+          <TypeForm form={forms.type} selectedVMs={forms.selectVMs.values.selectedVMs} />
         </WizardStepContainer>
       ),
       enableNext: forms.type.isValid,

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -25,7 +25,6 @@ import {
   IOpenShiftProvider,
   IPlan,
   IVMwareProvider,
-  IVMwareVM,
   Mapping,
   MappingType,
   PlanType,
@@ -36,7 +35,7 @@ import {
   IMappingBuilderItem,
   mappingBuilderItemsSchema,
 } from '@app/Mappings/components/MappingBuilder';
-import { generateMappings, useEditingPlanPrefillEffect } from './helpers';
+import { generateMappings, getSelectedVMsFromIds, useEditingPlanPrefillEffect } from './helpers';
 import {
   getMappingNameSchema,
   useMappingsQuery,
@@ -45,6 +44,7 @@ import {
   usePatchPlanMutation,
   usePlansQuery,
   useCreateMappingMutations,
+  useVMwareVMsQuery,
 } from '@app/queries';
 import { getAggregateQueryStatus } from '@app/queries/helpers';
 import { dnsLabelNameSchema } from '@app/common/constants';
@@ -102,7 +102,7 @@ const usePlanWizardFormState = (
       isPrefilled: useFormField(false, yup.boolean()),
     }),
     selectVMs: useFormState({
-      selectedVMs: useFormField<IVMwareVM[]>([], yup.array<IVMwareVM>().required()),
+      selectedVMIds: useFormField<string[]>([], yup.array<string>().required()),
     }),
     networkMapping: useMappingFormState(networkMappingsQuery),
     storageMapping: useMappingFormState(storageMappingsQuery),
@@ -142,6 +142,8 @@ const PlanWizard: React.FunctionComponent = () => {
     storageMappingsQuery,
     planBeingEdited
   );
+
+  const vmsQuery = useVMwareVMsQuery(forms.general.values.sourceProvider);
 
   const { isDonePrefilling, prefillQueries, prefillErrorTitles } = useEditingPlanPrefillEffect(
     forms,
@@ -227,6 +229,8 @@ const PlanWizard: React.FunctionComponent = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mutationStatus]);
 
+  const selectedVMs = getSelectedVMsFromIds(forms.selectVMs.values.selectedVMIds, vmsQuery);
+
   const steps = [
     {
       id: StepId.General,
@@ -265,6 +269,7 @@ const PlanWizard: React.FunctionComponent = () => {
                 form={forms.selectVMs}
                 selectedTreeNodes={forms.filterVMs.values.selectedTreeNodes}
                 sourceProvider={forms.general.values.sourceProvider}
+                selectedVMs={selectedVMs}
               />
             </WizardStepContainer>
           ),
@@ -284,7 +289,7 @@ const PlanWizard: React.FunctionComponent = () => {
             sourceProvider={forms.general.values.sourceProvider}
             targetProvider={forms.general.values.targetProvider}
             mappingType={MappingType.Network}
-            selectedVMs={forms.selectVMs.values.selectedVMs}
+            selectedVMs={selectedVMs}
             planBeingEdited={planBeingEdited}
           />
         </WizardStepContainer>
@@ -303,7 +308,7 @@ const PlanWizard: React.FunctionComponent = () => {
             sourceProvider={forms.general.values.sourceProvider}
             targetProvider={forms.general.values.targetProvider}
             mappingType={MappingType.Storage}
-            selectedVMs={forms.selectVMs.values.selectedVMs}
+            selectedVMs={selectedVMs}
             planBeingEdited={planBeingEdited}
           />
         </WizardStepContainer>
@@ -316,7 +321,7 @@ const PlanWizard: React.FunctionComponent = () => {
       name: 'Type',
       component: (
         <WizardStepContainer title="Migration type">
-          <TypeForm form={forms.type} selectedVMs={forms.selectVMs.values.selectedVMs} />
+          <TypeForm form={forms.type} selectedVMs={selectedVMs} />
         </WizardStepContainer>
       ),
       enableNext: forms.type.isValid,
@@ -332,6 +337,7 @@ const PlanWizard: React.FunctionComponent = () => {
             allMutationResults={allMutationResults}
             allMutationErrorTitles={allMutationErrorTitles}
             planBeingEdited={planBeingEdited}
+            selectedVMs={selectedVMs}
           />
         </WizardStepContainer>
       ),

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -89,6 +89,8 @@ const Review: React.FunctionComponent<IReviewProps> = ({
         <GridItem md={9}>
           <MappingDetailView mappingType={MappingType.Storage} mapping={storageMapping} />
         </GridItem>
+        <GridItem md={3}>Migration type</GridItem>
+        <GridItem md={9}>{forms.type.values.type}</GridItem>
       </Grid>
       <ResolvedQueries
         results={allMutationResults}

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -12,7 +12,7 @@ import {
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlanWizardFormState } from './PlanWizard';
 import MappingDetailView from '@app/Mappings/components/MappingDetailView';
-import { IPlan, Mapping, MappingType, POD_NETWORK } from '@app/queries/types';
+import { IPlan, IVMwareVM, Mapping, MappingType, POD_NETWORK } from '@app/queries/types';
 import { MutationResult } from 'react-query';
 import { IKubeResponse, KubeClientError } from '@app/client/types';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
@@ -27,6 +27,7 @@ interface IReviewProps {
   )[];
   allMutationErrorTitles: string[];
   planBeingEdited: IPlan | null;
+  selectedVMs: IVMwareVM[];
 }
 
 const Review: React.FunctionComponent<IReviewProps> = ({
@@ -34,6 +35,7 @@ const Review: React.FunctionComponent<IReviewProps> = ({
   allMutationResults,
   allMutationErrorTitles,
   planBeingEdited,
+  selectedVMs,
 }: IReviewProps) => {
   usePausedPollingEffect();
 
@@ -70,14 +72,14 @@ const Review: React.FunctionComponent<IReviewProps> = ({
             headerContent={<div>Selected VMs</div>}
             bodyContent={
               <List>
-                {forms.selectVMs.values.selectedVMs.map((vm, index) => (
+                {selectedVMs.map((vm, index) => (
                   <li key={index}>{vm.name}</li>
                 ))}
               </List>
             }
           >
             <Button variant="link" isInline>
-              {forms.selectVMs.values.selectedVMs.length}
+              {selectedVMs.length}
             </Button>
           </Popover>
         </GridItem>

--- a/src/app/Plans/components/Wizard/TypeForm.tsx
+++ b/src/app/Plans/components/Wizard/TypeForm.tsx
@@ -18,8 +18,6 @@ const TypeForm: React.FunctionComponent<ITypeFormProps> = ({
   form,
   selectedVMs,
 }: ITypeFormProps) => {
-  // TODO maybe we need to store only VM ids in selectedVMs state, and find the VM objects here so the concerns can be updated with polling?
-
   const warmCriticalConcernsFound = warmCriticalConcerns.filter((label) =>
     someVMHasConcern(selectedVMs, label)
   );
@@ -32,6 +30,8 @@ const TypeForm: React.FunctionComponent<ITypeFormProps> = ({
       : warmWarningConcernsFound.length > 0
       ? 'Warning'
       : 'Ok';
+
+  const isAnalysingVms = selectedVMs.some((vm) => vm.revisionValidated !== vm.revision);
 
   return (
     <>
@@ -61,7 +61,11 @@ const TypeForm: React.FunctionComponent<ITypeFormProps> = ({
                 copied, is run later.
               </ListItem>
             </List>
-            {warmWarnStatus !== 'Ok' ? (
+            {isAnalysingVms ? (
+              <div className={`${spacing.mtMd} ${spacing.mlXs}`}>
+                <StatusIcon status="Loading" label="Analysing warm migration compatibility" />
+              </div>
+            ) : warmWarnStatus !== 'Ok' ? (
               <div className={`${spacing.mtMd} ${spacing.mlXs}`}>
                 <StatusIcon
                   status={warmWarnStatus}

--- a/src/app/Plans/components/Wizard/TypeForm.tsx
+++ b/src/app/Plans/components/Wizard/TypeForm.tsx
@@ -2,43 +2,90 @@ import * as React from 'react';
 import { List, ListItem, Radio } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlanWizardFormState } from './PlanWizard';
+import { IVMwareVM } from '@app/queries/types';
+import { someVMHasConcern } from './helpers';
+import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+
+const warmCriticalConcerns = ['Changed Block Tracking (CBT) not enabled'];
+const warmWarningConcerns = ['VM snapshot detected'];
 
 interface ITypeFormProps {
   form: PlanWizardFormState['type'];
+  selectedVMs: IVMwareVM[];
 }
 
-const TypeForm: React.FunctionComponent<ITypeFormProps> = ({ form }: ITypeFormProps) => (
-  <>
-    <Radio
-      id="migration-type-cold"
-      name="migration-type"
-      label="Cold migration"
-      description={
-        <List>
-          <ListItem>Source VMs are shut down while all of the VM data is migrated.</ListItem>
-        </List>
-      }
-      isChecked={form.values.type === 'Cold'}
-      onChange={() => form.fields.type.setValue('Cold')}
-      className={spacing.mbMd}
-    />
-    <Radio
-      id="migration-type-warm"
-      name="migration-type"
-      label="Warm migration"
-      description={
-        <List>
-          <ListItem>VM data is incrementally copied, leaving source VMs running.</ListItem>
-          <ListItem>
-            A final cutover, which shuts down the source VMs while VM data and metadata are copied,
-            is run later.
-          </ListItem>
-        </List>
-      }
-      isChecked={form.values.type === 'Warm'}
-      onChange={() => form.fields.type.setValue('Warm')}
-    />
-  </>
-);
+const TypeForm: React.FunctionComponent<ITypeFormProps> = ({
+  form,
+  selectedVMs,
+}: ITypeFormProps) => {
+  // TODO maybe we need to store only VM ids in selectedVMs state, and find the VM objects here so the concerns can be updated with polling?
+
+  const warmCriticalConcernsFound = warmCriticalConcerns.filter((label) =>
+    someVMHasConcern(selectedVMs, label)
+  );
+  const warmWarningConcernsFound = warmWarningConcerns.filter((label) =>
+    someVMHasConcern(selectedVMs, label)
+  );
+  const warmWarnStatus: StatusType =
+    warmCriticalConcernsFound.length > 0
+      ? 'Error'
+      : warmWarningConcernsFound.length > 0
+      ? 'Warning'
+      : 'Ok';
+
+  return (
+    <>
+      <Radio
+        id="migration-type-cold"
+        name="migration-type"
+        label="Cold migration"
+        description={
+          <List>
+            <ListItem>Source VMs are shut down while all of the VM data is migrated.</ListItem>
+          </List>
+        }
+        isChecked={form.values.type === 'Cold'}
+        onChange={() => form.fields.type.setValue('Cold')}
+        className={spacing.mbMd}
+      />
+      <Radio
+        id="migration-type-warm"
+        name="migration-type"
+        label="Warm migration"
+        description={
+          <>
+            <List>
+              <ListItem>VM data is incrementally copied, leaving source VMs running.</ListItem>
+              <ListItem>
+                A final cutover, which shuts down the source VMs while VM data and metadata are
+                copied, is run later.
+              </ListItem>
+            </List>
+            {warmWarnStatus !== 'Ok' ? (
+              <div className={`${spacing.mtMd} ${spacing.mlXs}`}>
+                <StatusIcon
+                  status={warmWarnStatus}
+                  label={
+                    <>
+                      Warm migration {warmWarnStatus === 'Error' ? 'will' : 'might'} fail for one or
+                      more VMs because of the following conditions:
+                    </>
+                  }
+                />
+                <List className={`${spacing.mtSm} ${spacing.mlMd}`}>
+                  {[...warmCriticalConcernsFound, ...warmWarningConcernsFound].map((label) => (
+                    <ListItem key={label}>{label}</ListItem>
+                  ))}
+                </List>
+              </div>
+            ) : null}
+          </>
+        }
+        isChecked={form.values.type === 'Warm'}
+        onChange={() => form.fields.type.setValue('Warm')}
+      />
+    </>
+  );
+};
 
 export default TypeForm;

--- a/src/app/Plans/components/Wizard/TypeForm.tsx
+++ b/src/app/Plans/components/Wizard/TypeForm.tsx
@@ -4,10 +4,9 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlanWizardFormState } from './PlanWizard';
 import { IVMwareVM } from '@app/queries/types';
 import { someVMHasConcern } from './helpers';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 
 const warmCriticalConcerns = ['Changed Block Tracking (CBT) not enabled'];
-const warmWarningConcerns = ['VM snapshot detected'];
 
 interface ITypeFormProps {
   form: PlanWizardFormState['type'];
@@ -21,16 +20,6 @@ const TypeForm: React.FunctionComponent<ITypeFormProps> = ({
   const warmCriticalConcernsFound = warmCriticalConcerns.filter((label) =>
     someVMHasConcern(selectedVMs, label)
   );
-  const warmWarningConcernsFound = warmWarningConcerns.filter((label) =>
-    someVMHasConcern(selectedVMs, label)
-  );
-  const warmWarnStatus: StatusType =
-    warmCriticalConcernsFound.length > 0
-      ? 'Error'
-      : warmWarningConcernsFound.length > 0
-      ? 'Warning'
-      : 'Ok';
-
   const isAnalysingVms = selectedVMs.some((vm) => vm.revisionValidated !== vm.revision);
 
   return (
@@ -65,19 +54,14 @@ const TypeForm: React.FunctionComponent<ITypeFormProps> = ({
               <div className={`${spacing.mtMd} ${spacing.mlXs}`}>
                 <StatusIcon status="Loading" label="Analysing warm migration compatibility" />
               </div>
-            ) : warmWarnStatus !== 'Ok' ? (
+            ) : warmCriticalConcernsFound.length > 0 ? (
               <div className={`${spacing.mtMd} ${spacing.mlXs}`}>
                 <StatusIcon
-                  status={warmWarnStatus}
-                  label={
-                    <>
-                      Warm migration {warmWarnStatus === 'Error' ? 'will' : 'might'} fail for one or
-                      more VMs because of the following conditions:
-                    </>
-                  }
+                  status="Error"
+                  label="Warm migration will fail for one or more VMs because of the following conditions:"
                 />
                 <List className={`${spacing.mtSm} ${spacing.mlMd}`}>
-                  {[...warmCriticalConcernsFound, ...warmWarningConcernsFound].map((label) => (
+                  {warmCriticalConcernsFound.map((label) => (
                     <ListItem key={label}>{label}</ListItem>
                   ))}
                 </List>

--- a/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
@@ -11,7 +11,7 @@ const VMConcernsIcon: React.FunctionComponent<IVMConcernsIconProps> = ({
   vm,
 }: IVMConcernsIconProps) => {
   if (vm.revisionValidated !== vm.revision) {
-    return <StatusIcon status="Loading" label="Analyzing" />;
+    return <StatusIcon status="Loading" label="Analysing" />;
   }
   const worstConcern = getMostSevereVMConcern(vm);
   const statusType = getVMConcernStatusType(worstConcern);

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -301,6 +301,9 @@ export const getVMConcernStatusLabel = (concern: IVMwareVMConcern | null): strin
     ? 'Advisory'
     : concern?.category || 'Ok';
 
+export const someVMHasConcern = (vms: IVMwareVM[], concernLabel: string): boolean =>
+  vms.some((vm) => vm.concerns.some((concern) => concern.label === concernLabel));
+
 export interface IGenerateMappingsArgs {
   forms: PlanWizardFormState;
   generateName?: string;

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -372,19 +372,24 @@ export const generatePlan = (
       network: networkMappingRef,
       storage: storageMappingRef,
     },
-    vms: forms.selectVMs.values.selectedVMs.map((vm) => ({ id: vm.id })),
+    vms: forms.selectVMs.values.selectedVMIds.map((id) => ({ id })),
     warm: forms.type.values.type === 'Warm',
   },
 });
+
+export const getSelectedVMsFromIds = (
+  vmIds: string[],
+  vmsQuery: QueryResult<IVMwareVM[]>
+): IVMwareVM[] =>
+  vmIds.map((id) => vmsQuery.data?.find((vm) => vm.id === id)).filter((vm) => !!vm) as IVMwareVM[];
 
 export const getSelectedVMsFromPlan = (
   planBeingEdited: IPlan | null,
   vmsQuery: QueryResult<IVMwareVM[]>
 ): IVMwareVM[] => {
   if (!planBeingEdited) return [];
-  return planBeingEdited.spec.vms
-    .map(({ id }) => vmsQuery.data?.find((vm) => vm.id === id))
-    .filter((vm) => !!vm) as IVMwareVM[];
+  const vmIds = planBeingEdited.spec.vms.map(({ id }) => id);
+  return getSelectedVMsFromIds(vmIds, vmsQuery);
 };
 
 interface IEditingPrefillResults {
@@ -479,7 +484,7 @@ export const useEditingPlanPrefillEffect = (
       forms.filterVMs.fields.selectedTreeNodes.setInitialValue(selectedTreeNodes);
       forms.filterVMs.fields.isPrefilled.setInitialValue(true);
 
-      forms.selectVMs.fields.selectedVMs.setInitialValue(selectedVMs);
+      forms.selectVMs.fields.selectedVMIds.setInitialValue(selectedVMs.map((vm) => vm.id));
 
       forms.networkMapping.fields.builderItems.setInitialValue(
         getBuilderItemsWithMissingSources(

--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -50,7 +50,7 @@ export const getWarmPlanState = (
     if (migration.spec.cutover && pipelineHasStarted) {
       return 'Cutover';
     }
-    if (plan.status?.migration?.vms?.some((vm) => (vm.warm?.precopies.length || 0) > 0)) {
+    if (plan.status?.migration?.vms?.some((vm) => (vm.warm?.precopies?.length || 0) > 0)) {
       return 'Copying';
     }
     return 'Starting';

--- a/src/app/queries/mocks/vms.mock.ts
+++ b/src/app/queries/mocks/vms.mock.ts
@@ -52,6 +52,11 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           assessment:
             'Distributed resource scheduling is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.',
         },
+        {
+          category: 'Information',
+          label: 'VM snapshot detected',
+          assessment: 'Warm migration may not be possible for this VM',
+        },
       ],
       revisionValidated: 1,
     },
@@ -113,7 +118,15 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           datastore: { kind: 'Datastore', id: '1' },
         },
       ],
-      concerns: [{ category: 'Critical', label: 'Example', assessment: 'Something is really bad' }],
+      concerns: [
+        { category: 'Critical', label: 'Example', assessment: 'Something is really bad' },
+        {
+          category: 'Warning',
+          label: 'Changed Block Tracking (CBT) not enabled',
+          assessment:
+            'Changed Block Tracking (CBT) has not been enabled on this VM. This feature is a prerequisite for VM warm migration.',
+        },
+      ],
       revisionValidated: 1,
     },
     {

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -39,7 +39,7 @@ export interface IVMStatus {
     failures: number;
     successes: number;
     nextPrecopyAt?: string; // ISO timestamp
-    precopies: {
+    precopies?: {
       start: string;
       end?: string;
     }[];


### PR DESCRIPTION
Resolves #454

The Type step of the wizard now includes warnings under the "warm migration" option if any of the selected VMs have validation concerns relevant to warm migration (currently just a critical message when CBT not enabled).

VMs selected with a critical concern:
![Screen Shot 2021-03-23 at 1 17 57 PM](https://user-images.githubusercontent.com/811963/112190741-abb81a00-8bdb-11eb-9315-ae6bfe9520f4.png)

If the validation service re-runs analysis on the selected VMs while the user is on this step (for example, because they updated the settings on the VMs in response to these warnings) a spinner will display in place of the warnings while the validation catches up:

![Screen Shot 2021-03-23 at 1 53 37 PM](https://user-images.githubusercontent.com/811963/112195031-df953e80-8bdf-11eb-92ae-29c2f798f47a.png)

The Review step of the wizard now also shows the Migration Type at the bottom as part of the summary:

![Screen Shot 2021-03-23 at 1 29 19 PM](https://user-images.githubusercontent.com/811963/112190895-d30ee700-8bdb-11eb-8516-438dc2aee462.png)
