### PR TITLE
Hack around weird double scrollbar bug

### DIFF
--- a/src/app/Plans/components/Wizard/PlanWizard.css
+++ b/src/app/Plans/components/Wizard/PlanWizard.css
@@ -1,0 +1,6 @@
+.pf-c-wizard__main-body {
+  /* Fixes double scrollbar when wizard body contents are tall enough for scrolling. */
+  /* This should absolutely not be necessary, there is something funky going on here with heights and overflow. */
+  /* See https://github.com/konveyor/forklift-ui/issues/550 */
+  max-height: calc(100vh - 286px);
+}

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -53,6 +53,8 @@ import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import TypeForm from './TypeForm';
 
+import './PlanWizard.css';
+
 const useMappingFormState = (mappingsQuery: QueryResult<IKubeList<Mapping>>) => {
   const isSaveNewMapping = useFormField(false, yup.boolean().required());
   const newMappingNameSchema = getMappingNameSchema(mappingsQuery, null).label('Name');


### PR DESCRIPTION
This PR applies a custom `max-height` to the wizard body container in order to prevent there ever being "double scrollbars" where two nested containers both have overflowing content relative to their height. See https://github.com/konveyor/forklift-ui/issues/550 for a description of the bug. The arbitrary `286px` in the calculation is the total height of the app header, page section header, and wizard footer which are all static heights.

We need to remove this custom CSS and find the real solution to the bug it works around. Capturing that in https://github.com/konveyor/forklift-ui/issues/550.