### PR TITLE
Bug 1952636: Use the provider CR instead of the inventory provider to look for the defaultTransferNetwork annotation in the wizard

### DIFF
--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -26,6 +26,7 @@ import SelectOpenShiftNetworkModal from '@app/common/components/SelectOpenShiftN
 import { HelpIcon } from '@patternfly/react-icons';
 import { useOpenShiftNetworksQuery } from '@app/queries/networks';
 import { usePausedPollingEffect } from '@app/common/context';
+import { isSameResource } from '@app/queries/helpers';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
@@ -75,10 +76,12 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
     form.fields.targetNamespace.setIsTouched(true);
     setIsNamespaceSelectOpen(false);
     if (targetNamespace !== form.values.targetNamespace) {
+      const targetProviderCR = clusterProvidersQuery.data?.items.find((provider) =>
+        isSameResource(form.values.targetProvider, provider.metadata)
+      );
       const providerDefaultNetworkName =
-        form.values.targetProvider?.object.metadata.annotations?.[
-          'forklift.konveyor.io/defaultTransferNetwork'
-        ] || null;
+        targetProviderCR?.metadata.annotations?.['forklift.konveyor.io/defaultTransferNetwork'] ||
+        null;
       const matchingNetwork = openshiftNetworksQuery.data?.find(
         (network) =>
           network.name === providerDefaultNetworkName && network.namespace === targetNamespace


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1952636

When a target namespace is selected in the plan wizard, the UI looks up the annotations on the target provider to check if it has a default transfer network specified, and selects that network if present in the selected namespace.

The bug is happening because the UI does this by looking at the provider from the inventory API and using its `.object` reference to the CR, which is a subset of the CR and does not have the `metadata.annotations` property that the CR itself does. I'm not sure if that ever existed and disappeared, or if I made a bad assumption.

This PR instead uses the CR from the cluster API (already had it in memory in this page anyway) to look up that annotation.