### PR TITLE
[Backport] Bump netmask from 1.0.6 to 2.0.1 (#492)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9716,9 +9716,9 @@
       "dev": true
     },
     "netmask": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.1.tgz",
+      "integrity": "sha512-gB8eG6ubxz67c7O2gaGiyWdRUIbH61q7anjgueDqCC9kvIs/b4CTtCMaQKeJbv1/Y7FT19I4zKwYmjnjInRQsg=="
     },
     "next-tick": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "express": "^4.17.1",
     "fast-deep-equal": "^3.1.3",
     "http-proxy-middleware": "^1.0.6",
-    "netmask": "^1.0.6",
+    "netmask": "^2.0.1",
     "node-fetch": "^2.6.1",
     "q": "^1.5.1",
     "react": "^16.13.1",


### PR DESCRIPTION
Backports #492 

Bumps [netmask](https://github.com/rs/node-netmask) from 1.0.6 to 2.0.1.
- [Release notes](https://github.com/rs/node-netmask/releases)
- [Commits](https://github.com/rs/node-netmask/compare/1.0.6...2.0.1)

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>