### PR TITLE
Bug 1908745: Capture environment variables for version numbers at run time instead of build time

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -31,4 +31,25 @@ const sanitizeAndEncodeMeta = (meta) =>
 const getAppTitle = () =>
   process.env['BRAND_TYPE'] === 'RedHat' ? 'Migration Toolkit for Virtualization' : 'Forklift';
 
-module.exports = { getDevMeta, sanitizeAndEncodeMeta, getAppTitle };
+const FORKLIFT_ENV = [
+  'NODE_ENV',
+  'DATA_SOURCE',
+  'BRAND_TYPE',
+  'FORKLIFT_OPERATOR_VERSION',
+  'FORKLIFT_CONTROLLER_GIT_COMMIT',
+  'FORKLIFT_MUST_GATHER_GIT_COMMIT',
+  'FORKLIFT_OPERATOR_GIT_COMMIT',
+  'FORKLIFT_UI_GIT_COMMIT',
+  'FORKLIFT_VALIDATION_GIT_COMMIT',
+  'FORKLIFT_CLUSTER_VERSION',
+];
+
+const logEnv = () =>
+  FORKLIFT_ENV.forEach((varName) => console.log(` ${varName}=${process.env[varName]}`));
+
+const getEnv = () =>
+  FORKLIFT_ENV.reduce((newObj, varName) => ({ ...newObj, [varName]: process.env[varName] }), {});
+
+const getEncodedEnv = () => Buffer.from(JSON.stringify(getEnv())).toString('base64');
+
+module.exports = { getDevMeta, sanitizeAndEncodeMeta, getAppTitle, logEnv, getEnv, getEncodedEnv };

--- a/config/helpers.js
+++ b/config/helpers.js
@@ -44,12 +44,9 @@ const FORKLIFT_ENV = [
   'FORKLIFT_CLUSTER_VERSION',
 ];
 
-const logEnv = () =>
-  FORKLIFT_ENV.forEach((varName) => console.log(` ${varName}=${process.env[varName]}`));
-
 const getEnv = () =>
   FORKLIFT_ENV.reduce((newObj, varName) => ({ ...newObj, [varName]: process.env[varName] }), {});
 
 const getEncodedEnv = () => Buffer.from(JSON.stringify(getEnv())).toString('base64');
 
-module.exports = { getDevMeta, sanitizeAndEncodeMeta, getAppTitle, logEnv, getEnv, getEncodedEnv };
+module.exports = { getDevMeta, sanitizeAndEncodeMeta, getAppTitle, getEnv, getEncodedEnv };

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -6,17 +6,8 @@ const webpack = require('webpack');
 const BG_IMAGES_DIRNAME = 'bgimages';
 const helpers = require('./helpers');
 
-console.log('\nEnvironment:');
-console.log(`  NODE_ENV=${process.env.NODE_ENV}`);
-console.log(`  DATA_SOURCE=${process.env.DATA_SOURCE}`);
-console.log(`  BRAND_TYPE=${process.env.BRAND_TYPE}`);
-console.log(`  FORKLIFT_OPERATOR_VERSION=${process.env.FORKLIFT_OPERATOR_VERSION}`);
-console.log(`  FORKLIFT_CONTROLLER_GIT_COMMIT=${process.env.FORKLIFT_CONTROLLER_GIT_COMMIT}`);
-console.log(`  FORKLIFT_MUST_GATHER_GIT_COMMIT=${process.env.FORKLIFT_MUST_GATHER_GIT_COMMIT}`);
-console.log(`  FORKLIFT_OPERATOR_GIT_COMMIT=${process.env.FORKLIFT_OPERATOR_GIT_COMMIT}`);
-console.log(`  FORKLIFT_UI_GIT_COMMIT=${process.env.FORKLIFT_UI_GIT_COMMIT}`);
-console.log(`  FORKLIFT_VALIDATION_GIT_COMMIT=${process.env.FORKLIFT_VALIDATION_GIT_COMMIT}`);
-console.log(`  FORKLIFT_CLUSTER_VERSION=${process.env.FORKLIFT_CLUSTER_VERSION}\n`);
+console.log('\nEnvironment at build time:');
+helpers.logEnv();
 
 module.exports = (env) => {
   return {
@@ -150,16 +141,17 @@ module.exports = (env) => {
       new HtmlWebpackPlugin({
         ...(env === 'development' || process.env.DATA_SOURCE === 'mock'
           ? {
-              // In dev and mock-prod modes, populate window._meta at build time
+              // In dev and mock-prod modes, populate window._meta and window._env at build time
               filename: 'index.html',
               template: path.resolve(__dirname, '../src/index.html.ejs'),
               templateParameters: {
                 _meta: helpers.sanitizeAndEncodeMeta(helpers.getDevMeta()),
+                _env: helpers.getEncodedEnv(),
                 _app_title: helpers.getAppTitle(),
               },
             }
           : {
-              // In real prod mode, populate window._env at run time with express
+              // In real prod mode, populate window._meta and window._env at run time with express
               filename: 'index.html.ejs',
               template: `!!raw-loader!${path.resolve(__dirname, '../src/index.html.ejs')}`,
             }),
@@ -174,13 +166,6 @@ module.exports = (env) => {
         DATA_SOURCE: 'remote',
         BRAND_TYPE: 'Konveyor',
         NODE_ENV: 'production',
-        FORKLIFT_OPERATOR_VERSION: '-',
-        FORKLIFT_CONTROLLER_GIT_COMMIT: '-',
-        FORKLIFT_MUST_GATHER_GIT_COMMIT: '-',
-        FORKLIFT_OPERATOR_GIT_COMMIT: '-',
-        FORKLIFT_UI_GIT_COMMIT: '-',
-        FORKLIFT_VALIDATION_GIT_COMMIT: '-',
-        FORKLIFT_CLUSTER_VERSION: '-',
       }),
     ],
     resolve: {

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -7,7 +7,7 @@ const BG_IMAGES_DIRNAME = 'bgimages';
 const helpers = require('./helpers');
 
 console.log('\nEnvironment at build time:');
-helpers.logEnv();
+console.log(helpers.getEnv());
 
 module.exports = (env) => {
   return {

--- a/deploy/server.js
+++ b/deploy/server.js
@@ -19,9 +19,9 @@ if (process.env['DATA_SOURCE'] === 'mock') {
 }
 
 console.log('\nEnvironment at run time:');
-helpers.logEnv();
+console.log(helpers.getEnv());
 
-console.log(`\nUsing meta values:\n${metaStr}\n\n`);
+console.log(`\nValues from meta.json:\n${metaStr}\n\n`);
 const meta = JSON.parse(metaStr);
 
 const app = express();

--- a/deploy/server.js
+++ b/deploy/server.js
@@ -18,8 +18,10 @@ if (process.env['DATA_SOURCE'] === 'mock') {
   metaStr = fs.readFileSync(metaFile, 'utf8');
 }
 
-console.log(`\nUsing meta values:\n${metaStr}\n\n`);
+console.log('\nEnvironment at run time:');
+helpers.logEnv();
 
+console.log(`\nUsing meta values:\n${metaStr}\n\n`);
 const meta = JSON.parse(metaStr);
 
 const app = express();
@@ -135,11 +137,12 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
 
 app.get('*', (_, res) => {
   if (process.env['NODE_ENV'] === 'development' || process.env['DATA_SOURCE'] === 'mock') {
-    // In dev and mock-prod modes, window._meta was populated at build time
+    // In dev and mock-prod modes, window._meta and window._env were populated at build time
     res.sendFile(path.join(__dirname, '../dist/index.html'));
   } else {
     res.render('index.html.ejs', {
       _meta: helpers.sanitizeAndEncodeMeta(meta),
+      _env: helpers.getEncodedEnv(),
       _app_title: helpers.getAppTitle(),
     });
   }

--- a/src/app/AppLayout/ForkliftAboutModal.tsx
+++ b/src/app/AppLayout/ForkliftAboutModal.tsx
@@ -8,13 +8,15 @@ interface IForkliftAboutModalProps {
   onClose: () => void;
 }
 
+const truncateSha = (hash: string) => hash.slice(0, 7);
+
 const versions = [
   ['Toolkit operator version', ENV.FORKLIFT_OPERATOR_VERSION],
-  ['Git commit (forklift-controller)', ENV.FORKLIFT_CONTROLLER_GIT_COMMIT],
-  ['Git commit (forklift-must-gather)', ENV.FORKLIFT_MUST_GATHER_GIT_COMMIT],
-  ['Git commit (forklift-operator)', ENV.FORKLIFT_OPERATOR_GIT_COMMIT],
-  ['Git commit (forklift-ui)', ENV.FORKLIFT_UI_GIT_COMMIT],
-  ['Git commit (forklift-validation)', ENV.FORKLIFT_VALIDATION_GIT_COMMIT],
+  ['Git commit (forklift-controller)', truncateSha(ENV.FORKLIFT_CONTROLLER_GIT_COMMIT)],
+  ['Git commit (forklift-must-gather)', truncateSha(ENV.FORKLIFT_MUST_GATHER_GIT_COMMIT)],
+  ['Git commit (forklift-operator)', truncateSha(ENV.FORKLIFT_OPERATOR_GIT_COMMIT)],
+  ['Git commit (forklift-ui)', truncateSha(ENV.FORKLIFT_UI_GIT_COMMIT)],
+  ['Git commit (forklift-validation)', truncateSha(ENV.FORKLIFT_VALIDATION_GIT_COMMIT)],
   ['OpenShift version', ENV.FORKLIFT_CLUSTER_VERSION],
 ];
 

--- a/src/app/AppLayout/ForkliftAboutModal.tsx
+++ b/src/app/AppLayout/ForkliftAboutModal.tsx
@@ -8,7 +8,7 @@ interface IForkliftAboutModalProps {
   onClose: () => void;
 }
 
-const truncateSha = (hash: string) => hash.slice(0, 7);
+const truncateSha = (hash?: string) => hash?.slice(0, 7) || '-';
 
 const versions = [
   ['Toolkit operator version', ENV.FORKLIFT_OPERATOR_VERSION],

--- a/src/app/AppLayout/ForkliftAboutModal.tsx
+++ b/src/app/AppLayout/ForkliftAboutModal.tsx
@@ -1,4 +1,4 @@
-import { APP_TITLE } from '@app/common/constants';
+import { APP_TITLE, ENV } from '@app/common/constants';
 import { APP_BRAND, BrandType } from '@app/global-flags';
 import { AboutModal, TextContent, TextList, TextListItem } from '@patternfly/react-core';
 import * as React from 'react';
@@ -9,13 +9,13 @@ interface IForkliftAboutModalProps {
 }
 
 const versions = [
-  ['Toolkit operator version', process.env.FORKLIFT_OPERATOR_VERSION],
-  ['Git commit (forklift-controller)', process.env.FORKLIFT_CONTROLLER_GIT_COMMIT],
-  ['Git commit (forklift-must-gather)', process.env.FORKLIFT_MUST_GATHER_GIT_COMMIT],
-  ['Git commit (forklift-operator)', process.env.FORKLIFT_OPERATOR_GIT_COMMIT],
-  ['Git commit (forklift-ui)', process.env.FORKLIFT_UI_GIT_COMMIT],
-  ['Git commit (forklift-validation)', process.env.FORKLIFT_VALIDATION_GIT_COMMIT],
-  ['OpenShift version', process.env.FORKLIFT_CLUSTER_VERSION],
+  ['Toolkit operator version', ENV.FORKLIFT_OPERATOR_VERSION],
+  ['Git commit (forklift-controller)', ENV.FORKLIFT_CONTROLLER_GIT_COMMIT],
+  ['Git commit (forklift-must-gather)', ENV.FORKLIFT_MUST_GATHER_GIT_COMMIT],
+  ['Git commit (forklift-operator)', ENV.FORKLIFT_OPERATOR_GIT_COMMIT],
+  ['Git commit (forklift-ui)', ENV.FORKLIFT_UI_GIT_COMMIT],
+  ['Git commit (forklift-validation)', ENV.FORKLIFT_VALIDATION_GIT_COMMIT],
+  ['OpenShift version', ENV.FORKLIFT_CLUSTER_VERSION],
 ];
 
 const ForkliftAboutModal: React.FunctionComponent<IForkliftAboutModalProps> = ({

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
 
-import { IMetaVars } from './types';
+import { IEnvVars, IMetaVars } from './types';
 
 export const APP_TITLE =
   process.env['BRAND_TYPE'] === 'RedHat' ? 'Migration Toolkit for Virtualization' : 'Forklift';
@@ -79,6 +79,8 @@ export const META: IMetaVars =
         inventoryApi: '/mock/api',
         inventoryPayloadApi: '/mock/api',
       };
+
+export const ENV: IEnvVars = window['_env'];
 
 export const dnsLabelNameSchema = yup
   .string()

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -80,7 +80,7 @@ export const META: IMetaVars =
         inventoryPayloadApi: '/mock/api',
       };
 
-export const ENV: IEnvVars = window['_env'];
+export const ENV: IEnvVars = window['_env'] || {};
 
 export const dnsLabelNameSchema = yup
   .string()

--- a/src/app/common/types.ts
+++ b/src/app/common/types.ts
@@ -1,3 +1,5 @@
+import { BrandType } from '@app/global-flags';
+
 export interface IMetaVars {
   clusterApi: string;
   devServerPort: string;
@@ -11,4 +13,17 @@ export interface IMetaVars {
   configNamespace: string;
   inventoryApi: string;
   inventoryPayloadApi: string;
+}
+
+export interface IEnvVars {
+  NODE_ENV: string;
+  DATA_SOURCE: string;
+  BRAND_TYPE: BrandType;
+  FORKLIFT_OPERATOR_VERSION: string;
+  FORKLIFT_CONTROLLER_GIT_COMMIT: string;
+  FORKLIFT_MUST_GATHER_GIT_COMMIT: string;
+  FORKLIFT_OPERATOR_GIT_COMMIT: string;
+  FORKLIFT_UI_GIT_COMMIT: string;
+  FORKLIFT_VALIDATION_GIT_COMMIT: string;
+  FORKLIFT_CLUSTER_VERSION: string;
 }

--- a/src/index.html.ejs
+++ b/src/index.html.ejs
@@ -13,6 +13,7 @@
     <base href="/" />
     <script>
       window._meta = JSON.parse(atob('<%= _meta %>'));
+      window._env = JSON.parse(atob('<%= _env %>'));
     </script>
   </head>
 


### PR DESCRIPTION
Resolves the last part of https://bugzilla.redhat.com/show_bug.cgi?id=1908745, where cluster and operator versions were not appearing in the UI. These variables are not present when webpack builds the UI, only when express runs it. This PR uses a similar mechanism to the one we use for `meta.json` to populate a subset of env vars into the UI via a base64-encoded `window._env` variable injected by express. webpack also injects this variable when building in dev and mock modes so it will always be defined.