### PR TITLE
Add required asterisk to Name field when saving a mapping to use again in the plan wizard

### DIFF
--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -268,6 +268,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
                           field={form.fields.newMappingName}
                           label="Name"
                           fieldId="new-mapping-name"
+                          isRequired
                         />
                       </GridItem>
                     </Grid>


### PR DESCRIPTION
Noticed in the usability study review meeting. Trivial fix, so there's no associated issue or BZ.