### PR TITLE
Bug 1942066: Always sort provider tabs alphabetically

### DIFF
--- a/src/app/Providers/ProvidersPage.tsx
+++ b/src/app/Providers/ProvidersPage.tsx
@@ -67,7 +67,9 @@ const ProvidersPage: React.FunctionComponent = () => {
 
   const availableProviderTypes = Array.from(
     new Set(clusterProviders.map((provider) => provider.spec.type))
-  ).filter((type) => !!type) as ProviderType[];
+  )
+    .filter((type) => !!type)
+    .sort() as ProviderType[];
 
   const activeProviderType = match?.params.providerType
     ? ProviderType[match?.params.providerType]


### PR DESCRIPTION
Resolves #465. OpenShift Virtualization will always appear before VMware even if the API returns them out of order.