### PR TITLE
Update management network identification

### DIFF
--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -16,9 +16,9 @@ export const findSelectedNetworkAdapter = (
   hostConfig: IHostConfig | null
 ): IHostNetworkAdapter | null => {
   const managementNetwork =
-  host.networkAdapters.find((adapter) =>
-    new Netmask(adapter.ipAddress, adapter.subnetMask).contains(host.managementServerIp)
-  ) || null;
+    host.networkAdapters.find((adapter) =>
+      new Netmask(adapter.ipAddress, adapter.subnetMask).contains(host.managementServerIp)
+    ) || null;
   if (!hostConfig) return managementNetwork;
   return (
     host.networkAdapters.find((adapter) => adapter.ipAddress === hostConfig?.spec.ipAddress) ||

--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -16,7 +16,9 @@ export const findSelectedNetworkAdapter = (
   hostConfig: IHostConfig | null
 ): IHostNetworkAdapter | null => {
   const managementNetwork =
-    host.networkAdapters.find((adapter) => new Netmask(adapter.ipAddress, adapter.subnetMask).contains(host.managementServerIp)) || null;
+  host.networkAdapters.find((adapter) =>
+    new Netmask(adapter.ipAddress, adapter.subnetMask).contains(host.managementServerIp)
+  ) || null;
   if (!hostConfig) return managementNetwork;
   return (
     host.networkAdapters.find((adapter) => adapter.ipAddress === hostConfig?.spec.ipAddress) ||

--- a/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/src/app/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -16,7 +16,7 @@ export const findSelectedNetworkAdapter = (
   hostConfig: IHostConfig | null
 ): IHostNetworkAdapter | null => {
   const managementNetwork =
-    host.networkAdapters.find((adapter) => adapter.ipAddress === host.managementServerIp) || null;
+    host.networkAdapters.find((adapter) => new Netmask(adapter.ipAddress, adapter.subnetMask).contains(host.managementServerIp)) || null;
   if (!hostConfig) return managementNetwork;
   return (
     host.networkAdapters.find((adapter) => adapter.ipAddress === hostConfig?.spec.ipAddress) ||

--- a/src/app/queries/mocks/hosts.mock.ts
+++ b/src/app/queries/mocks/hosts.mock.ts
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     name: 'esx12.v2v.bos.redhat.com',
     selfLink: '/providers/vsphere/test/hosts/host-44',
     inMaintenance: false,
-    managementServerIp: '10.19.2.12',
+    managementServerIp: '10.19.2.10',
     thumbprint: 'D3:47:18:B1:11:39:87:25:F4:52:B2:04:EC:85:88:FA:9D:78:73:11',
     cpuSockets: 2,
     cpuCores: 16,


### PR DESCRIPTION
The `managementServerIp` attribute of the host is not the address of the host on the management network, but the address of the vCenter that manages the host. To identify the management network, we need to identify the item in the host `networkAdapters` array which `ipAddress` + `subnetMask` matches the `managementServerIp`.

This pull request updates the logic to compute the network range based on the `ipAddress` and `subnetMask` for each network adapter and pick the one that contains `managementServerIp`.