### PR TITLE
[Backport] Add id to the create plan buttons, change the text to consistently…

### DIFF
--- a/src/app/Plans/components/CreatePlanButton.tsx
+++ b/src/app/Plans/components/CreatePlanButton.tsx
@@ -7,12 +7,10 @@ import { useHistory } from 'react-router-dom';
 
 interface ICreatePlanButtonProps {
   variant?: ButtonProps['variant'];
-  label?: string;
 }
 
 const CreatePlanButton: React.FunctionComponent<ICreatePlanButtonProps> = ({
   variant = 'primary',
-  label = 'Create migration plan',
 }: ICreatePlanButtonProps) => {
   const sufficientProvidersQuery = useHasSufficientProvidersQuery();
   const { hasSufficientProviders } = sufficientProvidersQuery;
@@ -27,8 +25,9 @@ const CreatePlanButton: React.FunctionComponent<ICreatePlanButtonProps> = ({
           onClick={() => history.push('/plans/create')}
           isDisabled={!hasSufficientProviders}
           variant={variant}
+          id="create-plan-button"
         >
-          {label}
+          Create plan
         </Button>
       </div>
     </ConditionalTooltip>

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -288,7 +288,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
               />
             </FlexItem>
             <FlexItem>
-              <CreatePlanButton variant="secondary" label="Create plan" />
+              <CreatePlanButton variant="secondary" />
             </FlexItem>
           </Flex>
         </LevelItem>


### PR DESCRIPTION
Add id to the create plan buttons, change the text to consistently say 'create plan' (#469)

Co-authored-by: Gilles Dubreuil <gilles@redhat.com>
(cherry picked from commit c15158d3772294b7a5c89bf0709f5f34f4183220)