### PR TITLE
Bug 1942137: Add show/hide password feature via new ValidatedPasswordField component

### DIFF
--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -310,22 +310,39 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
                     ),
                   }}
                 />
-
                 <ValidatedPasswordInput
                   field={openshiftForm.fields.saToken}
                   label="Service account token"
                   isRequired
                   fieldId="openshift-sa-token"
-                  helpContent={
-                    <>
-                      To obtain SA token, run the following command:
-                      <br />
-                      <i>$ oc serviceaccounts get-token serviceaccount_name -n namespace_name</i>
-                      <br />
-                      <br />
-                      <b>** Be sure to use the namespace in which you created the SA.</b>
-                    </>
-                  }
+                  formGroupProps={{
+                    labelIcon: (
+                      <Popover
+                        bodyContent={
+                          <>
+                            To obtain SA token, run the following command:
+                            <br />
+                            <i>
+                              $ oc serviceaccounts get-token serviceaccount_name -n namespace_name
+                            </i>
+                            <br />
+                            <br />
+                            <b>** Be sure to use the namespace in which you created the SA.</b>
+                          </>
+                        }
+                      >
+                        <Button
+                          variant="plain"
+                          aria-label="More info for service account field"
+                          onClick={(e) => e.preventDefault()}
+                          aria-describedby="service-account-info"
+                          className="pf-c-form__group-label-help"
+                        >
+                          <HelpIcon noVerticalAlign />
+                        </Button>
+                      </Popover>
+                    ),
+                  }}
                 />
               </>
             ) : null}

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -224,7 +224,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
                 />
                 <ValidatedTextInput
                   field={vmwareForm.fields.fingerprint}
-                  label="Certificate SHA1 Fingerprint"
+                  label="SHA-1 Fingerprint"
                   isRequired
                   fieldId="vmware-fingerprint"
                   formGroupProps={{
@@ -242,7 +242,7 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
                       >
                         <Button
                           variant="plain"
-                          aria-label="More info for SHA1 Fingerprint field"
+                          aria-label="More info for SHA-1 Fingerprint field"
                           onClick={(e) => e.preventDefault()}
                           aria-describedby="vmware-fingerprint"
                           className="pf-c-form__group-label-help"

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -34,6 +34,7 @@ import { QuerySpinnerMode, ResolvedQuery } from '@app/common/components/Resolved
 import { IKubeList } from '@app/client/types';
 import { useEditProviderPrefillEffect } from './helpers';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
+import ValidatedPasswordInput from '@app/common/components/ValidatedPasswordInput';
 
 interface IAddEditProviderModalProps {
   onClose: (navToProviderType?: ProviderType | null) => void;
@@ -190,14 +191,15 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
                   formGroupProps={{
                     labelIcon: (
                       <Popover bodyContent="User specified name that will be displayed in the UI.">
-                        <button
+                        <Button
+                          variant="plain"
                           aria-label="More info for name field"
                           onClick={(e) => e.preventDefault()}
                           aria-describedby="vmware-name-info"
                           className="pf-c-form__group-label-help"
                         >
                           <HelpIcon noVerticalAlign />
-                        </button>
+                        </Button>
                       </Popover>
                     ),
                   }}
@@ -214,9 +216,8 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
                   isRequired
                   fieldId="vmware-username"
                 />
-                <ValidatedTextInput
+                <ValidatedPasswordInput
                   field={vmwareForm.fields.password}
-                  type="password"
                   label="Password"
                   isRequired
                   fieldId="vmware-password"
@@ -239,14 +240,15 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
                           </div>
                         }
                       >
-                        <button
+                        <Button
+                          variant="plain"
                           aria-label="More info for SHA1 Fingerprint field"
                           onClick={(e) => e.preventDefault()}
                           aria-describedby="vmware-fingerprint"
                           className="pf-c-form__group-label-help"
                         >
                           <HelpIcon noVerticalAlign />
-                        </button>
+                        </Button>
                       </Popover>
                     ),
                   }}
@@ -266,14 +268,15 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
                   formGroupProps={{
                     labelIcon: (
                       <Popover bodyContent="User specified name that will be displayed in the UI.">
-                        <button
+                        <Button
+                          variant="plain"
                           aria-label="More info for name field"
                           onClick={(e) => e.preventDefault()}
                           aria-describedby="openshift-name-info"
                           className="pf-c-form__group-label-help"
                         >
                           <HelpIcon noVerticalAlign />
-                        </button>
+                        </Button>
                       </Popover>
                     ),
                   }}
@@ -294,51 +297,35 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
                           </>
                         }
                       >
-                        <button
+                        <Button
+                          variant="plain"
                           aria-label="More info for URL field"
                           onClick={(e) => e.preventDefault()}
                           aria-describedby="openshift-cluster-url-info"
                           className="pf-c-form__group-label-help"
                         >
                           <HelpIcon noVerticalAlign />
-                        </button>
+                        </Button>
                       </Popover>
                     ),
                   }}
                 />
-                <ValidatedTextInput
+
+                <ValidatedPasswordInput
                   field={openshiftForm.fields.saToken}
-                  type="password"
                   label="Service account token"
                   isRequired
                   fieldId="openshift-sa-token"
-                  formGroupProps={{
-                    labelIcon: (
-                      <Popover
-                        bodyContent={
-                          <>
-                            To obtain SA token, run the following command:
-                            <br />
-                            <i>
-                              $ oc serviceaccounts get-token serviceaccount_name -n namespace_name
-                            </i>
-                            <br />
-                            <br />
-                            <b>** Be sure to use the namespace in which you created the SA.</b>
-                          </>
-                        }
-                      >
-                        <button
-                          aria-label="More info for service account field"
-                          onClick={(e) => e.preventDefault()}
-                          aria-describedby="service-account-info"
-                          className="pf-c-form__group-label-help"
-                        >
-                          <HelpIcon noVerticalAlign />
-                        </button>
-                      </Popover>
-                    ),
-                  }}
+                  helpContent={
+                    <>
+                      To obtain SA token, run the following command:
+                      <br />
+                      <i>$ oc serviceaccounts get-token serviceaccount_name -n namespace_name</i>
+                      <br />
+                      <br />
+                      <b>** Be sure to use the namespace in which you created the SA.</b>
+                    </>
+                  }
                 />
               </>
             ) : null}

--- a/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -146,7 +146,7 @@ describe('<AddEditProviderModal />', () => {
     await waitFor(() => {
       const name = screen.getByRole('textbox', { name: /name/i });
       const url = screen.getByRole('textbox', { name: /url/i });
-      const saToken = screen.getByLabelText(/Service account token/);
+      const saToken = screen.getByLabelText(/^Service account token/);
 
       userEvent.type(name, 'providername');
       userEvent.type(url, 'http://host.example.com');
@@ -176,7 +176,7 @@ describe('<AddEditProviderModal />', () => {
     await waitFor(() => {
       const name = screen.getByRole('textbox', { name: /name/i });
       const url = screen.getByRole('textbox', { name: /url/i });
-      const saToken = screen.getByLabelText(/Service account token/);
+      const saToken = screen.getByLabelText(/^Service account token/);
 
       userEvent.type(name, 'providername');
       userEvent.type(url, 'host');

--- a/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -54,7 +54,7 @@ describe('<AddEditProviderModal />', () => {
       const username = screen.getByRole('textbox', { name: /username/i });
       const password = screen.getByLabelText(/^Password/);
       const certFingerprint = screen.getByRole('textbox', {
-        name: /certificate sha1 fingerprint/i,
+        name: /sha-1 fingerprint/i,
       });
 
       userEvent.type(name, 'providername');
@@ -93,7 +93,7 @@ describe('<AddEditProviderModal />', () => {
       const username = screen.getByRole('textbox', { name: /username/i });
       const password = screen.getByLabelText(/^Password/);
       const certFingerprint = screen.getByRole('textbox', {
-        name: /certificate sha1 fingerprint/i,
+        name: /sha-1 fingerprint/i,
       });
 
       userEvent.type(name, 'providername');

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -20,6 +20,7 @@ import { useConfigureHostsMutation } from '@app/queries';
 import { QuerySpinnerMode, ResolvedQuery } from '@app/common/components/ResolvedQuery';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import ConditionalTooltip from '@app/common/components/ConditionalTooltip';
+import ValidatedPasswordInput from '@app/common/components/ValidatedPasswordInput';
 
 interface ISelectNetworkModalProps {
   selectedHosts: IHost[];
@@ -171,8 +172,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
             content="Credentials are not needed when selecting the provider’s default management network."
             position="left"
           >
-            <ValidatedTextInput
-              type="password"
+            <ValidatedPasswordInput
               field={form.fields.adminPassword}
               label="ESXi host admin password"
               isRequired

--- a/src/app/common/components/ValidatedPasswordInput.tsx
+++ b/src/app/common/components/ValidatedPasswordInput.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Button, Popover, TextInputProps } from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon, HelpIcon } from '@patternfly/react-icons';
+import { IValidatedFormField, ValidatedTextInput } from '@konveyor/lib-ui';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+
+interface IValidatedPasswordInputProps {
+  field: IValidatedFormField<string> | IValidatedFormField<string | undefined>;
+  label: string;
+  isRequired?: boolean;
+  fieldId: string;
+  helpContent?: React.ReactNode;
+  helpAriaLabel?: string;
+  inputProps?: Partial<TextInputProps>;
+}
+
+const ValidatedPasswordInput: React.FunctionComponent<IValidatedPasswordInputProps> = ({
+  field,
+  label,
+  isRequired = false,
+  fieldId,
+  helpContent = null,
+  helpAriaLabel = `More info for ${label} field`,
+  inputProps = {},
+}: IValidatedPasswordInputProps) => {
+  const [isValueVisible, toggleValueVisible] = React.useReducer((isVisible) => !isVisible, false);
+  const showHideButton = (
+    <Button
+      variant="plain"
+      onClick={toggleValueVisible}
+      aria-label={`Show/hide ${label}`}
+      className="pf-c-form__group-label-help"
+    >
+      {!isValueVisible ? <EyeIcon noVerticalAlign /> : <EyeSlashIcon noVerticalAlign />}
+    </Button>
+  );
+  return (
+    <ValidatedTextInput
+      field={field}
+      type={isValueVisible ? 'text' : 'password'}
+      label={label}
+      isRequired={isRequired}
+      fieldId={fieldId}
+      formGroupProps={{
+        labelIcon: (
+          <>
+            {helpContent ? (
+              <Popover bodyContent={helpContent}>
+                <Button
+                  variant="plain"
+                  aria-label={helpAriaLabel}
+                  onClick={(e) => e.preventDefault()}
+                  className={`pf-c-form__group-label-help ${spacing.mrXs}`}
+                >
+                  <HelpIcon noVerticalAlign />
+                </Button>
+              </Popover>
+            ) : null}
+            {showHideButton}
+          </>
+        ),
+      }}
+      inputProps={inputProps}
+    />
+  );
+};
+
+export default ValidatedPasswordInput;

--- a/src/app/common/components/ValidatedPasswordInput.tsx
+++ b/src/app/common/components/ValidatedPasswordInput.tsx
@@ -1,67 +1,65 @@
 import * as React from 'react';
-import { Button, Popover, TextInputProps } from '@patternfly/react-core';
-import { EyeIcon, EyeSlashIcon, HelpIcon } from '@patternfly/react-icons';
-import { IValidatedFormField, ValidatedTextInput } from '@konveyor/lib-ui';
-import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import {
+  Button,
+  FormGroup,
+  FormGroupProps,
+  InputGroup,
+  TextInput,
+  TextInputProps,
+} from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
+import { getFormGroupProps, getTextInputProps, IValidatedFormField } from '@konveyor/lib-ui';
 
-interface IValidatedPasswordInputProps {
+// TODO this is based heavily on ValidatedTextInput from lib-ui, which should be enhanced to support an InputGroup somehow.
+// See https://github.com/konveyor/lib-ui/issues/55
+
+interface IValidatedPasswordInputProps
+  extends Pick<FormGroupProps, 'label' | 'fieldId' | 'isRequired'> {
+  /** A field returned from useFormField() or useFormState().fields.* */
   field: IValidatedFormField<string> | IValidatedFormField<string | undefined>;
-  label: string;
-  isRequired?: boolean;
-  fieldId: string;
-  helpContent?: React.ReactNode;
-  helpAriaLabel?: string;
+  /** Any extra props for the PatternFly FormGroup */
+  formGroupProps?: Partial<FormGroupProps>;
+  /** Any extra props for the PatternFly TextInput */
   inputProps?: Partial<TextInputProps>;
+  showPasswordAriaLabel?: string;
+  hidePasswordAriaLabel?: string;
 }
 
 const ValidatedPasswordInput: React.FunctionComponent<IValidatedPasswordInputProps> = ({
   field,
   label,
-  isRequired = false,
   fieldId,
-  helpContent = null,
-  helpAriaLabel = `More info for ${label} field`,
+  isRequired,
+  formGroupProps = {},
   inputProps = {},
+  showPasswordAriaLabel = `Show ${label}`,
+  hidePasswordAriaLabel = `Hide ${label}`,
 }: IValidatedPasswordInputProps) => {
   const [isValueVisible, toggleValueVisible] = React.useReducer((isVisible) => !isVisible, false);
-  const showHideButton = (
-    <Button
-      variant="plain"
-      onClick={toggleValueVisible}
-      aria-label={`Show/hide ${label}`}
-      className="pf-c-form__group-label-help"
-    >
-      {!isValueVisible ? <EyeIcon noVerticalAlign /> : <EyeSlashIcon noVerticalAlign />}
-    </Button>
-  );
   return (
-    <ValidatedTextInput
-      field={field}
-      type={isValueVisible ? 'text' : 'password'}
+    <FormGroup
       label={label}
       isRequired={isRequired}
       fieldId={fieldId}
-      formGroupProps={{
-        labelIcon: (
-          <>
-            {helpContent ? (
-              <Popover bodyContent={helpContent}>
-                <Button
-                  variant="plain"
-                  aria-label={helpAriaLabel}
-                  onClick={(e) => e.preventDefault()}
-                  className={`pf-c-form__group-label-help ${spacing.mrXs}`}
-                >
-                  <HelpIcon noVerticalAlign />
-                </Button>
-              </Popover>
-            ) : null}
-            {showHideButton}
-          </>
-        ),
-      }}
-      inputProps={inputProps}
-    />
+      {...getFormGroupProps(field as IValidatedFormField<string | undefined>)}
+      {...formGroupProps}
+    >
+      <InputGroup>
+        <TextInput
+          id={fieldId}
+          type={isValueVisible ? 'text' : 'password'}
+          {...getTextInputProps(field)}
+          {...(inputProps as Partial<TextInputProps>)}
+        />
+        <Button
+          variant="control"
+          onClick={toggleValueVisible}
+          aria-label={isValueVisible ? hidePasswordAriaLabel : showPasswordAriaLabel}
+        >
+          {!isValueVisible ? <EyeIcon /> : <EyeSlashIcon />}
+        </Button>
+      </InputGroup>
+    </FormGroup>
   );
 };
 

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -121,7 +121,7 @@ export const vmwareHostnameSchema = yup
 
 export const vmwareFingerprintSchema = yup
   .string()
-  .label('Certificate SHA1 Fingerprint')
+  .label('SHA-1 Fingerprint')
   .matches(/^[a-fA-F0-9]{2}((:[a-fA-F0-9]{2}){19}|(:[a-fA-F0-9]{2}){15})$/, {
     message:
       'Fingerprint must consist of 16 or 20 pairs of hexadecimal characters separated by colons, e.g. XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX',


### PR DESCRIPTION
Resolves #468 (https://bugzilla.redhat.com/show_bug.cgi?id=1942137)
Also resolves #452 in the interest of time, because separate PRs for these two fixes would conflict.

Adds a new common component `ValidatedPasswordField` which adds a show/hide icon button on the right side of the field. Replaces the plain password input with this component in 3 places: VMware provider password, OpenShift provider SA token, and ESXi host admin password. 

The first commit puts the toggle icon next to the field label like it's done in MTC today, but then @vconzola pointed out that the PatternFly login page example has the icon in an InputGroup next to the input field (see https://github.com/patternfly/patternfly-react/pull/5481), so the second commit switches to that design.

I had to duplicate some of the code from the lib-ui ValidatedTextInput component since it doesn't support InputGroups. We can add that feature to lib-ui and simplify this code in the future. Opened https://github.com/konveyor/lib-ui/issues/55 to track this.

![xvCQrJKku7](https://user-images.githubusercontent.com/811963/113924440-d4353c00-97b7-11eb-85ca-3f252f0d4535.gif)
