### PR TITLE
Use API version v1beta1

### DIFF
--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -23,7 +23,7 @@ export class ForkliftResource extends NamespacedResource {
 
     this._gvk = {
       group: 'forklift.konveyor.io',
-      version: 'v1alpha1',
+      version: 'v1beta1',
       kindPlural: kind,
     };
   }

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -5,7 +5,7 @@ import { IEnvVars, IMetaVars } from './types';
 export const APP_TITLE =
   process.env['BRAND_TYPE'] === 'RedHat' ? 'Migration Toolkit for Virtualization' : 'Forklift';
 
-export const CLUSTER_API_VERSION = 'forklift.konveyor.io/v1alpha1';
+export const CLUSTER_API_VERSION = 'forklift.konveyor.io/v1beta1';
 
 export const CLOUD_MA_LINK = {
   href: 'https://cloud.redhat.com/migrations/migration-analytics',

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -177,7 +177,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-01',
+        '/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-migration/plans/plantest-01',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -263,7 +263,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-02',
+        '/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-migration/plans/plantest-02',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -326,7 +326,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       generation: 2,
       resourceVersion: '30825023',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-03',
+        '/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-migration/plans/plantest-03',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -396,7 +396,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-04',
+        '/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-migration/plans/plantest-04',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },
@@ -550,7 +550,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       generation: 2,
       resourceVersion: '30825024',
       selfLink:
-        '/apis/forklift.konveyor.io/v1alpha1/namespaces/openshift-migration/plans/plantest-06',
+        '/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-migration/plans/plantest-06',
       uid: '28fde094-b667-4d21-8f29-27c18f22178c',
       creationTimestamp: '2020-08-27T19:40:49Z',
     },


### PR DESCRIPTION
With [forklift-controller#238](https://github.com/konveyor/forklift-controller/pull/238) merged, the API version has changed to `v1beta1`. So, the API fails to retrieve the inventory and to create new custom resources. This merge request updates the UI to use `v1beta1` API version;