### PR TITLE
Bug 1908745: Add cluster and operator versions to the About modal

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -10,11 +10,13 @@ console.log('\nEnvironment:');
 console.log(`  NODE_ENV=${process.env.NODE_ENV}`);
 console.log(`  DATA_SOURCE=${process.env.DATA_SOURCE}`);
 console.log(`  BRAND_TYPE=${process.env.BRAND_TYPE}`);
+console.log(`  FORKLIFT_OPERATOR_VERSION=${process.env.FORKLIFT_OPERATOR_VERSION}`);
 console.log(`  FORKLIFT_CONTROLLER_GIT_COMMIT=${process.env.FORKLIFT_CONTROLLER_GIT_COMMIT}`);
 console.log(`  FORKLIFT_MUST_GATHER_GIT_COMMIT=${process.env.FORKLIFT_MUST_GATHER_GIT_COMMIT}`);
 console.log(`  FORKLIFT_OPERATOR_GIT_COMMIT=${process.env.FORKLIFT_OPERATOR_GIT_COMMIT}`);
 console.log(`  FORKLIFT_UI_GIT_COMMIT=${process.env.FORKLIFT_UI_GIT_COMMIT}`);
-console.log(`  FORKLIFT_VALIDATION_GIT_COMMIT=${process.env.FORKLIFT_VALIDATION_GIT_COMMIT}\n`);
+console.log(`  FORKLIFT_VALIDATION_GIT_COMMIT=${process.env.FORKLIFT_VALIDATION_GIT_COMMIT}`);
+console.log(`  FORKLIFT_CLUSTER_VERSION=${process.env.FORKLIFT_CLUSTER_VERSION}\n`);
 
 module.exports = (env) => {
   return {
@@ -172,11 +174,13 @@ module.exports = (env) => {
         DATA_SOURCE: 'remote',
         BRAND_TYPE: 'Konveyor',
         NODE_ENV: 'production',
+        FORKLIFT_OPERATOR_VERSION: '-',
         FORKLIFT_CONTROLLER_GIT_COMMIT: '-',
         FORKLIFT_MUST_GATHER_GIT_COMMIT: '-',
         FORKLIFT_OPERATOR_GIT_COMMIT: '-',
         FORKLIFT_UI_GIT_COMMIT: '-',
         FORKLIFT_VALIDATION_GIT_COMMIT: '-',
+        FORKLIFT_CLUSTER_VERSION: '-',
       }),
     ],
     resolve: {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dr:surge": "node dr-surge.js",
     "build": "npm run clean && NODE_ENV=production $(npm bin)/webpack --config ./config/webpack.prod.js",
     "build:remote": "DATA_SOURCE=remote npm run build",
-    "build:mock": "DATA_SOURCE=mock npm run build && npm run dr:surge",
+    "build:mock": "DATA_SOURCE=mock FORKLIFT_UI_GIT_COMMIT=$(git rev-parse --short HEAD) npm run build && npm run dr:surge",
     "setup:dev:remote": "node --trace-deprecation ./scripts/remote-dev.js",
     "start": "node --trace-deprecation deploy/server.js",
     "start:remote": "DATA_SOURCE=remote npm run start",

--- a/src/app/AppLayout/ForkliftAboutModal.tsx
+++ b/src/app/AppLayout/ForkliftAboutModal.tsx
@@ -10,11 +10,11 @@ interface IForkliftAboutModalProps {
 
 const versions = [
   ['Toolkit operator version', process.env.FORKLIFT_OPERATOR_VERSION],
-  ['FORKLIFT_CONTROLLER_GIT_COMMIT', process.env.FORKLIFT_CONTROLLER_GIT_COMMIT],
-  ['FORKLIFT_MUST_GATHER_GIT_COMMIT', process.env.FORKLIFT_MUST_GATHER_GIT_COMMIT],
-  ['FORKLIFT_OPERATOR_GIT_COMMIT', process.env.FORKLIFT_OPERATOR_GIT_COMMIT],
-  ['FORKLIFT_UI_GIT_COMMIT', process.env.FORKLIFT_UI_GIT_COMMIT],
-  ['FORKLIFT_VALIDATION_GIT_COMMIT', process.env.FORKLIFT_VALIDATION_GIT_COMMIT],
+  ['Git commit (forklift-controller)', process.env.FORKLIFT_CONTROLLER_GIT_COMMIT],
+  ['Git commit (forklift-must-gather)', process.env.FORKLIFT_MUST_GATHER_GIT_COMMIT],
+  ['Git commit (forklift-operator)', process.env.FORKLIFT_OPERATOR_GIT_COMMIT],
+  ['Git commit (forklift-ui)', process.env.FORKLIFT_UI_GIT_COMMIT],
+  ['Git commit (forklift-validation)', process.env.FORKLIFT_VALIDATION_GIT_COMMIT],
   ['OpenShift version', process.env.FORKLIFT_CLUSTER_VERSION],
 ];
 

--- a/src/app/AppLayout/ForkliftAboutModal.tsx
+++ b/src/app/AppLayout/ForkliftAboutModal.tsx
@@ -8,12 +8,14 @@ interface IForkliftAboutModalProps {
   onClose: () => void;
 }
 
-const envVars = [
+const versions = [
+  ['Toolkit operator version', process.env.FORKLIFT_OPERATOR_VERSION],
   ['FORKLIFT_CONTROLLER_GIT_COMMIT', process.env.FORKLIFT_CONTROLLER_GIT_COMMIT],
   ['FORKLIFT_MUST_GATHER_GIT_COMMIT', process.env.FORKLIFT_MUST_GATHER_GIT_COMMIT],
   ['FORKLIFT_OPERATOR_GIT_COMMIT', process.env.FORKLIFT_OPERATOR_GIT_COMMIT],
   ['FORKLIFT_UI_GIT_COMMIT', process.env.FORKLIFT_UI_GIT_COMMIT],
   ['FORKLIFT_VALIDATION_GIT_COMMIT', process.env.FORKLIFT_VALIDATION_GIT_COMMIT],
+  ['OpenShift version', process.env.FORKLIFT_CLUSTER_VERSION],
 ];
 
 const ForkliftAboutModal: React.FunctionComponent<IForkliftAboutModalProps> = ({
@@ -32,7 +34,7 @@ const ForkliftAboutModal: React.FunctionComponent<IForkliftAboutModalProps> = ({
   >
     <TextContent>
       <TextList component="dl">
-        {envVars.map((v) => (
+        {versions.map((v) => (
           <React.Fragment key={v[0]}>
             <TextListItem component="dt">{v[0]}</TextListItem>
             <TextListItem component="dd">{v[1]}</TextListItem>


### PR DESCRIPTION
Resolves #470 (https://bugzilla.redhat.com/show_bug.cgi?id=1908745)

Adds the version numbers from the new environment variables exposed by https://github.com/konveyor/forklift-operator/pull/96. Also restores the ability to see the UI git commit in mock mode that was removed by https://github.com/konveyor/forklift-ui/pull/490 (this time it won't break prod, sorry @fdupont-redhat 😄)

Changes the labels on the git commit versions to be more human-readable instead of exposing the env var names.

![Screen Shot 2021-04-05 at 1 13 56 PM](https://user-images.githubusercontent.com/811963/113604505-62bc8880-9613-11eb-92f4-9a14e98ff4e2.png)
