### PR TITLE
Bug 1947519: Track migrate/cutover request state locally to the button instead of at the plans page level

### DIFF
--- a/src/app/Plans/PlansPage.tsx
+++ b/src/app/Plans/PlansPage.tsx
@@ -10,37 +10,23 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { useHistory } from 'react-router-dom';
 
 import {
   useHasSufficientProvidersQuery,
   usePlansQuery,
-  useCreateMigrationMutation,
   useClusterProvidersQuery,
-  useSetCutoverMutation,
 } from '@app/queries';
 
 import PlansTable from './components/PlansTable';
 import CreatePlanButton from './components/CreatePlanButton';
-import {
-  ResolvedQuery,
-  QuerySpinnerMode,
-  ResolvedQueries,
-} from '@app/common/components/ResolvedQuery';
-import { IMigration } from '@app/queries/types/migrations.types';
+import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 
 const PlansPage: React.FunctionComponent = () => {
   const sufficientProvidersQuery = useHasSufficientProvidersQuery();
   const clusterProvidersQuery = useClusterProvidersQuery();
   const plansQuery = usePlansQuery();
 
-  const history = useHistory();
-  const onMigrationStarted = (migration: IMigration) => {
-    history.push(`/plans/${migration.spec.plan.name}`);
-  };
-  const [createMigration, createMigrationResult] = useCreateMigrationMutation(onMigrationStarted);
-
-  const [setCutover, setCutoverResult] = useSetCutoverMutation();
+  const errorContainerRef = React.useRef<HTMLDivElement>(null);
 
   return (
     <>
@@ -48,20 +34,7 @@ const PlansPage: React.FunctionComponent = () => {
         <Title headingLevel="h1">Migration plans</Title>
       </PageSection>
       <PageSection>
-        <ResolvedQuery
-          result={createMigrationResult}
-          errorTitle="Error starting migration"
-          errorsInline={false}
-          spinnerMode={QuerySpinnerMode.None}
-          className={spacing.mbMd}
-        />
-        <ResolvedQuery
-          result={setCutoverResult}
-          errorTitle="Error setting cutover time"
-          errorsInline={false}
-          spinnerMode={QuerySpinnerMode.None}
-          className={spacing.mbMd}
-        />
+        <div ref={errorContainerRef} />
         <ResolvedQueries
           results={[sufficientProvidersQuery.result, clusterProvidersQuery, plansQuery]}
           errorTitles={[
@@ -87,10 +60,7 @@ const PlansPage: React.FunctionComponent = () => {
               ) : (
                 <PlansTable
                   plans={plansQuery.data?.items || []}
-                  createMigration={createMigration}
-                  createMigrationResult={createMigrationResult}
-                  setCutover={setCutover}
-                  setCutoverResult={setCutoverResult}
+                  errorContainerRef={errorContainerRef}
                 />
               )}
             </CardBody>

--- a/src/app/Plans/components/MigrateOrCutoverButton.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverButton.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { useHistory } from 'react-router-dom';
+import { Button, Spinner } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { useCreateMigrationMutation, useSetCutoverMutation } from '@app/queries';
+import { IMigration } from '@app/queries/types/migrations.types';
+import { IPlan } from '@app/queries/types';
+import { PlanActionButtonType } from './PlansTable';
+import { ResolvedQuery, QuerySpinnerMode } from '@app/common/components/ResolvedQuery';
+
+interface IMigrateOrCutoverButtonProps {
+  plan: IPlan;
+  buttonType: PlanActionButtonType;
+  isBeingStarted: boolean;
+  errorContainerRef: React.RefObject<HTMLDivElement>;
+}
+
+const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonProps> = ({
+  plan,
+  buttonType,
+  isBeingStarted,
+  errorContainerRef,
+}: IMigrateOrCutoverButtonProps) => {
+  const history = useHistory();
+  const onMigrationStarted = (migration: IMigration) => {
+    history.push(`/plans/${migration.spec.plan.name}`);
+  };
+  const [createMigration, createMigrationResult] = useCreateMigrationMutation(onMigrationStarted);
+  const [setCutover, setCutoverResult] = useSetCutoverMutation();
+  if (isBeingStarted || createMigrationResult.isLoading || setCutoverResult.isLoading) {
+    return <Spinner size="md" className={spacing.mxLg} />;
+  }
+  return (
+    <>
+      <Button
+        variant="secondary"
+        onClick={() => {
+          if (buttonType === 'Start' || buttonType === 'Restart') {
+            createMigration(plan);
+          } else if (buttonType === 'Cutover') {
+            setCutover({ plan, cutover: new Date().toISOString() });
+          }
+        }}
+      >
+        {buttonType}
+      </Button>
+      {(createMigrationResult.isError || setCutoverResult.isError) && errorContainerRef.current
+        ? createPortal(
+            <>
+              <ResolvedQuery
+                result={createMigrationResult}
+                errorTitle="Error starting migration"
+                errorsInline={false}
+                spinnerMode={QuerySpinnerMode.None}
+                className={spacing.mbMd}
+              />
+              <ResolvedQuery
+                result={setCutoverResult}
+                errorTitle="Error setting cutover time"
+                errorsInline={false}
+                spinnerMode={QuerySpinnerMode.None}
+                className={spacing.mbMd}
+              />
+            </>,
+            errorContainerRef.current
+          )
+        : null}
+    </>
+  );
+};
+
+export default MigrateOrCutoverButton;


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1947519

Currently when clicking the Start, Restart or Cutover buttons on a plan, all the action buttons for all plans turn grey while the CR is being created/mutated. This is because there is one query hook at the plans page level for all plans, since we display any errors with these requests at the top of the plans page. This is confusing because greying out all the buttons on unrelated plans looks weird, and because it isn't apparent that the action is working.

This PR factors out a `MigrateOrCutoverButton` component which contains its own `useCreateMigrationMutation` and `useSetCutoverMutation` hooks, allowing us to track that request state at a per-plan level. To achieve the centralized error container we had before, a React Portal is used which allows the error child of the button component to be rendered at the top of the plans page. Also, instead of greying out the button during the request, it is replaced by a spinner to be more clear that something is happening.

Along with https://github.com/konveyor/forklift-ui/pull/531, this should hopefully clear up any confusion during the transition while a migration is being started.

Although we can't start migrations in mock mode, the spinner behavior and error reporting can still be tested there.