### PR TITLE
Correctly handle plan status when it finishes with some VMs canceled

### DIFF
--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -225,11 +225,15 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     } else if (hasCondition(conditions, PlanStatusType.Canceled)) {
       title = PlanStatusDisplayType.Canceled;
     } else if (hasCondition(conditions, PlanStatusType.Failed)) {
-      buttonType = 'Restart';
       title = PlanStatusDisplayType.Failed;
       variant = ProgressVariant.danger;
     } else if (plan.status?.migration?.started) {
-      console.warn('Migration plan unexpected status:', plan);
+      if (canPlanBeStarted(plan)) {
+        title = 'Finished - Incomplete';
+        variant = ProgressVariant.warning;
+      } else {
+        console.warn('Migration plan unexpected status:', plan);
+      }
     }
 
     if (buttonType !== 'Start' && canPlanBeStarted(plan)) {

--- a/src/app/queries/mocks/migrations.mock.ts
+++ b/src/app/queries/mocks/migrations.mock.ts
@@ -6,7 +6,7 @@ import { MOCK_PLANS } from './plans.mock';
 export let MOCK_MIGRATIONS: IMigration[];
 
 if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-  const runningPlanIndexes = [0, 2, 3, 4, 6, 7, 8];
+  const runningPlanIndexes = [0, 2, 3, 4, 6, 7, 8, 9];
   MOCK_MIGRATIONS = runningPlanIndexes.map((index) => ({
     apiVersion: CLUSTER_API_VERSION,
     kind: 'Migration',
@@ -20,13 +20,15 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     status: MOCK_PLANS[index].status?.migration,
   }));
 
-  // plantest-03 (plan index 2) has a canceled VM
-  MOCK_MIGRATIONS[1].spec.cancel = [
+  // plantest-03 (plan index 2) and plantest-10 (plan index 9) have canceled VMs
+  const cancelSpec = [
     {
       id: 'vm-1630',
       name: 'fdupont-test-migration',
     },
   ];
+  MOCK_MIGRATIONS[1].spec.cancel = cancelSpec;
+  MOCK_MIGRATIONS[7].spec.cancel = cancelSpec;
 
   // plantest-8 (plan index 7) is in cutover
   MOCK_MIGRATIONS[5].spec.cutover = '2021-03-16T18:31:30Z';

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -96,6 +96,16 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     phase: 'Mock VM Phase',
     started: '2020-10-10T14:04:10Z',
     completed: '2020-10-10T15:58:43Z',
+    conditions: [
+      {
+        category: 'Advisory',
+        durable: true,
+        lastTransitionTime: '2020-10-10T15:58:43Z',
+        message: 'The VM migration has SUCCEEDED.',
+        status: 'True',
+        type: 'Succeeded',
+      },
+    ],
   };
 
   const vmStatus4: IVMStatus = {
@@ -210,6 +220,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           reason: 'Valid',
           status: 'True',
           type: 'Executing',
+        },
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
         },
       ],
       observedGeneration: 2,
@@ -332,6 +350,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           status: 'True',
           type: 'Failed',
         },
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
+        },
       ],
       observedGeneration: 2,
       migration: {
@@ -392,6 +418,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           reason: 'Valid',
           status: 'True',
           type: 'Succeeded',
+        },
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
         },
       ],
       observedGeneration: 2,
@@ -468,6 +502,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           reason: 'Valid',
           status: 'True',
           type: 'Failed',
+        },
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
         },
       ],
       observedGeneration: 2,
@@ -649,6 +691,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           status: 'True',
           type: 'Executing',
         },
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
+        },
       ],
       observedGeneration: 2,
       migration: {
@@ -716,6 +766,14 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           status: 'True',
           type: 'Failed',
         },
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
+        },
       ],
       observedGeneration: 2,
       migration: {
@@ -741,5 +799,44 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6, plan7, plan8, plan9];
+  const plan10: IPlan = {
+    ...plan1,
+    metadata: { ...plan1.metadata, name: 'plantest-10' },
+    spec: { ...plan1.spec, description: 'finished with some canceled VMs' },
+    status: {
+      conditions: [
+        {
+          category: 'Info',
+          lastTransitionTime: '2020-09-18T16:04:10Z',
+          message: 'Ready for migration',
+          reason: 'Valid',
+          status: 'True',
+          type: 'Ready',
+        },
+      ],
+      observedGeneration: 2,
+      migration: {
+        active: '',
+        started: '2020-10-10T14:04:10Z',
+        completed: '2020-10-10T15:04:10Z',
+        vms: [vmStatus1WithCancel, vmStatus3],
+        history: [
+          {
+            conditions: [],
+            migration: {
+              name: 'plan-9-mock-migration',
+              namespace: META.namespace,
+            },
+            plan: {
+              name: 'plantest-10',
+              namespace: 'openshift-migration',
+            },
+            provider: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+          },
+        ],
+      },
+    },
+  };
+
+  MOCK_PLANS = [plan1, plan2, plan3, plan4, plan5, plan6, plan7, plan8, plan9, plan10];
 }


### PR DESCRIPTION
This is a corner case I missed when considering canceled VMs in https://github.com/konveyor/forklift-ui/pull/501.