### PR TITLE
Bug 1942135: Remove provider name from title on hosts page to avoid inconsistency with breadcrumb bar

### DIFF
--- a/src/app/Providers/HostsPage.tsx
+++ b/src/app/Providers/HostsPage.tsx
@@ -56,7 +56,7 @@ export const HostsPage: React.FunctionComponent = () => {
         </Level>
         <Level className={spacing.mtLg}>
           <LevelItem>
-            <Title headingLevel="h1">Hosts - {match?.params.providerName}</Title>
+            <Title headingLevel="h1">Hosts</Title>
           </LevelItem>
         </Level>
       </PageSection>


### PR DESCRIPTION
Resolves #460 (https://bugzilla.redhat.com/show_bug.cgi?id=1942135)