### PR TITLE
[Backport] Track migrate/cutover request state locally to the button instead of at the plans page level (#537)

### DIFF
--- a/src/app/Plans/PlansPage.tsx
+++ b/src/app/Plans/PlansPage.tsx
@@ -10,37 +10,23 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { useHistory } from 'react-router-dom';
 
 import {
   useHasSufficientProvidersQuery,
   usePlansQuery,
-  useCreateMigrationMutation,
   useClusterProvidersQuery,
-  useSetCutoverMutation,
 } from '@app/queries';
 
 import PlansTable from './components/PlansTable';
 import CreatePlanButton from './components/CreatePlanButton';
-import {
-  ResolvedQuery,
-  QuerySpinnerMode,
-  ResolvedQueries,
-} from '@app/common/components/ResolvedQuery';
-import { IMigration } from '@app/queries/types/migrations.types';
+import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 
 const PlansPage: React.FunctionComponent = () => {
   const sufficientProvidersQuery = useHasSufficientProvidersQuery();
   const clusterProvidersQuery = useClusterProvidersQuery();
   const plansQuery = usePlansQuery();
 
-  const history = useHistory();
-  const onMigrationStarted = (migration: IMigration) => {
-    history.push(`/plans/${migration.spec.plan.name}`);
-  };
-  const [createMigration, createMigrationResult] = useCreateMigrationMutation(onMigrationStarted);
-
-  const [setCutover, setCutoverResult] = useSetCutoverMutation();
+  const errorContainerRef = React.useRef<HTMLDivElement>(null);
 
   return (
     <>
@@ -48,20 +34,7 @@ const PlansPage: React.FunctionComponent = () => {
         <Title headingLevel="h1">Migration plans</Title>
       </PageSection>
       <PageSection>
-        <ResolvedQuery
-          result={createMigrationResult}
-          errorTitle="Error starting migration"
-          errorsInline={false}
-          spinnerMode={QuerySpinnerMode.None}
-          className={spacing.mbMd}
-        />
-        <ResolvedQuery
-          result={setCutoverResult}
-          errorTitle="Error setting cutover time"
-          errorsInline={false}
-          spinnerMode={QuerySpinnerMode.None}
-          className={spacing.mbMd}
-        />
+        <div ref={errorContainerRef} />
         <ResolvedQueries
           results={[sufficientProvidersQuery.result, clusterProvidersQuery, plansQuery]}
           errorTitles={[
@@ -87,10 +60,7 @@ const PlansPage: React.FunctionComponent = () => {
               ) : (
                 <PlansTable
                   plans={plansQuery.data?.items || []}
-                  createMigration={createMigration}
-                  createMigrationResult={createMigrationResult}
-                  setCutover={setCutover}
-                  setCutoverResult={setCutoverResult}
+                  errorContainerRef={errorContainerRef}
                 />
               )}
             </CardBody>

--- a/src/app/Plans/components/MigrateOrCutoverButton.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverButton.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { useHistory } from 'react-router-dom';
+import { Button, Spinner } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { useCreateMigrationMutation, useSetCutoverMutation } from '@app/queries';
+import { IMigration } from '@app/queries/types/migrations.types';
+import { IPlan } from '@app/queries/types';
+import { PlanActionButtonType } from './PlansTable';
+import { ResolvedQuery, QuerySpinnerMode } from '@app/common/components/ResolvedQuery';
+
+interface IMigrateOrCutoverButtonProps {
+  plan: IPlan;
+  buttonType: PlanActionButtonType;
+  isBeingStarted: boolean;
+  errorContainerRef: React.RefObject<HTMLDivElement>;
+}
+
+const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonProps> = ({
+  plan,
+  buttonType,
+  isBeingStarted,
+  errorContainerRef,
+}: IMigrateOrCutoverButtonProps) => {
+  const history = useHistory();
+  const onMigrationStarted = (migration: IMigration) => {
+    history.push(`/plans/${migration.spec.plan.name}`);
+  };
+  const [createMigration, createMigrationResult] = useCreateMigrationMutation(onMigrationStarted);
+  const [setCutover, setCutoverResult] = useSetCutoverMutation();
+  if (isBeingStarted || createMigrationResult.isLoading || setCutoverResult.isLoading) {
+    return <Spinner size="md" className={spacing.mxLg} />;
+  }
+  return (
+    <>
+      <Button
+        variant="secondary"
+        onClick={() => {
+          if (buttonType === 'Start' || buttonType === 'Restart') {
+            createMigration(plan);
+          } else if (buttonType === 'Cutover') {
+            setCutover({ plan, cutover: new Date().toISOString() });
+          }
+        }}
+      >
+        {buttonType}
+      </Button>
+      {(createMigrationResult.isError || setCutoverResult.isError) && errorContainerRef.current
+        ? createPortal(
+            <>
+              <ResolvedQuery
+                result={createMigrationResult}
+                errorTitle="Error starting migration"
+                errorsInline={false}
+                spinnerMode={QuerySpinnerMode.None}
+                className={spacing.mbMd}
+              />
+              <ResolvedQuery
+                result={setCutoverResult}
+                errorTitle="Error setting cutover time"
+                errorsInline={false}
+                spinnerMode={QuerySpinnerMode.None}
+                className={spacing.mbMd}
+              />
+            </>,
+            errorContainerRef.current
+          )
+        : null}
+    </>
+  );
+};
+
+export default MigrateOrCutoverButton;


### PR DESCRIPTION
Backports #537