### PR TITLE
[Backport] Add required asterisk to Name field when saving a mapping to use agai…

### DIFF
--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -268,6 +268,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
                           field={form.fields.newMappingName}
                           label="Name"
                           fieldId="new-mapping-name"
+                          isRequired
                         />
                       </GridItem>
                     </Grid>


### PR DESCRIPTION
Add required asterisk to Name field when saving a mapping to use again in the plan wizard (#461)

(cherry picked from commit 92ce49afcfbcf77b344d435fd40f318d893607d7)