### PR TITLE
Make status column clickable while plan is running, navigates to migration details

### DIFF
--- a/src/app/Plans/components/PlanStatusNavLink.tsx
+++ b/src/app/Plans/components/PlanStatusNavLink.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import { Button } from '@patternfly/react-core';
+import { IPlan } from '@app/queries/types';
+
+interface IPlanStatusNavLinkProps {
+  plan: IPlan;
+  isInline?: boolean;
+  children: React.ReactNode;
+}
+
+const PlanStatusNavLink: React.FunctionComponent<IPlanStatusNavLinkProps> = ({
+  plan,
+  isInline = true,
+  children,
+}: IPlanStatusNavLinkProps) => {
+  const history = useHistory();
+  return (
+    <Button
+      variant="link"
+      onClick={() => history.push(`/plans/${plan.metadata.name}`)}
+      isInline={isInline}
+      className={!isInline ? 'clickable-progress-bar' : ''}
+    >
+      {children}
+    </Button>
+  );
+};
+
+export default PlanStatusNavLink;

--- a/src/app/Plans/components/PlansTable.css
+++ b/src/app/Plans/components/PlansTable.css
@@ -22,3 +22,10 @@
 .pf-c-table.plans-table table.expanded-content tr > td {
   padding-left: var(--pf-global--spacer--xl);
 }
+
+.pf-c-table.plans-table button.clickable-progress-bar {
+  margin: calc(0px - var(--pf-global--spacer--form-element))
+    calc(0px - var(--pf-global--spacer--md));
+  width: 100%;
+  text-align: left;
+}

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -9,7 +9,6 @@ import {
   ProgressMeasureLocation,
   ProgressVariant,
   Text,
-  Tooltip,
 } from '@patternfly/react-core';
 import {
   Table,
@@ -58,9 +57,9 @@ import {
 import { isSameResource } from '@app/queries/helpers';
 import StatusCondition from '@app/common/components/StatusCondition';
 import MigrateOrCutoverButton from './MigrateOrCutoverButton';
+import PlanStatusNavLink from './PlanStatusNavLink';
 
 export type PlanActionButtonType = 'Start' | 'Restart' | 'Cutover';
-
 interface IPlansTableProps {
   plans: IPlan[];
   errorContainerRef: React.RefObject<HTMLDivElement>;
@@ -258,17 +257,21 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
         plan.spec.warm ? 'Warm' : 'Cold',
         {
           title: isBeingStarted ? (
-            'Running - preparing for migration'
+            <PlanStatusNavLink plan={plan}>Running - preparing for migration</PlanStatusNavLink>
           ) : warmState === 'Starting' ? (
-            'Running - preparing for incremental data copies'
+            <PlanStatusNavLink plan={plan}>
+              Running - preparing for incremental data copies
+            </PlanStatusNavLink>
           ) : !plan.status?.migration?.started || warmState === 'NotStarted' ? (
             <StatusCondition status={plan.status} />
           ) : warmState === 'Copying' ? (
-            'Running - performing incremental data copies'
+            <PlanStatusNavLink plan={plan}>
+              Running - performing incremental data copies
+            </PlanStatusNavLink>
           ) : warmState === 'StartingCutover' ? (
-            'Running - preparing for cutover'
+            <PlanStatusNavLink plan={plan}>Running - preparing for cutover</PlanStatusNavLink>
           ) : (
-            <Tooltip content="Click the plan name to see migration details.">
+            <PlanStatusNavLink plan={plan} isInline={false}>
               <Progress
                 title={title}
                 value={statusValue}
@@ -277,7 +280,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
                 variant={variant}
                 measureLocation={ProgressMeasureLocation.top}
               />
-            </Tooltip>
+            </PlanStatusNavLink>
           ),
         },
         {


### PR DESCRIPTION
Resolves #521. Nice-to-have.