### PR TITLE
Bug 1942091: Re-enable polling in the General step of the plan wizard to pick up new namespace options

### DIFF
--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -22,7 +22,6 @@ import { useNamespacesQuery } from '@app/queries/namespaces';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import ProviderSelect from '@app/common/components/ProviderSelect';
 import { ProviderType } from '@app/common/constants';
-import { usePausedPollingEffect } from '@app/common/context';
 import SelectOpenShiftNetworkModal from '@app/common/components/SelectOpenShiftNetworkModal';
 import { HelpIcon } from '@patternfly/react-icons';
 import { useOpenShiftNetworksQuery } from '@app/queries/networks';
@@ -36,8 +35,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   form,
   planBeingEdited,
 }: IGeneralFormProps) => {
-  usePausedPollingEffect();
-
   const inventoryProvidersQuery = useInventoryProvidersQuery();
   const clusterProvidersQuery = useClusterProvidersQuery();
   const namespacesQuery = useNamespacesQuery(form.values.targetProvider);


### PR DESCRIPTION
Resolves #464 (https://bugzilla.redhat.com/show_bug.cgi?id=1942091).

In https://github.com/konveyor/forklift-ui/pull/129, we disabled polling on all steps of the wizard (we later re-enabled it for the Select VMs step in https://github.com/konveyor/forklift-ui/pull/411 so the validation concerns could be updated automatically). This was done because some of the polled resources return immutable copies on each poll, and that was breaking selection logic that depended on referential equality. As a side-effect, newly created namespaces were not being picked up by the wizard automatically without reloading the wizard.

It is safe to re-enable polling on the General step because of changes since we disabled it that alleviate this equality issue for provider selections (https://github.com/konveyor/forklift-ui/pull/358). The equality issue was never present for the target namespace field since it uses string values.

This PR leaves polling disabled for the filter VMs step and the mapping steps, because it is uncertain whether re-enabling it will cause bugs there. It isn't as important for inventory resources to be updated automatically without restarting the wizard as it is for namespaces, so it's not worth the risk so close to the GA release. we can address that post-GA if we need to.