### PR TITLE
Inform the user on the Review step if a new target namespace is being created

### DIFF
--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -25,6 +25,7 @@ import { ProviderType } from '@app/common/constants';
 import SelectOpenShiftNetworkModal from '@app/common/components/SelectOpenShiftNetworkModal';
 import { HelpIcon } from '@patternfly/react-icons';
 import { useOpenShiftNetworksQuery } from '@app/queries/networks';
+import { usePausedPollingEffect } from '@app/common/context';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
@@ -40,6 +41,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   const namespacesQuery = useNamespacesQuery(form.values.targetProvider);
 
   const [isNamespaceSelectOpen, setIsNamespaceSelectOpen] = React.useState(false);
+  usePausedPollingEffect(isNamespaceSelectOpen);
 
   const getFilteredOptions = (searchText?: string) => {
     const namespaceOptions = namespacesQuery.data?.map((namespace) => namespace.name) || [];

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -18,6 +18,7 @@ import { IKubeResponse, KubeClientError } from '@app/client/types';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { generateMappings } from './helpers';
 import { usePausedPollingEffect } from '@app/common/context';
+import { useNamespacesQuery } from '@app/queries/namespaces';
 
 interface IReviewProps {
   forms: PlanWizardFormState;
@@ -40,6 +41,13 @@ const Review: React.FunctionComponent<IReviewProps> = ({
   usePausedPollingEffect();
 
   const { networkMapping, storageMapping } = generateMappings({ forms });
+
+  const namespacesQuery = useNamespacesQuery(forms.general.values.targetProvider);
+  const namespaceOptions = namespacesQuery.data?.map((namespace) => namespace.name) || [];
+  const isNewNamespace = !namespaceOptions.find(
+    (namespace) => namespace === forms.general.values.targetNamespace
+  );
+
   return (
     <Form>
       <TextContent>
@@ -63,7 +71,16 @@ const Review: React.FunctionComponent<IReviewProps> = ({
         <GridItem md={3}>Target provider</GridItem>
         <GridItem md={9}>{forms.general.values.targetProvider?.name}</GridItem>
         <GridItem md={3}>Target namespace</GridItem>
-        <GridItem md={9}>{forms.general.values.targetNamespace}</GridItem>
+        <GridItem md={9}>
+          {forms.general.values.targetNamespace}
+          {isNewNamespace ? (
+            <TextContent>
+              <Text component="small">
+                This is a new namespace that will be created when the plan is started.
+              </Text>
+            </TextContent>
+          ) : null}
+        </GridItem>
         <GridItem md={3}>Migration transfer network</GridItem>
         <GridItem md={9}>{forms.general.values.migrationNetwork || POD_NETWORK.name}</GridItem>
         <GridItem md={3}>Selected VMs</GridItem>

--- a/src/app/common/context/PollingContext.tsx
+++ b/src/app/common/context/PollingContext.tsx
@@ -65,11 +65,15 @@ export const PollingContextProvider: React.FunctionComponent<IPollingContextProv
 
 export const usePollingContext = (): IPollingContext => React.useContext(PollingContext);
 
-export const usePausedPollingEffect = (): void => {
-  // Pauses polling when a component mounts, resumes when it unmounts
+export const usePausedPollingEffect = (shouldPause = true): void => {
+  // Pauses polling when a component mounts, resumes when it unmounts. If shouldPause changes while mounted, polling pauses/resumes to match.
   const { pausePolling, resumePolling } = usePollingContext();
   React.useEffect(() => {
-    pausePolling();
+    if (shouldPause) {
+      pausePolling();
+    } else {
+      resumePolling();
+    }
     return resumePolling;
-  }, [pausePolling, resumePolling]);
+  }, [pausePolling, resumePolling, shouldPause]);
 };


### PR DESCRIPTION
This is a piece of #463 that we decided not to delay to post-GA since it's low-risk and helpful.

![Screen Shot 2021-04-06 at 2 58 32 PM](https://user-images.githubusercontent.com/811963/113764143-94ebea00-96e8-11eb-9eb3-51d5e79cc000.png)

Also, this PR fixes a regression introduced by #505 where polling while the target namespace field is open and search text has been entered will cause the filter results to reset. Disables polling only while the dropdown is open, so you can still pick up new namespaces by closing the dropdown and reopening it. (in fact, when closing it the polling cycle is restarted immediately so there is no need to wait for the next cycle, new namespaces will be fetched immediately)