### PR TITLE
Bug 1945567: Fix errors when saving a shared mapping from within the plan wizard

### DIFF
--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -107,7 +107,11 @@ export const getMappingFromBuilderItems = ({
     apiVersion: CLUSTER_API_VERSION,
     kind: mappingType === MappingType.Network ? 'NetworkMap' : 'StorageMap',
     metadata: {
-      ...(mappingName ? { name: mappingName } : { generateName: generateName || '' }),
+      ...(generateName
+        ? { generateName }
+        : mappingName
+        ? { name: mappingName }
+        : { generateName: '' }),
       namespace: META.namespace,
       ...(owner
         ? {


### PR DESCRIPTION
Resolves #495 (https://bugzilla.redhat.com/show_bug.cgi?id=1945567)

Fixes a regression introduced in https://github.com/konveyor/forklift-ui/pull/432. When selecting the box to save a mapping for later, the `mappingName` entered in that field is erroneously passed into `getMappingFromBuilderItems` not only for the new shared mapping but for the new plan-owned mapping, and it overrides the `generateName` param. So the wizard attempts to create two mappings with the same name instead of using a generated name for the owned mapping. This PR makes sure that if a `generateName` arg is passed it will be used.