### PR TITLE
[Backport] Change plan transferNetwork to be a name/namespace ref, fix bug where  'Pod network' string could be passed (#559)

### DIFF
--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -367,7 +367,14 @@ export const generatePlan = (
       destination: nameAndNamespace(forms.general.values.targetProvider),
     },
     targetNamespace: forms.general.values.targetNamespace,
-    transferNetwork: forms.general.values.migrationNetwork || '',
+    // Note: This assumes we will only ever allow migration networks that are in the target namespace.
+    //       We may want to store migrationNetwork name/namespace in form state instead of just name.
+    transferNetwork: forms.general.values.migrationNetwork
+      ? {
+          name: forms.general.values.migrationNetwork,
+          namespace: forms.general.values.targetNamespace,
+        }
+      : null,
     map: {
       network: networkMappingRef,
       storage: storageMappingRef,
@@ -478,7 +485,7 @@ export const useEditingPlanPrefillEffect = (
       forms.general.fields.targetProvider.setInitialValue(targetProvider);
       forms.general.fields.targetNamespace.setInitialValue(planBeingEdited.spec.targetNamespace);
       forms.general.fields.migrationNetwork.setInitialValue(
-        planBeingEdited.spec.transferNetwork || null
+        planBeingEdited.spec.transferNetwork?.name || null
       );
 
       forms.filterVMs.fields.selectedTreeNodes.setInitialValue(selectedTreeNodes);

--- a/src/app/common/components/SelectOpenShiftNetworkModal.tsx
+++ b/src/app/common/components/SelectOpenShiftNetworkModal.tsx
@@ -25,6 +25,7 @@ import { MutationResult } from 'react-query';
 import { IKubeResponse, KubeClientError } from '@app/client/types';
 import { QuerySpinnerMode, ResolvedQuery } from './ResolvedQuery';
 import { useOpenShiftNetworksQuery } from '@app/queries/networks';
+import { isSameResource } from '@app/queries/helpers';
 
 interface ISelectOpenShiftNetworkModalProps {
   targetProvider: IOpenShiftProvider | null;
@@ -97,7 +98,8 @@ const SelectOpenShiftNetworkModal: React.FunctionComponent<ISelectOpenShiftNetwo
               variant="primary"
               isDisabled={!form.isDirty || !form.isValid || mutationResult?.isLoading}
               onClick={() => {
-                onSubmit(selectedNetworkOption?.value || null);
+                const isPodNetwork = isSameResource(selectedNetworkOption?.value, POD_NETWORK);
+                onSubmit((!isPodNetwork && selectedNetworkOption?.value) || null);
               }}
             >
               Select

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -188,6 +188,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
+      transferNetwork: null,
       map: {
         network: nameAndNamespace(MOCK_NETWORK_MAPPINGS[0].metadata),
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
@@ -273,7 +274,10 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
-      transferNetwork: 'ocp-network-2',
+      transferNetwork: {
+        name: 'ocp-network-2',
+        namespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
+      },
       map: {
         network: nameAndNamespace(MOCK_NETWORK_MAPPINGS[0].metadata),
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
@@ -333,6 +337,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
+      transferNetwork: null,
       map: {
         network: nameAndNamespace(MOCK_NETWORK_MAPPINGS[0].metadata),
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
@@ -402,6 +407,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
+      transferNetwork: null,
       map: {
         network: nameAndNamespace(MOCK_NETWORK_MAPPINGS[0].metadata),
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),
@@ -555,6 +561,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[1]),
       },
       targetNamespace: MOCK_OPENSHIFT_NAMESPACES[0].name,
+      transferNetwork: null,
       map: {
         network: nameAndNamespace(MOCK_NETWORK_MAPPINGS[0].metadata),
         storage: nameAndNamespace(MOCK_STORAGE_MAPPINGS[0].metadata),

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -77,7 +77,7 @@ export interface IPlan extends ICR {
     description: string;
     provider: ISrcDestRefs;
     targetNamespace: string;
-    transferNetwork?: string;
+    transferNetwork: INameNamespaceRef | null;
     map: {
       network: INameNamespaceRef;
       storage: INameNamespaceRef;


### PR DESCRIPTION
Backports #559