### PR TITLE
Fix various minor issues with the target namespace field in the plan wizard

### DIFF
--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -152,36 +152,36 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             >
               {getFilteredOptions()}
             </Select>
-            {form.values.targetNamespace ? (
-              <>
-                <TextContent className={spacing.mtMd}>
-                  <Text component="p">
-                    The migration transfer network for this migration plan is:{' '}
-                    <strong>{form.values.migrationNetwork || POD_NETWORK.name}</strong>.
-                    <Popover bodyContent="The default migration network defined for the OpenShift Virtualization provider is used if it exists in the target namespace. Otherwise, the pod network is used. You can select a different network for this migration plan.">
-                      <Button
-                        variant="plain"
-                        aria-label="More info for migration transfer network field"
-                        onClick={(e) => e.preventDefault()}
-                        className="pf-c-form__group-label-help"
-                      >
-                        <HelpIcon noVerticalAlign />
-                      </Button>
-                    </Popover>
-                  </Text>
-                </TextContent>
-                <Button
-                  variant="link"
-                  isInline
-                  onClick={toggleSelectNetworkModal}
-                  className={spacing.mtXs}
-                >
-                  Select a different network
-                </Button>
-              </>
-            ) : null}
           </ResolvedQueries>
         </FormGroup>
+        {form.values.targetNamespace ? (
+          <div>
+            <TextContent>
+              <Text component="p">
+                The migration transfer network for this migration plan is:{' '}
+                <strong>{form.values.migrationNetwork || POD_NETWORK.name}</strong>.
+                <Popover bodyContent="The default migration network defined for the OpenShift Virtualization provider is used if it exists in the target namespace. Otherwise, the pod network is used. You can select a different network for this migration plan.">
+                  <Button
+                    variant="plain"
+                    aria-label="More info for migration transfer network field"
+                    onClick={(e) => e.preventDefault()}
+                    className="pf-c-form__group-label-help"
+                  >
+                    <HelpIcon noVerticalAlign />
+                  </Button>
+                </Popover>
+              </Text>
+            </TextContent>
+            <Button
+              variant="link"
+              isInline
+              onClick={toggleSelectNetworkModal}
+              className={spacing.mtXs}
+            >
+              Select a different network
+            </Button>
+          </div>
+        ) : null}
       </Form>
       {isSelectNetworkModalOpen ? (
         <SelectOpenShiftNetworkModal

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -45,7 +45,13 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     const namespaceOptions = namespacesQuery.data?.map((namespace) => namespace.name) || [];
     const filteredNamespaces = !searchText
       ? namespaceOptions
-      : namespaceOptions.filter((option) => !!option.toLowerCase().match(searchText.toLowerCase()));
+      : namespaceOptions.filter((option) => {
+          try {
+            return !!option.toLowerCase().match(searchText.toLowerCase());
+          } catch (e) {
+            return false;
+          }
+        });
     return [
       <SelectGroup key="group" label="Select or type to create a namespace">
         {filteredNamespaces.map((option) => (
@@ -136,6 +142,11 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
                 onTargetNamespaceChange(selection as string);
               }}
               onFilter={(event) => getFilteredOptions(event.target.value)}
+              onClear={() => {
+                form.fields.targetNamespace.setValue('');
+                setIsNamespaceSelectOpen(false);
+                onTargetNamespaceChange('');
+              }}
               selections={form.values.targetNamespace}
               variant="typeahead"
               isCreatable
@@ -153,13 +164,14 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
                     The migration transfer network for this migration plan is:{' '}
                     <strong>{form.values.migrationNetwork || POD_NETWORK.name}</strong>.
                     <Popover bodyContent="The default migration network defined for the OpenShift Virtualization provider is used if it exists in the target namespace. Otherwise, the pod network is used. You can select a different network for this migration plan.">
-                      <button
+                      <Button
+                        variant="plain"
                         aria-label="More info for migration transfer network field"
                         onClick={(e) => e.preventDefault()}
                         className="pf-c-form__group-label-help"
                       >
                         <HelpIcon noVerticalAlign />
-                      </button>
+                      </Button>
                     </Popover>
                   </Text>
                 </TextContent>

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -69,6 +69,9 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   const openshiftNetworksQuery = useOpenShiftNetworksQuery(form.values.targetProvider);
 
   const onTargetNamespaceChange = (targetNamespace: string) => {
+    form.fields.targetNamespace.setValue(targetNamespace);
+    form.fields.targetNamespace.setIsTouched(true);
+    setIsNamespaceSelectOpen(false);
     if (targetNamespace !== form.values.targetNamespace) {
       const providerDefaultNetworkName =
         form.values.targetProvider?.object.metadata.annotations?.[
@@ -136,17 +139,9 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
               placeholderText="Select a namespace"
               isOpen={isNamespaceSelectOpen}
               onToggle={setIsNamespaceSelectOpen}
-              onSelect={(_event, selection) => {
-                form.fields.targetNamespace.setValue(selection as string);
-                setIsNamespaceSelectOpen(false);
-                onTargetNamespaceChange(selection as string);
-              }}
+              onSelect={(_event, selection) => onTargetNamespaceChange(selection as string)}
               onFilter={(event) => getFilteredOptions(event.target.value)}
-              onClear={() => {
-                form.fields.targetNamespace.setValue('');
-                setIsNamespaceSelectOpen(false);
-                onTargetNamespaceChange('');
-              }}
+              onClear={() => onTargetNamespaceChange('')}
               selections={form.values.targetNamespace}
               variant="typeahead"
               isCreatable


### PR DESCRIPTION
* Fixes #507: Validation errors were not appearing on the target namespace field when creating a new namespace with an invalid name
* Regex escape characters (`\`) in the search box were causing errors, now they just produce 0 matches
* The Clear (x) button was missing from the field
* Pressing Enter in the field was triggering the popover on the help icon for the transfer network field (weird ref issue with the Popover component, switching the HTML button to a PF Button fixed it)

Does not address the remaining issues in https://github.com/konveyor/forklift-ui/issues/463