### PR TITLE
Fix leading slash on selfLinks after inventory URL scheme change

### DIFF
--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -84,7 +84,8 @@ export const useMockableMutation = <
     config
   );
 };
-export const getInventoryApiUrl = (relativePath: string): string => `/inventory-api${relativePath}`;
+export const getInventoryApiUrl = (relativePath: string): string =>
+  `/inventory-api/${relativePath}`;
 
 export const getAggregateQueryStatus = (
   queryResults: (QueryResult<unknown> | MutationResult<unknown>)[]


### PR DESCRIPTION
Since https://github.com/konveyor/forklift-controller/pull/191 it appears that the `selfLink` property on resources no longer has a leading slash, so the UI is constructing invalid URLs and getting 404s in certain places. This PR just adds a leading slash before the `selfLink` in `getInventoryApiUrl`. This should also still work if the selfLinks do have leading slashes in the future.