### PR TITLE
[Backport] Warm migration followup: warn when selecting warm with incompatible…

### DIFF
--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -117,7 +117,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
             getTotalCopiedRatio(vmStatus).completed,
             getPipelineSummaryTitle(vmStatus),
           ]
-        : [vmStatus.warm?.precopies.length || 0, getWarmVMCopyState(vmStatus).state]),
+        : [vmStatus.warm?.precopies?.length || 0, getWarmVMCopyState(vmStatus).state]),
     ];
   };
 
@@ -281,7 +281,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
               { title: <PipelineSummary status={vmStatus} isCanceled={isCanceled} /> },
             ]
           : [
-              vmStatus.warm?.precopies.length || 0,
+              vmStatus.warm?.precopies?.length || 0,
               { title: <VMWarmCopyStatus vmStatus={vmStatus} /> },
             ]),
       ],

--- a/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -23,7 +23,7 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
   status,
   isCanceled,
 }: IVMStatusPrecopyTableProps) => {
-  if (!status.warm || status.warm.precopies.length === 0) {
+  if (!status.warm || status.warm.precopies?.length === 0) {
     return (
       <TextContent>
         <Text component="p">Preparing to start incremental copies</Text>
@@ -31,7 +31,7 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
     );
   }
 
-  const sortedPrecopies = status.warm.precopies.sort((a, b) => {
+  const sortedPrecopies = (status.warm.precopies || []).sort((a, b) => {
     // Most recent first
     if (a.start < b.start) return 1;
     if (a.start > b.start) return -1;

--- a/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -18,7 +18,7 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
       label: 'Failed',
     };
   }
-  if (!vmStatus.warm || vmStatus.warm.precopies.length === 0) {
+  if (!vmStatus.warm || (vmStatus.warm.precopies || []).length === 0) {
     return {
       state: 'Starting',
       status: 'Loading',
@@ -26,14 +26,14 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
     };
   }
   const { precopies, nextPrecopyAt } = vmStatus.warm;
-  if (precopies.some((copy) => !!copy.start && !copy.end)) {
+  if ((precopies || []).some((copy) => !!copy.start && !copy.end)) {
     return {
       state: 'Copying',
       status: 'Loading',
       label: 'Performing incremental data copy',
     };
   }
-  if (precopies.every((copy) => !!copy.start && !!copy.end)) {
+  if ((precopies || []).every((copy) => !!copy.start && !!copy.end)) {
     return {
       state: 'Idle',
       status: 'Paused',

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -12,7 +12,7 @@ import {
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlanWizardFormState } from './PlanWizard';
 import MappingDetailView from '@app/Mappings/components/MappingDetailView';
-import { IPlan, Mapping, MappingType, POD_NETWORK } from '@app/queries/types';
+import { IPlan, IVMwareVM, Mapping, MappingType, POD_NETWORK } from '@app/queries/types';
 import { MutationResult } from 'react-query';
 import { IKubeResponse, KubeClientError } from '@app/client/types';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
@@ -27,6 +27,7 @@ interface IReviewProps {
   )[];
   allMutationErrorTitles: string[];
   planBeingEdited: IPlan | null;
+  selectedVMs: IVMwareVM[];
 }
 
 const Review: React.FunctionComponent<IReviewProps> = ({
@@ -34,6 +35,7 @@ const Review: React.FunctionComponent<IReviewProps> = ({
   allMutationResults,
   allMutationErrorTitles,
   planBeingEdited,
+  selectedVMs,
 }: IReviewProps) => {
   usePausedPollingEffect();
 
@@ -70,14 +72,14 @@ const Review: React.FunctionComponent<IReviewProps> = ({
             headerContent={<div>Selected VMs</div>}
             bodyContent={
               <List>
-                {forms.selectVMs.values.selectedVMs.map((vm, index) => (
+                {selectedVMs.map((vm, index) => (
                   <li key={index}>{vm.name}</li>
                 ))}
               </List>
             }
           >
             <Button variant="link" isInline>
-              {forms.selectVMs.values.selectedVMs.length}
+              {selectedVMs.length}
             </Button>
           </Popover>
         </GridItem>
@@ -89,6 +91,8 @@ const Review: React.FunctionComponent<IReviewProps> = ({
         <GridItem md={9}>
           <MappingDetailView mappingType={MappingType.Storage} mapping={storageMapping} />
         </GridItem>
+        <GridItem md={3}>Migration type</GridItem>
+        <GridItem md={9}>{forms.type.values.type}</GridItem>
       </Grid>
       <ResolvedQueries
         results={allMutationResults}

--- a/src/app/Plans/components/Wizard/TypeForm.tsx
+++ b/src/app/Plans/components/Wizard/TypeForm.tsx
@@ -2,43 +2,78 @@ import * as React from 'react';
 import { List, ListItem, Radio } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlanWizardFormState } from './PlanWizard';
+import { IVMwareVM } from '@app/queries/types';
+import { someVMHasConcern } from './helpers';
+import { StatusIcon } from '@konveyor/lib-ui';
+
+const warmCriticalConcerns = ['Changed Block Tracking (CBT) not enabled'];
 
 interface ITypeFormProps {
   form: PlanWizardFormState['type'];
+  selectedVMs: IVMwareVM[];
 }
 
-const TypeForm: React.FunctionComponent<ITypeFormProps> = ({ form }: ITypeFormProps) => (
-  <>
-    <Radio
-      id="migration-type-cold"
-      name="migration-type"
-      label="Cold migration"
-      description={
-        <List>
-          <ListItem>Source VMs are shut down while all of the VM data is migrated.</ListItem>
-        </List>
-      }
-      isChecked={form.values.type === 'Cold'}
-      onChange={() => form.fields.type.setValue('Cold')}
-      className={spacing.mbMd}
-    />
-    <Radio
-      id="migration-type-warm"
-      name="migration-type"
-      label="Warm migration"
-      description={
-        <List>
-          <ListItem>VM data is incrementally copied, leaving source VMs running.</ListItem>
-          <ListItem>
-            A final cutover, which shuts down the source VMs while VM data and metadata are copied,
-            is run later.
-          </ListItem>
-        </List>
-      }
-      isChecked={form.values.type === 'Warm'}
-      onChange={() => form.fields.type.setValue('Warm')}
-    />
-  </>
-);
+const TypeForm: React.FunctionComponent<ITypeFormProps> = ({
+  form,
+  selectedVMs,
+}: ITypeFormProps) => {
+  const warmCriticalConcernsFound = warmCriticalConcerns.filter((label) =>
+    someVMHasConcern(selectedVMs, label)
+  );
+  const isAnalysingVms = selectedVMs.some((vm) => vm.revisionValidated !== vm.revision);
+
+  return (
+    <>
+      <Radio
+        id="migration-type-cold"
+        name="migration-type"
+        label="Cold migration"
+        description={
+          <List>
+            <ListItem>Source VMs are shut down while all of the VM data is migrated.</ListItem>
+          </List>
+        }
+        isChecked={form.values.type === 'Cold'}
+        onChange={() => form.fields.type.setValue('Cold')}
+        className={spacing.mbMd}
+      />
+      <Radio
+        id="migration-type-warm"
+        name="migration-type"
+        label="Warm migration"
+        description={
+          <>
+            <List>
+              <ListItem>VM data is incrementally copied, leaving source VMs running.</ListItem>
+              <ListItem>
+                A final cutover, which shuts down the source VMs while VM data and metadata are
+                copied, is run later.
+              </ListItem>
+            </List>
+            {isAnalysingVms ? (
+              <div className={`${spacing.mtMd} ${spacing.mlXs}`}>
+                <StatusIcon status="Loading" label="Analysing warm migration compatibility" />
+              </div>
+            ) : warmCriticalConcernsFound.length > 0 ? (
+              <div className={`${spacing.mtMd} ${spacing.mlXs}`}>
+                <StatusIcon
+                  status="Error"
+                  label="Warm migration will fail for one or more VMs because of the following conditions:"
+                />
+                <List className={`${spacing.mtSm} ${spacing.mlMd}`}>
+                  {warmCriticalConcernsFound.map((label) => (
+                    <ListItem key={label}>{label}</ListItem>
+                  ))}
+                </List>
+              </div>
+            ) : null}
+          </>
+        }
+        isChecked={form.values.type === 'Warm'}
+        onChange={() => form.fields.type.setValue('Warm')}
+      />
+    </>
+  );
+};
 
 export default TypeForm;

--- a/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsIcon.tsx
@@ -11,7 +11,7 @@ const VMConcernsIcon: React.FunctionComponent<IVMConcernsIconProps> = ({
   vm,
 }: IVMConcernsIconProps) => {
   if (vm.revisionValidated !== vm.revision) {
-    return <StatusIcon status="Loading" label="Analyzing" />;
+    return <StatusIcon status="Loading" label="Analysing" />;
   }
   const worstConcern = getMostSevereVMConcern(vm);
   const statusType = getVMConcernStatusType(worstConcern);

--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -50,7 +50,7 @@ export const getWarmPlanState = (
     if (migration.spec.cutover && pipelineHasStarted) {
       return 'Cutover';
     }
-    if (plan.status?.migration?.vms?.some((vm) => (vm.warm?.precopies.length || 0) > 0)) {
+    if (plan.status?.migration?.vms?.some((vm) => (vm.warm?.precopies?.length || 0) > 0)) {
       return 'Copying';
     }
     return 'Starting';

--- a/src/app/queries/mocks/vms.mock.ts
+++ b/src/app/queries/mocks/vms.mock.ts
@@ -52,6 +52,11 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           assessment:
             'Distributed resource scheduling is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.',
         },
+        {
+          category: 'Information',
+          label: 'VM snapshot detected',
+          assessment: 'Warm migration may not be possible for this VM',
+        },
       ],
       revisionValidated: 1,
     },
@@ -113,7 +118,15 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           datastore: { kind: 'Datastore', id: '1' },
         },
       ],
-      concerns: [{ category: 'Critical', label: 'Example', assessment: 'Something is really bad' }],
+      concerns: [
+        { category: 'Critical', label: 'Example', assessment: 'Something is really bad' },
+        {
+          category: 'Warning',
+          label: 'Changed Block Tracking (CBT) not enabled',
+          assessment:
+            'Changed Block Tracking (CBT) has not been enabled on this VM. This feature is a prerequisite for VM warm migration.',
+        },
+      ],
       revisionValidated: 1,
     },
     {

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -39,7 +39,7 @@ export interface IVMStatus {
     failures: number;
     successes: number;
     nextPrecopyAt?: string; // ISO timestamp
-    precopies: {
+    precopies?: {
       start: string;
       end?: string;
     }[];


### PR DESCRIPTION
…VMs, show migration type in the Review step of the wizard (#458)

* Show migration type in the Review step of the wizard

* Add warnings to warm migration option on Type step of wizard

* Change selectedVMs form state to selectedVMIds so the latest validation data can be looked up from polling

* Fix some issues where precopies array may not be defined

* Remove the warning message about VM snapshots

(cherry picked from commit 47e8a2641cead17da72e78e42415035c95b9a83b)