### PR TITLE
For QE: Add id to the create plan buttons, change the text to consistently say 'Create plan'

### DIFF
--- a/src/app/Plans/components/CreatePlanButton.tsx
+++ b/src/app/Plans/components/CreatePlanButton.tsx
@@ -7,12 +7,10 @@ import { useHistory } from 'react-router-dom';
 
 interface ICreatePlanButtonProps {
   variant?: ButtonProps['variant'];
-  label?: string;
 }
 
 const CreatePlanButton: React.FunctionComponent<ICreatePlanButtonProps> = ({
   variant = 'primary',
-  label = 'Create migration plan',
 }: ICreatePlanButtonProps) => {
   const sufficientProvidersQuery = useHasSufficientProvidersQuery();
   const { hasSufficientProviders } = sufficientProvidersQuery;
@@ -27,8 +25,9 @@ const CreatePlanButton: React.FunctionComponent<ICreatePlanButtonProps> = ({
           onClick={() => history.push('/plans/create')}
           isDisabled={!hasSufficientProviders}
           variant={variant}
+          id="create-plan-button"
         >
-          {label}
+          Create plan
         </Button>
       </div>
     </ConditionalTooltip>

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -371,7 +371,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
               />
             </FlexItem>
             <FlexItem>
-              <CreatePlanButton variant="secondary" label="Create plan" />
+              <CreatePlanButton variant="secondary" />
             </FlexItem>
           </Flex>
         </LevelItem>


### PR DESCRIPTION
Currently the plans page has a button "Create migration plan" on the empty state when there are no plans to display, but when there are plans, the button at the top of the table says "Create plan". This PR changes them to consistently say "Create plan" for both, and also adds an id to those buttons for ease of selection in QE tests.