### PR TITLE
Add named preview deployments for release branches

### DIFF
--- a/.github/workflows/deploy-main-preview.yaml
+++ b/.github/workflows/deploy-main-preview.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   test-and-release:
     name: Deploy preview to Surge
-    if: github.repository == "konveyor/forklift-ui"
+    if: ${{ github.repository == 'konveyor/forklift-ui' }}
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-main-preview.yaml
+++ b/.github/workflows/deploy-main-preview.yaml
@@ -1,12 +1,14 @@
-name: Deploy main branch preview
+name: Deploy main/release branch preview
 on:
   push:
     branches:
       - main
+      - release*
 
 jobs:
   test-and-release:
     name: Deploy preview to Surge
+    if: github.repository == "konveyor/forklift-ui"
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -23,5 +25,9 @@ jobs:
         run: npm run build:mock
       - name: Install Surge
         run: npm install -g surge
+      - name: Extract branch name for Surge URL
+        shell: bash
+        run: echo "##[set-output name=branch_slug;]$(echo ${GITHUB_REF#refs/heads/}- | tr . _ | sed -r 's/^main-$//g')"
+        id: extract_branch
       - name: Deploy to Surge
-        run: surge ./dist/ konveyor-forklift-ui-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        run: surge ./dist/ konveyor-forklift-ui-${{ steps.extract_branch.outputs.branch_slug }}preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
I realized this would be nice to have and easy to throw in.

Currently the `deploy-main-preview.yaml` workflow just runs when commits are pushed to `main` and deploys to the hard-coded `konveyor-forklift-ui-preview.surge.sh` URL. I figured it would be nice to have a preview of the current state of our release branches as well, for people to be able to easily look at what has and has not been backported, etc. and to preserve the latest preview of the release branch without having to look for the most recent backported PR.

This PR adds a step to this workflow to extract the branch name from the `GITHUB_REF` environment variable (see https://stackoverflow.com/a/58035262), replace any dots in it with underscores (so it can be part of a valid surge subdomain), and place it in the Surge URL. So if the workflow is running on the `release-v2.0.0` branch, the `branch_slug` will be `release-v2_0_0-` and the resulting preview URL will be `konveyor-forklift-ui-release-v2_0_0-preview.surge.sh`.

In order to preserve the existing `konveyor-forklift-ui-preview.surge.sh` for the main branch, the `branch_slug` contains a trailing dash after the escaped branch name and uses `sed` to replace `main-` with an empty string. So when this runs on the main branch, it will continue to deploy to the existing URL and not break anyone's bookmarks 😄 

Also, the new `if` conditional on the job prevents it from running in forks (it will only run in the konveyor/forklift-ui repo). This way we don't get failed job alerts because we pushed a `release-foo` branch to a fork that doesn't have our Surge token set up.