### PR TITLE
[Backport] Fix leading slash on selfLinks after inventory URL scheme change (#497)

### DIFF
--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -84,7 +84,8 @@ export const useMockableMutation = <
     config
   );
 };
-export const getInventoryApiUrl = (relativePath: string): string => `/inventory-api${relativePath}`;
+export const getInventoryApiUrl = (relativePath: string): string =>
+  `/inventory-api/${relativePath}`;
 
 export const getAggregateQueryStatus = (
   queryResults: (QueryResult<unknown> | MutationResult<unknown>)[]


### PR DESCRIPTION
Backports #497