### PR TITLE
[Backport] Add support for warm migration (selection in wizard, status info on plans table and migration details table, cutover action) (#440)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1181,9 +1181,9 @@
       }
     },
     "@konveyor/lib-ui": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-1.11.0.tgz",
-      "integrity": "sha512-RLL1RvsGL5tnoSY9/3n6qDbAmaz21/T+MHnaqWsg49U39rxVcPdxjxhuDTiN4AaMFY6IZgluHlr62Z5TQMKQfA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-2.1.0.tgz",
+      "integrity": "sha512-fXwtGaTm34ywHiLxmJfHPI4kK1x44lKplytVRyxaaxkwnRngKUL02jDMzIpnMB35E0PDHSysRfdBYyB0RPBMWA==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "yup": "^0.29.3"
@@ -13555,9 +13555,9 @@
       }
     },
     "tslib": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tsutils": {
       "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ts-jest": "^26.4.4",
     "ts-loader": "^7.0.5",
     "tsconfig-paths-webpack-plugin": "^3.3.0",
-    "tslib": "^2.0.0",
+    "tslib": "^2.1.0",
     "typescript": "^3.9.3",
     "url-loader": "^4.1.0",
     "webpack": "^5.17.0",
@@ -92,7 +92,7 @@
     "webpack-merge": "^5.7.3"
   },
   "dependencies": {
-    "@konveyor/lib-ui": "^1.11.0",
+    "@konveyor/lib-ui": "^2.1.0",
     "@patternfly/react-core": "^4.79.2",
     "@patternfly/react-icons": "^4.7.18",
     "@patternfly/react-styles": "^4.7.16",

--- a/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
 import {
   IAnnotatedStorageClass,
@@ -92,7 +92,7 @@ const MappingTargetSelect: React.FunctionComponent<IMappingTargetSelectProps> = 
             <div>
               {hasNoProvisionerWarning ? (
                 <>
-                  <StatusIcon status={StatusType.Warning} className={spacing.mrSm} />
+                  <StatusIcon status="Warning" className={spacing.mrSm} />
                   <TruncatedText className="inline-option-text">{name}</TruncatedText>
                 </>
               ) : (

--- a/src/app/Mappings/components/MappingStatus.tsx
+++ b/src/app/Mappings/components/MappingStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { useResourceQueriesForMapping } from '@app/queries';
 import { MappingType, Mapping } from '@app/queries/types';
@@ -22,12 +22,7 @@ const MappingStatus: React.FunctionComponent<IMappingStatusProps> = ({
     mapping
   );
   const isValid = isMappingValid(mappingType, mapping, availableSources, availableTargets);
-  const icon = (
-    <StatusIcon
-      status={isValid ? StatusType.Ok : StatusType.Error}
-      label={isValid ? 'OK' : 'Invalid'}
-    />
-  );
+  const icon = <StatusIcon status={isValid ? 'Ok' : 'Error'} label={isValid ? 'OK' : 'Invalid'} />;
   return (
     <ResolvedQueries
       results={queries}

--- a/src/app/Plans/components/PlansTable.css
+++ b/src/app/Plans/components/PlansTable.css
@@ -5,3 +5,20 @@
 .pf-c-table.plans-table tbody > tr > * {
   vertical-align: middle;
 }
+
+.pf-c-table.plans-table tbody > tr > td.pf-c-table__toggle {
+  padding-bottom: var(--pf-c-table--tbody--cell--PaddingBottom);
+}
+
+.pf-c-table.plans-table tbody > tr > td.pf-c-table__toggle .pf-c-button {
+  margin-top: 0;
+}
+
+.pf-c-table.plans-table table.expanded-content tr > th {
+  padding-left: 0;
+  font-weight: bold;
+}
+
+.pf-c-table.plans-table table.expanded-content tr > td {
+  padding-left: var(--pf-global--spacer--xl);
+}

--- a/src/app/Plans/components/VMStatusPipelineTable.tsx
+++ b/src/app/Plans/components/VMStatusPipelineTable.tsx
@@ -15,15 +15,15 @@ import { IVMStatus, IStep } from '@app/queries/types';
 import TickingElapsedTime from '@app/common/components/TickingElapsedTime';
 import { findCurrentStep, getStepType, isStepOnError } from '@app/common/helpers';
 
-interface IVMStatusTableProps {
+interface IVMStatusPipelineTableProps {
   status: IVMStatus;
   isCanceled: boolean;
 }
 
-const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
+const VMStatusPipelineTable: React.FunctionComponent<IVMStatusPipelineTableProps> = ({
   status,
   isCanceled,
-}: IVMStatusTableProps) => {
+}: IVMStatusPipelineTableProps) => {
   const columns: ICell[] = [
     {
       title: 'Step',
@@ -97,4 +97,4 @@ const VMStatusTable: React.FunctionComponent<IVMStatusTableProps> = ({
   );
 };
 
-export default VMStatusTable;
+export default VMStatusPipelineTable;

--- a/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { Text, TextContent } from '@patternfly/react-core';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  ICell,
+  IRow,
+  textCenter,
+  fitContent,
+} from '@patternfly/react-table';
+
+import { IVMStatus } from '@app/queries/types';
+import TickingElapsedTime from '@app/common/components/TickingElapsedTime';
+import { StatusIcon } from '@konveyor/lib-ui';
+
+interface IVMStatusPrecopyTableProps {
+  status: IVMStatus;
+  isCanceled: boolean;
+}
+
+const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> = ({
+  status,
+  isCanceled,
+}: IVMStatusPrecopyTableProps) => {
+  if (!status.warm || status.warm.precopies.length === 0) {
+    return (
+      <TextContent>
+        <Text component="p">Preparing to start incremental copies</Text>
+      </TextContent>
+    );
+  }
+
+  const sortedPrecopies = status.warm.precopies.sort((a, b) => {
+    // Most recent first
+    if (a.start < b.start) return 1;
+    if (a.start > b.start) return -1;
+    return 0;
+  });
+
+  const columns: ICell[] = [
+    {
+      title: 'Copy number',
+      columnTransforms: [textCenter, fitContent],
+    },
+    { title: 'Elapsed time' },
+    { title: 'Status' },
+  ];
+
+  const rows: IRow[] = sortedPrecopies.map((precopy, index) => {
+    const consecutiveFailures = (index === 0 && status.warm?.consecutiveFailures) || 0;
+    return {
+      meta: { precopy },
+      cells: [
+        sortedPrecopies.length - index,
+        {
+          title: <TickingElapsedTime start={precopy.start} end={precopy.end || status.completed} />,
+        },
+        {
+          title: precopy.end ? (
+            <StatusIcon status="Ok" label="Complete" />
+          ) : status.error && index === 0 ? (
+            <StatusIcon status="Error" label="Failed" />
+          ) : isCanceled ? (
+            <StatusIcon status="Info" label="Canceled" />
+          ) : (
+            <StatusIcon
+              status="Loading"
+              label={`Copying data${
+                consecutiveFailures > 0 ? ` - Retrying after ${consecutiveFailures} failures` : ''
+              }`}
+            />
+          ),
+        },
+      ],
+    };
+  });
+
+  return (
+    <>
+      <Table
+        className="migration-inner-vmStatus-table"
+        variant="compact"
+        aria-label="VM status table for migration plan"
+        cells={columns}
+        rows={rows}
+      >
+        <TableHeader />
+        <TableBody />
+      </Table>
+    </>
+  );
+};
+
+export default VMStatusPrecopyTable;

--- a/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { IVMStatus } from '@app/queries/types';
+import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { Button, Popover } from '@patternfly/react-core';
+import { getMinutesUntil } from '@app/common/helpers';
+
+interface IWarmVMCopyState {
+  state: 'Starting' | 'Copying' | 'Idle' | 'Failed' | 'Warning';
+  status: StatusType;
+  label: string;
+}
+
+export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
+  if (vmStatus.error) {
+    return {
+      state: 'Failed',
+      status: 'Error',
+      label: 'Failed',
+    };
+  }
+  if (!vmStatus.warm || vmStatus.warm.precopies.length === 0) {
+    return {
+      state: 'Starting',
+      status: 'Loading',
+      label: 'Preparing for incremental copies',
+    };
+  }
+  const { precopies, nextPrecopyAt } = vmStatus.warm;
+  if (precopies.some((copy) => !!copy.start && !copy.end)) {
+    return {
+      state: 'Copying',
+      status: 'Loading',
+      label: 'Performing incremental data copy',
+    };
+  }
+  if (precopies.every((copy) => !!copy.start && !!copy.end)) {
+    return {
+      state: 'Idle',
+      status: 'Paused',
+      label: nextPrecopyAt
+        ? `Idle - Next incremental copy will begin in ${getMinutesUntil(nextPrecopyAt)}`
+        : 'Idle - Waiting for next incremental copy',
+    };
+  }
+  return {
+    state: 'Warning',
+    status: 'Warning',
+    label: 'Unknown',
+  };
+};
+
+interface IVMWarmCopyStatusProps {
+  vmStatus: IVMStatus;
+}
+
+const VMWarmCopyStatus: React.FunctionComponent<IVMWarmCopyStatusProps> = ({
+  vmStatus,
+}: IVMWarmCopyStatusProps) => {
+  if (vmStatus.error) {
+    return (
+      <Popover hasAutoWidth bodyContent={<>{vmStatus.error.reasons.join('; ')}</>}>
+        <Button variant="link" isInline>
+          <StatusIcon status="Error" label="Failed" />
+        </Button>
+      </Popover>
+    );
+  }
+  const { status, label } = getWarmVMCopyState(vmStatus);
+  return <StatusIcon status={status} label={label} />;
+};
+
+export default VMWarmCopyStatus;

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -28,6 +28,7 @@ import {
   IVMwareVM,
   Mapping,
   MappingType,
+  PlanType,
   VMwareTree,
   VMwareTreeType,
 } from '@app/queries/types';
@@ -50,6 +51,7 @@ import { dnsLabelNameSchema } from '@app/common/constants';
 import { IKubeList } from '@app/client/types';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
+import TypeForm from './TypeForm';
 
 const useMappingFormState = (mappingsQuery: QueryResult<IKubeList<Mapping>>) => {
   const isSaveNewMapping = useFormField(false, yup.boolean().required());
@@ -104,6 +106,9 @@ const usePlanWizardFormState = (
     }),
     networkMapping: useMappingFormState(networkMappingsQuery),
     storageMapping: useMappingFormState(storageMappingsQuery),
+    type: useFormState({
+      type: useFormField<PlanType>('Cold', yup.string().oneOf(['Cold', 'Warm']).required()),
+    }),
   };
 
   return {
@@ -150,6 +155,7 @@ const PlanWizard: React.FunctionComponent = () => {
     SelectVMs,
     NetworkMapping,
     StorageMapping,
+    Type,
     Review,
   }
 
@@ -303,6 +309,17 @@ const PlanWizard: React.FunctionComponent = () => {
       ),
       enableNext: forms.storageMapping.isValid,
       canJumpTo: stepIdReached >= StepId.StorageMapping,
+    },
+    {
+      id: StepId.Type,
+      name: 'Type',
+      component: (
+        <WizardStepContainer title="Migration type">
+          <TypeForm form={forms.type} />
+        </WizardStepContainer>
+      ),
+      enableNext: forms.type.isValid,
+      canJumpTo: stepIdReached >= StepId.Type,
     },
     {
       id: StepId.Review,

--- a/src/app/Plans/components/Wizard/TypeForm.tsx
+++ b/src/app/Plans/components/Wizard/TypeForm.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { List, ListItem, Radio } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { PlanWizardFormState } from './PlanWizard';
+
+interface ITypeFormProps {
+  form: PlanWizardFormState['type'];
+}
+
+const TypeForm: React.FunctionComponent<ITypeFormProps> = ({ form }: ITypeFormProps) => (
+  <>
+    <Radio
+      id="migration-type-cold"
+      name="migration-type"
+      label="Cold migration"
+      description={
+        <List>
+          <ListItem>Source VMs are shut down while all of the VM data is migrated.</ListItem>
+        </List>
+      }
+      isChecked={form.values.type === 'Cold'}
+      onChange={() => form.fields.type.setValue('Cold')}
+      className={spacing.mbMd}
+    />
+    <Radio
+      id="migration-type-warm"
+      name="migration-type"
+      label="Warm migration"
+      description={
+        <List>
+          <ListItem>VM data is incrementally copied, leaving source VMs running.</ListItem>
+          <ListItem>
+            A final cutover, which shuts down the source VMs while VM data and metadata are copied,
+            is run later.
+          </ListItem>
+        </List>
+      }
+      isChecked={form.values.type === 'Warm'}
+      onChange={() => form.fields.type.setValue('Warm')}
+    />
+  </>
+);
+
+export default TypeForm;

--- a/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 import { TextContent, Text, List, ListItem, Flex, FlexItem } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PRODUCT_DOCO_LINK } from '@app/common/constants';
@@ -53,7 +53,7 @@ const VMConcernsDescription: React.FunctionComponent<IVMConcernsDescriptionProps
                   }
                 >
                   <FlexItem>
-                    <StatusIcon status={getVMConcernStatusType(concern) || StatusType.Warning} />
+                    <StatusIcon status={getVMConcernStatusType(concern) || 'Warning'} />
                   </FlexItem>
                   <FlexItem>
                     <strong>{concern.label}:</strong> {concern.assessment}

--- a/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IVMwareVM } from '@app/queries/types';
-import { StatusIcon, StatusType } from '@konveyor/lib-ui';
+import { StatusIcon } from '@konveyor/lib-ui';
 
 import { getMostSevereVMConcern, getVMConcernStatusLabel, getVMConcernStatusType } from './helpers';
 interface IVMConcernsIconProps {
@@ -11,7 +11,7 @@ const VMConcernsIcon: React.FunctionComponent<IVMConcernsIconProps> = ({
   vm,
 }: IVMConcernsIconProps) => {
   if (vm.revisionValidated !== vm.revision) {
-    return <StatusIcon status={StatusType.Loading} label="Analyzing" />;
+    return <StatusIcon status="Loading" label="Analyzing" />;
   }
   const worstConcern = getMostSevereVMConcern(vm);
   const statusType = getVMConcernStatusType(worstConcern);

--- a/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -71,7 +71,7 @@ describe('<AddEditProviderModal />', () => {
 
   it('allows to edit a plan', async () => {
     const history = createMemoryHistory();
-    history.push('/plans/plantest-2/edit');
+    history.push('/plans/plantest-02/edit');
     render(
       <NetworkContextProvider>
         <Router history={history}>
@@ -85,14 +85,14 @@ describe('<AddEditProviderModal />', () => {
         'Migration plans'
       );
       expect(screen.getByRole('navigation', { name: /Breadcrumb/ })).toHaveTextContent(
-        'plantest-2'
+        'plantest-02'
       );
       expect(screen.getByRole('navigation', { name: /Breadcrumb/ })).toHaveTextContent('Edit');
       expect(screen.getByRole('link', { name: /Migration plans/ })).toBeInTheDocument();
       expect(screen.getByRole('heading', { name: /Edit migration plan/ })).toBeInTheDocument();
 
       expect(screen.getByRole('heading', { name: /General settings/ })).toBeInTheDocument();
-      expect(screen.getByText(/plantest-2/i)).toBeInTheDocument();
+      expect(screen.getByText(/plantest-02/i)).toBeInTheDocument();
       expect(screen.getByText(/my 2nd plan/i)).toBeInTheDocument();
       expect(screen.getByText(/vcenter-1/i)).toBeInTheDocument();
       expect(screen.getByText(/ocpv-1/i)).toBeInTheDocument();
@@ -127,6 +127,11 @@ describe('<AddEditProviderModal />', () => {
     const storageTarget = screen.getByRole('textbox', { name: /select target.../i });
     expect(storageTarget).toHaveValue('standard (default)');
     expect(screen.getByRole('checkbox', { name: /save mapping checkbox/ })).not.toBeChecked();
+    await waitFor(() => expect(nextButton).toBeEnabled());
+    userEvent.click(nextButton);
+
+    expect(screen.getByRole('heading', { name: /Migration type/ })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Cold migration/)).toHaveAttribute('checked');
     await waitFor(() => expect(nextButton).toBeEnabled());
     userEvent.click(nextButton);
 

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -287,13 +287,13 @@ export const getMostSevereVMConcern = (vm: IVMwareVM): IVMwareVMConcern | null =
 
 export const getVMConcernStatusType = (concern: IVMwareVMConcern | null): StatusType | null =>
   !concern
-    ? StatusType.Ok
+    ? 'Ok'
     : concern.category === 'Critical'
-    ? StatusType.Error
+    ? 'Error'
     : concern.category === 'Warning'
-    ? StatusType.Warning
+    ? 'Warning'
     : concern.category === 'Information' || concern.category === 'Advisory'
-    ? StatusType.Info
+    ? 'Info'
     : null;
 
 export const getVMConcernStatusLabel = (concern: IVMwareVMConcern | null): string =>
@@ -370,6 +370,7 @@ export const generatePlan = (
       storage: storageMappingRef,
     },
     vms: forms.selectVMs.values.selectedVMs.map((vm) => ({ id: vm.id })),
+    warm: forms.type.values.type === 'Warm',
   },
 });
 
@@ -508,6 +509,8 @@ export const useEditingPlanPrefillEffect = (
         )
       );
       forms.storageMapping.fields.isPrefilled.setInitialValue(true);
+
+      forms.type.fields.type.setValue(planBeingEdited.spec.warm ? 'Warm' : 'Cold');
 
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {

--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -1,5 +1,7 @@
 import { PlanStatusType, PlanStatusDisplayType } from '@app/common/constants';
+import { hasCondition } from '@app/common/helpers';
 import { IPlan } from '@app/queries/types';
+import { IMigration } from '@app/queries/types/migrations.types';
 
 export const getPlanStatusTitle = (plan: IPlan): string => {
   const condition = plan.status?.conditions.find(
@@ -10,4 +12,55 @@ export const getPlanStatusTitle = (plan: IPlan): string => {
       condition.type === PlanStatusType.Failed
   );
   return condition ? PlanStatusDisplayType[condition.type] : '';
+};
+
+// TODO maybe generalize this for cold migrations too
+type WarmPlanState =
+  | 'NotStarted'
+  | 'Starting'
+  | 'Copying'
+  | 'AbortedCopying'
+  | 'StartingCutover'
+  | 'Cutover'
+  | 'Finished';
+
+export const getWarmPlanState = (
+  plan: IPlan | null,
+  migration: IMigration | null
+): WarmPlanState | null => {
+  if (!plan || !plan.spec.warm) return null;
+  if (!migration) return 'NotStarted';
+  if (!!migration && (plan.status?.migration?.vms?.length || 0) === 0) return 'Starting';
+  const conditions = plan.status?.conditions || [];
+  if (
+    (hasCondition(conditions, PlanStatusType.Canceled) ||
+      hasCondition(conditions, PlanStatusType.Failed)) &&
+    !migration.spec.cutover
+  ) {
+    return 'AbortedCopying';
+  }
+  if (!!migration && !!plan.status?.migration?.completed) return 'Finished';
+  if (hasCondition(conditions, PlanStatusType.Executing)) {
+    const pipelineHasStarted = plan.status?.migration?.vms?.some((vm) =>
+      vm.pipeline.some((step) => !!step.started)
+    );
+    if (migration.spec.cutover && !pipelineHasStarted) {
+      return 'StartingCutover';
+    }
+    if (migration.spec.cutover && pipelineHasStarted) {
+      return 'Cutover';
+    }
+    if (plan.status?.migration?.vms?.some((vm) => (vm.warm?.precopies.length || 0) > 0)) {
+      return 'Copying';
+    }
+    return 'Starting';
+  }
+  if (
+    hasCondition(conditions, PlanStatusType.Succeeded) ||
+    hasCondition(conditions, PlanStatusType.Canceled) ||
+    hasCondition(conditions, PlanStatusType.Failed)
+  ) {
+    return 'Finished';
+  }
+  return null;
 };

--- a/src/app/common/components/StatusCondition.tsx
+++ b/src/app/common/components/StatusCondition.tsx
@@ -14,19 +14,19 @@ const StatusCondition: React.FunctionComponent<IStatusConditionProps> = ({
   status = {},
   unknownFallback = null,
 }: IStatusConditionProps) => {
-  const getStatusType = (severity: string) => {
+  const getStatusType = (severity: string): StatusType => {
     if (status) {
       if (severity === PlanStatusType.Ready) {
-        return StatusType.Ok;
+        return 'Ok';
       }
       if (severity === StatusCategoryType.Advisory) {
-        return StatusType.Info;
+        return 'Info';
       }
       if (severity === StatusCategoryType.Critical || severity === StatusCategoryType.Error) {
-        return StatusType.Error;
+        return 'Error';
       }
     }
-    return StatusType.Warning;
+    return 'Warning';
   };
 
   if (status) {

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -119,3 +119,10 @@ export const getObjectRef = (cr: ICR): IObjectReference => ({
   namespace: cr.metadata.namespace,
   uid: cr.metadata.uid,
 });
+
+export const getMinutesUntil = (timestamp: Date | string): string => {
+  const minutes = dayjs(timestamp).diff(dayjs(), 'minute');
+  if (minutes <= 0) return 'less than 1 minute';
+  if (minutes === 1) return '1 minute';
+  return `${minutes} minutes`;
+};

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -46,7 +46,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         {
           apiVersion: CLUSTER_API_VERSION,
           kind: 'Plan',
-          name: 'plantest-1',
+          name: 'plantest-01',
           namespace: 'openshift-migration',
           uid: '28fde094-b667-4d21-8f29-27c18f22178c',
         },
@@ -150,7 +150,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         {
           apiVersion: CLUSTER_API_VERSION,
           kind: 'Plan',
-          name: 'plantest-1',
+          name: 'plantest-01',
           namespace: 'openshift-migration',
           uid: '28fde094-b667-4d21-8f29-27c18f22178c',
         },

--- a/src/app/queries/mocks/migrations.mock.ts
+++ b/src/app/queries/mocks/migrations.mock.ts
@@ -6,72 +6,28 @@ import { MOCK_PLANS } from './plans.mock';
 export let MOCK_MIGRATIONS: IMigration[];
 
 if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-  MOCK_MIGRATIONS = [
-    {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-0-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[0].metadata),
-      },
-      status: MOCK_PLANS[0].status?.migration,
+  const runningPlanIndexes = [0, 2, 3, 4, 6, 7, 8];
+  MOCK_MIGRATIONS = runningPlanIndexes.map((index) => ({
+    apiVersion: CLUSTER_API_VERSION,
+    kind: 'Migration',
+    metadata: {
+      name: `plan-${index}-mock-migration`,
+      namespace: META.namespace,
     },
-    {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-1-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[1].metadata),
-      },
-      status: MOCK_PLANS[1].status?.migration,
+    spec: {
+      plan: nameAndNamespace(MOCK_PLANS[index].metadata),
     },
+    status: MOCK_PLANS[index].status?.migration,
+  }));
+
+  // plantest-03 (plan index 2) has a canceled VM
+  MOCK_MIGRATIONS[1].spec.cancel = [
     {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-2-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[2].metadata),
-        cancel: [
-          {
-            id: 'vm-1630',
-            name: 'fdupont-test-migration',
-          },
-        ],
-      },
-      status: MOCK_PLANS[2].status?.migration,
-    },
-    {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-3-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[3].metadata),
-      },
-      status: MOCK_PLANS[3].status?.migration,
-    },
-    {
-      apiVersion: CLUSTER_API_VERSION,
-      kind: 'Migration',
-      metadata: {
-        name: 'plan-4-mock-migration',
-        namespace: META.namespace,
-      },
-      spec: {
-        plan: nameAndNamespace(MOCK_PLANS[4].metadata),
-      },
-      status: MOCK_PLANS[4].status?.migration,
+      id: 'vm-1630',
+      name: 'fdupont-test-migration',
     },
   ];
+
+  // plantest-8 (plan index 7) is in cutover
+  MOCK_MIGRATIONS[5].spec.cutover = '2021-03-16T18:31:30Z';
 }

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -28,14 +28,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     id: vm1.id,
     pipeline: [
       {
-        name: 'PreHook',
-        description: 'Pre hook',
-        progress: { total: 2, completed: 2 },
-        phase: 'Mock Step Phase',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
-      {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
         progress: { total: 1024 * 64, completed: 1024 * 30 },
@@ -51,12 +43,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         phase: 'Mock Step Phase',
         started: '2020-10-10T15:57:10Z',
       },
-      {
-        name: 'PostHook',
-        description: 'Post hook',
-        progress: { total: 2, completed: 0 },
-        phase: 'Mock Step Phase',
-      },
     ],
     phase: 'Mock VM Phase',
     started: '2020-10-10T14:04:10Z',
@@ -65,14 +51,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const vmStatus2: IVMStatus = {
     id: vm2.id,
     pipeline: [
-      {
-        name: 'PreHook',
-        description: 'Pre hook',
-        progress: { total: 1, completed: 1 },
-        phase: 'Mock Step Phase',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
       {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
@@ -89,12 +67,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         phase: 'Mock Step Phase',
         started: '2020-10-10T15:57:10Z',
       },
-      {
-        name: 'PostHook',
-        description: 'Post hook',
-        progress: { total: 1, completed: 0 },
-        phase: 'Mock Step Phase',
-      },
     ],
     phase: 'Mock VM Phase',
     started: '2020-10-10T14:04:10Z',
@@ -103,14 +75,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const vmStatus3: IVMStatus = {
     id: vm3.id,
     pipeline: [
-      {
-        name: 'PreHook',
-        description: 'Pre hook',
-        progress: { total: 2, completed: 2 },
-        phase: 'Latest message from controller',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
       {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
@@ -138,14 +102,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     id: vm4.id,
     pipeline: [
       {
-        name: 'PreHook',
-        description: 'Pre Hook',
-        progress: { total: 2, completed: 2 },
-        phase: 'Latest message from controller',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
-      {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
         progress: { total: 1024 * 64, completed: 1024 * 64 },
@@ -167,12 +123,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           ],
         },
       },
-      {
-        name: 'PostHook',
-        description: 'Post Hook',
-        progress: { total: 1, completed: 0 },
-        phase: 'Mock Step Phase',
-      },
     ],
     phase: 'Mock VM Phase',
     started: '2020-10-10T14:04:10Z',
@@ -189,14 +139,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     id: vm2.id,
     pipeline: [
       {
-        name: 'PreHook',
-        description: 'Pre hook',
-        progress: { total: 1, completed: 1 },
-        phase: 'Mock Step Phase',
-        started: '2020-10-10T14:04:10Z',
-        completed: '2020-10-10T14:21:10Z',
-      },
-      {
         name: 'DiskTransfer',
         description: 'Transfer disks.',
         progress: { total: 1024 * 64, completed: 0 },
@@ -206,12 +148,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       {
         name: 'ImageConversion',
         description: 'Convert image to kubevirt.',
-        progress: { total: 1, completed: 0 },
-        phase: 'Mock Step Phase',
-      },
-      {
-        name: 'PostHook',
-        description: 'Post hook',
         progress: { total: 1, completed: 0 },
         phase: 'Mock Step Phase',
       },
@@ -226,12 +162,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-1',
+      name: 'plantest-01',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-1',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-01',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -247,6 +183,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm1, vm2],
+      warm: false,
     },
     status: {
       conditions: [
@@ -288,7 +225,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-1',
+              name: 'plantest-01',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -302,12 +239,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-2',
+      name: 'plantest-02',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-2',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-02',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -324,6 +261,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm1],
+      warm: false,
     },
     status: {
       conditions: [
@@ -344,9 +282,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     ...vmStatus1,
     pipeline: [
       vmStatus1.pipeline[0],
-      vmStatus1.pipeline[1],
-      { ...vmStatus1.pipeline[2], completed: '2020-10-10T17:34:10Z' },
-      vmStatus1.pipeline[3],
+      { ...vmStatus1.pipeline[1], completed: '2020-10-10T17:34:10Z' },
     ],
     conditions: [
       {
@@ -363,12 +299,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-3',
+      name: 'plantest-03',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825023',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-3',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-03',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -384,6 +320,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm1, vm2, vm3, vm4],
+      warm: false,
     },
     status: {
       conditions: [
@@ -409,7 +346,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-3',
+              name: 'plantest-03',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -423,12 +360,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-4',
+      name: 'plantest-04',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-4',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-04',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -444,6 +381,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm3],
+      warm: false,
     },
     status: {
       conditions: [
@@ -470,7 +408,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-4',
+              name: 'plantest-04',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -483,16 +421,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   const vmStatus1WithError: IVMStatus = {
     ...vmStatus1,
     pipeline: [
-      vmStatus1.pipeline[0],
       {
-        ...vmStatus1.pipeline[1],
+        ...vmStatus1.pipeline[0],
         error: {
           phase: 'DiskTransferFailed',
           reasons: ['Error transferring disks'],
         },
       },
-      { ...vmStatus1.pipeline[2], started: undefined },
-      vmStatus1.pipeline[3],
+      { ...vmStatus1.pipeline[1], started: undefined },
     ],
     error: {
       phase: 'DiskTransfer',
@@ -504,16 +440,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     ...vmStatus1,
     pipeline: [
       vmStatus1.pipeline[0],
-      vmStatus1.pipeline[1],
       {
-        ...vmStatus1.pipeline[2],
+        ...vmStatus1.pipeline[1],
         completed: '2020-10-10T15:58:10Z',
         error: {
           phase: 'ImageConversionFailed',
           reasons: ['Error converting image'],
         },
       },
-      vmStatus1.pipeline[3],
     ],
     error: {
       phase: 'ImageConversion',
@@ -523,7 +457,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
 
   const plan5: IPlan = {
     ...plan1,
-    metadata: { ...plan1.metadata, name: 'plantest-5' },
+    metadata: { ...plan1.metadata, name: 'plantest-05' },
     spec: { ...plan1.spec, description: 'completed with errors' },
     status: {
       conditions: [
@@ -549,7 +483,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               namespace: META.namespace,
             },
             plan: {
-              name: 'plantest-5',
+              name: 'plantest-05',
               namespace: 'openshift-migration',
             },
             provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
@@ -563,17 +497,17 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Plan',
     metadata: {
-      name: 'plantest-6',
+      name: 'plantest-06',
       namespace: 'openshift-migration',
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-2',
+        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-06',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
     spec: {
-      description: 'has a non-ready provider',
+      description: 'newly created warm plan',
       provider: {
         source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),
@@ -584,6 +518,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
       },
       vms: [vm1],
+      warm: true,
     },
     status: {
       conditions: [
@@ -600,5 +535,211 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6];
+  const warmVmPrecopying: IVMStatus = {
+    ...vmStatus1,
+    pipeline: vmStatus1.pipeline.map((step) => {
+      // Remove started/completed/progress
+      const { name, description, phase, annotations } = step;
+      return {
+        name,
+        description,
+        progress: { ...step.progress, completed: 0 },
+        phase,
+        annotations,
+      };
+    }),
+    warm: {
+      consecutiveFailures: 0,
+      failures: 0,
+      precopies: [
+        {
+          start: '2021-03-16T17:28:48Z',
+        },
+      ],
+      successes: 0,
+    },
+  };
+
+  const warmVmWithConsecutiveFailures: IVMStatus = {
+    ...vmStatus2,
+    pipeline: warmVmPrecopying.pipeline,
+    warm: {
+      consecutiveFailures: 2,
+      failures: 0,
+      precopies: [
+        {
+          start: '2021-03-16T17:28:48Z',
+          end: '2021-03-16T17:29:42Z',
+        },
+        {
+          start: '2021-03-16T18:29:20Z',
+          end: '2021-03-16T18:30:38Z',
+        },
+        {
+          start: '2021-03-16T18:30:38Z',
+        },
+      ],
+      successes: 0,
+    },
+  };
+
+  const warmVmPrecopyingWithError: IVMStatus = {
+    ...warmVmPrecopying,
+    completed: '2021-03-16T19:13:48Z',
+    error: { phase: 'Mock Error', reasons: ['Something went wrong with a precopy?'] },
+  };
+
+  const warmVmIdle: IVMStatus = {
+    ...vmStatus3,
+    completed: undefined,
+    pipeline: warmVmPrecopying.pipeline,
+    warm: {
+      consecutiveFailures: 0,
+      failures: 0,
+      nextPrecopyAt: '2021-03-16T18:29:20Z',
+      precopies: [
+        {
+          start: '2021-03-16T17:28:48Z',
+          end: '2021-03-16T17:29:42Z',
+        },
+        {
+          start: '2021-03-16T18:29:20Z',
+          end: '2021-03-16T18:30:38Z',
+        },
+        {
+          start: '2021-03-16T18:30:38Z',
+          end: '2021-03-16T18:31:48Z',
+        },
+      ],
+      successes: 3,
+    },
+  };
+
+  const warmVmCuttingOver1: IVMStatus = {
+    ...vmStatus1,
+    warm: warmVmIdle.warm,
+  };
+
+  const warmVmCuttingOver2: IVMStatus = {
+    ...vmStatus2,
+    warm: warmVmIdle.warm,
+  };
+
+  const warmVmCuttingOver3: IVMStatus = {
+    ...vmStatus3,
+    warm: warmVmIdle.warm,
+  };
+
+  const plan7: IPlan = {
+    ...plan1,
+    metadata: { ...plan1.metadata, name: 'plantest-07' },
+    spec: {
+      ...plan1.spec,
+      description: 'various precopy states',
+      warm: true,
+      vms: [vm1, vm2, vm3],
+    },
+    status: {
+      conditions: [
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'In progress',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Executing',
+        },
+      ],
+      observedGeneration: 2,
+      migration: {
+        active: '',
+        started: '2020-10-10T14:04:10Z',
+        vms: [warmVmPrecopying, warmVmWithConsecutiveFailures, warmVmIdle],
+        history: [
+          {
+            conditions: [],
+            migration: {
+              name: 'plan-6-mock-migration',
+              namespace: META.namespace,
+            },
+            plan: {
+              name: 'plantest-07',
+              namespace: 'openshift-migration',
+            },
+            provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+          },
+        ],
+      },
+    },
+  };
+
+  const plan8: IPlan = {
+    ...plan1,
+    metadata: { ...plan1.metadata, name: 'plantest-08' },
+    spec: { ...plan7.spec, description: 'cutover started', vms: [vm1, vm2, vm3] },
+    status: {
+      conditions: plan7.status?.conditions || [],
+      observedGeneration: 2,
+      migration: {
+        active: '',
+        started: '2020-10-10T14:04:10Z',
+        vms: [warmVmCuttingOver1, warmVmCuttingOver2, warmVmCuttingOver3],
+        history: [
+          {
+            conditions: [],
+            migration: {
+              name: 'plan-7-mock-migration',
+              namespace: META.namespace,
+            },
+            plan: {
+              name: 'plantest-08',
+              namespace: 'openshift-migration',
+            },
+            provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+          },
+        ],
+      },
+    },
+  };
+
+  const plan9: IPlan = {
+    ...plan1,
+    metadata: { ...plan1.metadata, name: 'plantest-09' },
+    spec: { ...plan7.spec, description: 'failed before cutover' },
+    status: {
+      conditions: [
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-10-10T15:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Failed',
+        },
+      ],
+      observedGeneration: 2,
+      migration: {
+        active: '',
+        started: '2020-10-10T14:04:10Z',
+        completed: '2020-10-10T15:04:10Z',
+        vms: [warmVmPrecopyingWithError],
+        history: [
+          {
+            conditions: [],
+            migration: {
+              name: 'plan-8-mock-migration',
+              namespace: META.namespace,
+            },
+            plan: {
+              name: 'plantest-09',
+              namespace: 'openshift-migration',
+            },
+            provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+          },
+        ],
+      },
+    },
+  };
+
+  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6, plan7, plan8, plan9];
 }

--- a/src/app/queries/types/migrations.types.ts
+++ b/src/app/queries/types/migrations.types.ts
@@ -12,6 +12,7 @@ export interface IMigration extends ICR {
   spec: {
     plan: INameNamespaceRef;
     cancel?: ICanceledVM[];
+    cutover?: string; // ISO timestamp
   };
   status?: IPlanStatus['migration'];
 }

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -34,6 +34,16 @@ export interface IVMStatus {
   started?: string;
   completed?: string;
   conditions?: IStatusCondition[];
+  warm?: {
+    consecutiveFailures: number;
+    failures: number;
+    successes: number;
+    nextPrecopyAt?: string; // ISO timestamp
+    precopies: {
+      start: string;
+      end?: string;
+    }[];
+  };
 }
 
 export interface IPlanVM {
@@ -73,6 +83,10 @@ export interface IPlan extends ICR {
       storage: INameNamespaceRef;
     };
     vms: IPlanVM[];
+    warm: boolean;
+    cutover?: string; // ISO timestamp -- default for all migrations of this plan?
   };
   status?: IPlanStatus;
 }
+
+export type PlanType = 'Cold' | 'Warm';


### PR DESCRIPTION
Backports #440.

* Add wizard step for migration type

* Add warm and cutover properties to plan spec

* Add Type column to plans table, fix mock data

* Add stub expandable content to plan rows and fix spacing on expand toggle

* Move providers and VMs from columns to expanded content

* Add mutation for setting cutover time, simplify logic for start/cutover status spinner

* Specify warm property on plan CR

* Fix test

* Fix React validateDOMNesting warning

* Fix nested table styles

* Add warm type to plan status

* Fix warm/cold type not being prefilled when editing a warm migration

* TODO

* Implement plan-level warm migration status, add TODOs

* Fix mock data and logic for plan-level status

* Handle case where cutover is set but not started yet

* Better logic for when to show spinners in the actions column

* Remove mocked pipeline steps for pre/post hooks to avoid confusion

* Add VMStatusPrecopyTable and conditional columns for VMMigrationDetails

* Fix edge cases, handle case where migration failed before cutover

* Handle pending case and add better mock plan descriptions

* One more tweak to pending case in warm migrations

* last plan description

* Add logic for VM-level precopy status column (still needs countdown to next copy)

* Upgrade lib-ui and fix type errors caused by StatusType breaking change

* Display minutes until next precopy

* Improve mock data, display consecutive failures in precopy table

* Fix errors in cold migration mocks after removing hook steps

* Fix mock data showing a VM in precopy as not cancelable

* Fix elapsed time ticking after fatal errors during precopy in mock mode