### PR TITLE
Hooks wizard step scaffolding, form state, and modal to add hooks to the plan

### DIFF
--- a/src/app/Hooks/components/HookDefinitionInputs.tsx
+++ b/src/app/Hooks/components/HookDefinitionInputs.tsx
@@ -1,29 +1,38 @@
-import { IHook } from '@app/queries/types';
+import * as React from 'react';
 import { ValidatedTextInput } from '@konveyor/lib-ui';
 import { Popover, Button } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
-import * as React from 'react';
-import { HookDefinitionFormState } from './AddEditHookModal';
+import { HookFormState } from './AddEditHookModal';
 
 interface IHookDefinitionInputsProps {
-  fields: HookDefinitionFormState['fields'];
-  hookBeingEdited: IHook | null;
+  fields: HookFormState['fields']; // Can come from either HookFormState or PlanHookInstanceFormState since they share these fields!
+  editingHookName: string | null;
+  hideName?: boolean;
+  children?: React.ReactNode; // Fields to render after the name field... convenient for what we need, may need to refactor if we change field order
 }
 
 const HookDefinitionInputs: React.FunctionComponent<IHookDefinitionInputsProps> = ({
   fields,
-  hookBeingEdited,
+  editingHookName,
+  hideName = false,
+  children = null,
 }: IHookDefinitionInputsProps) => (
   <>
-    <ValidatedTextInput field={fields.name} label="Hook name" isRequired fieldId="hook-name" />
+    {!hideName ? (
+      <ValidatedTextInput
+        field={fields.name}
+        label="Hook name"
+        isRequired
+        fieldId="hook-name"
+        inputProps={{ isDisabled: !!editingHookName }}
+      />
+    ) : null}
+    {children}
     <ValidatedTextInput
       field={fields.url}
       label="Git repository URL"
       isRequired
       fieldId="hook-url"
-      inputProps={{
-        isDisabled: !!hookBeingEdited,
-      }}
       formGroupProps={{
         labelIcon: (
           <Popover bodyContent="This is the Git repository where the Ansible playbook is located.">

--- a/src/app/Hooks/components/HookDefinitionInputs.tsx
+++ b/src/app/Hooks/components/HookDefinitionInputs.tsx
@@ -1,0 +1,47 @@
+import { IHook } from '@app/queries/types';
+import { ValidatedTextInput } from '@konveyor/lib-ui';
+import { Popover, Button } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { HookDefinitionFormState } from './AddEditHookModal';
+
+interface IHookDefinitionInputsProps {
+  fields: HookDefinitionFormState['fields'];
+  hookBeingEdited: IHook | null;
+}
+
+const HookDefinitionInputs: React.FunctionComponent<IHookDefinitionInputsProps> = ({
+  fields,
+  hookBeingEdited,
+}: IHookDefinitionInputsProps) => (
+  <>
+    <ValidatedTextInput field={fields.name} label="Hook name" isRequired fieldId="hook-name" />
+    <ValidatedTextInput
+      field={fields.url}
+      label="Git repository URL"
+      isRequired
+      fieldId="hook-url"
+      inputProps={{
+        isDisabled: !!hookBeingEdited,
+      }}
+      formGroupProps={{
+        labelIcon: (
+          <Popover bodyContent="This is the Git repository where the Ansible playbook is located.">
+            <Button
+              variant="plain"
+              aria-label="More info for url field"
+              onClick={(e) => e.preventDefault()}
+              aria-describedby="hook-url-info"
+              className="pf-c-form__group-label-help"
+            >
+              <HelpIcon noVerticalAlign />
+            </Button>
+          </Popover>
+        ),
+      }}
+    />
+    <ValidatedTextInput field={fields.branch} label="Branch" isRequired fieldId="hook-branch" />
+  </>
+);
+
+export default HookDefinitionInputs;

--- a/src/app/Hooks/components/helpers.ts
+++ b/src/app/Hooks/components/helpers.ts
@@ -1,9 +1,9 @@
 import { CLUSTER_API_VERSION, META } from '@app/common/constants';
 import { IHook } from '@app/queries/types';
 import React from 'react';
-import { HookFormState } from './AddEditHookModal';
+import { HookDefinitionFormState } from './AddEditHookModal';
 
-export const generateHook = (form: HookFormState): IHook => ({
+export const generateHook = (form: HookDefinitionFormState): IHook => ({
   apiVersion: CLUSTER_API_VERSION,
   kind: 'Hook',
   metadata: {
@@ -21,7 +21,7 @@ interface IEditHookPrefillEffect {
 }
 
 export const useEditHookPrefillEffect = (
-  form: HookFormState,
+  form: HookDefinitionFormState,
   hookBeingEdited: IHook | null
 ): IEditHookPrefillEffect => {
   const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);

--- a/src/app/Hooks/components/helpers.ts
+++ b/src/app/Hooks/components/helpers.ts
@@ -1,9 +1,35 @@
-import { CLUSTER_API_VERSION, META } from '@app/common/constants';
+import * as yup from 'yup';
+import { CLUSTER_API_VERSION, META, urlSchema } from '@app/common/constants';
 import { IHook } from '@app/queries/types';
+import { IFormField, useFormField } from '@konveyor/lib-ui';
 import React from 'react';
-import { HookDefinitionFormState } from './AddEditHookModal';
+import { HookFormState } from './AddEditHookModal';
+import { IKubeList } from '@app/client/types';
+import { QueryResult } from 'react-query';
+import { getHookNameSchema } from '@app/queries';
 
-export const generateHook = (form: HookDefinitionFormState): IHook => ({
+export type HookStep = 'PreHook' | 'PostHook';
+
+export interface IHookDefinitionFields {
+  name: IFormField<string>;
+  url: IFormField<string>;
+  branch: IFormField<string>;
+}
+
+export const useHookDefinitionFields = (
+  hooksQuery: QueryResult<IKubeList<IHook>>,
+  editingHookName: string | null,
+  isNameRequired: boolean
+): IHookDefinitionFields => {
+  const nameSchema = getHookNameSchema(hooksQuery, editingHookName).label('Hook name');
+  return {
+    name: useFormField('', isNameRequired ? nameSchema.required() : nameSchema),
+    url: useFormField('', urlSchema.required()),
+    branch: useFormField('', yup.string().required()),
+  };
+};
+
+export const generateHook = (form: HookFormState): IHook => ({
   apiVersion: CLUSTER_API_VERSION,
   kind: 'Hook',
   metadata: {
@@ -21,7 +47,7 @@ interface IEditHookPrefillEffect {
 }
 
 export const useEditHookPrefillEffect = (
-  form: HookDefinitionFormState,
+  form: HookFormState,
   hookBeingEdited: IHook | null
 ): IEditHookPrefillEffect => {
   const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);

--- a/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -20,6 +20,7 @@ export interface IMappingBuilderItem {
 export const mappingBuilderItemsSchema = yup
   .array<IMappingBuilderItem>()
   .required()
+  .min(1)
   .test('no-empty-selections', 'All sources must be mapped to a target.', (builderItems) =>
     builderItems ? builderItems.every((item) => item.source && item.target) : false
   );

--- a/src/app/Plans/components/Wizard/HooksForm.css
+++ b/src/app/Plans/components/Wizard/HooksForm.css
@@ -1,0 +1,3 @@
+#existing-hook-select .pf-c-select__menu-group .pf-c-select__menu-item {
+  padding-left: var(--pf-global--spacer--xl);
+}

--- a/src/app/Plans/components/Wizard/HooksForm.tsx
+++ b/src/app/Plans/components/Wizard/HooksForm.tsx
@@ -12,6 +12,8 @@ import {
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import PlanAddEditHookModal, { PlanHookInstance } from './PlanAddEditHookModal';
 
+import './HooksForm.css';
+
 interface IHooksFormProps {
   form: PlanWizardFormState['hooks'];
 }

--- a/src/app/Plans/components/Wizard/HooksForm.tsx
+++ b/src/app/Plans/components/Wizard/HooksForm.tsx
@@ -22,13 +22,16 @@ interface IHooksFormProps {
 
 const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFormProps) => {
   const hooks: IHook[] = []; // TODO load from a query based on what's in the plan? or prefilled form state?
+  // TODO handle the fact that we'll be listing hook CRs that don't exist yet? I guess we can just store the whole object in form state?
+
+  const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
+  // TODO show the AddEditHookModal from Gilles' PR with a isWizardMode flag or something, to add the extra fields?
 
   return (
     <>
       <TextContent className={spacing.mbMd}>
         <Text component="p">
           Hooks are contained in Ansible playbooks that can be run before or after the migration.
-          They are run on either the source or target provider.
         </Text>
       </TextContent>
       {hooks.length === 0 ? (
@@ -37,13 +40,13 @@ const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFor
           <EmptyStateBody className={spacing.mt_0}>
             No hooks have been added to this migration plan
           </EmptyStateBody>
-          <Button variant="secondary" className={spacing.mtMd} onClick={() => alert('TODO')}>
+          <Button variant="secondary" className={spacing.mtMd} onClick={toggleAddEditModal}>
             Add hook
           </Button>
         </EmptyState>
       ) : (
         <>
-          <Button variant="secondary" onClick={() => alert('TODO')}>
+          <Button variant="secondary" onClick={toggleAddEditModal}>
             Add hook
           </Button>
           <h1>TODO: table here</h1>

--- a/src/app/Plans/components/Wizard/HooksForm.tsx
+++ b/src/app/Plans/components/Wizard/HooksForm.tsx
@@ -10,21 +10,22 @@ import {
   EmptyStateIcon,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import PlanAddEditHookModal from './PlanAddEditHookModal';
-import { IHook } from '@app/queries/types';
+import PlanAddEditHookModal, { PlanHookInstance } from './PlanAddEditHookModal';
 
 interface IHooksFormProps {
   form: PlanWizardFormState['hooks'];
 }
 
 const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFormProps) => {
-  const hooks: IHook[] = []; // TODO load from a query based on what's in the plan? or prefilled form state?
-  // TODO handle the fact that we'll be listing hook CRs that don't exist yet? I guess we can just store the whole object in form state?
-
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
-  // TODO show the AddEditHookModal from Gilles' PR with a isWizardMode flag or something, to add the extra fields?
 
-  // TODO disable add button if both a pre and post hook are already added
+  // TODO disable the Add button if both a pre and post hook are already added
+
+  const onSaveInstance = (newHookInstance: PlanHookInstance) => {
+    // TODO update the existing one instead of adding one if we are editing, once edit is working
+    form.fields.instances.setValue([...form.values.instances, newHookInstance]);
+    toggleAddEditModal();
+  };
 
   return (
     <>
@@ -33,7 +34,7 @@ const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFor
           Hooks are contained in Ansible playbooks that can be run before or after the migration.
         </Text>
       </TextContent>
-      {hooks.length === 0 ? (
+      {form.values.instances.length === 0 ? (
         <EmptyState className={spacing.my_2xl}>
           <EmptyStateIcon icon={PlusCircleIcon} />
           <EmptyStateBody className={spacing.mt_0}>
@@ -54,6 +55,7 @@ const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFor
       {isAddEditModalOpen ? (
         <PlanAddEditHookModal
           onClose={toggleAddEditModal}
+          onSave={onSaveInstance}
           instanceBeingEdited={null} // TODO
         />
       ) : null}

--- a/src/app/Plans/components/Wizard/HooksForm.tsx
+++ b/src/app/Plans/components/Wizard/HooksForm.tsx
@@ -50,6 +50,7 @@ const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFor
             Add hook
           </Button>
           <h1>TODO: table here</h1>
+          <p>{JSON.stringify(form.values.instances, undefined, 4)}</p>
         </>
       )}
       {isAddEditModalOpen ? (

--- a/src/app/Plans/components/Wizard/HooksForm.tsx
+++ b/src/app/Plans/components/Wizard/HooksForm.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
-import TableEmptyState from '@app/common/components/TableEmptyState';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { PlanWizardFormState } from './PlanWizard';
-import { TextContent, Text, Button } from '@patternfly/react-core';
+import {
+  TextContent,
+  Text,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+} from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 /// TODO replace this!
@@ -17,29 +23,32 @@ interface IHooksFormProps {
 const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFormProps) => {
   const hooks: IHook[] = []; // TODO load from a query based on what's in the plan? or prefilled form state?
 
-  const table =
-    hooks.length === 0 ? (
-      <TableEmptyState
-        icon={PlusCircleIcon}
-        bodyText="No hooks have been added to this migration plan"
-      />
-    ) : (
-      <>
-        <TextContent className={spacing.mbMd}>
-          <Text component="p">
-            Hooks are contained in Ansible playbooks that can be run before or after the migration.
-          </Text>
-        </TextContent>
-        <h1>TODO</h1>
-      </>
-    );
-
   return (
     <>
-      <Button variant="secondary" onClick={() => alert('TODO')}>
-        Add hook
-      </Button>
-      {table}
+      <TextContent className={spacing.mbMd}>
+        <Text component="p">
+          Hooks are contained in Ansible playbooks that can be run before or after the migration.
+          They are run on either the source or target provider.
+        </Text>
+      </TextContent>
+      {hooks.length === 0 ? (
+        <EmptyState className={spacing.my_2xl}>
+          <EmptyStateIcon icon={PlusCircleIcon} />
+          <EmptyStateBody className={spacing.mt_0}>
+            No hooks have been added to this migration plan
+          </EmptyStateBody>
+          <Button variant="secondary" className={spacing.mtMd} onClick={() => alert('TODO')}>
+            Add hook
+          </Button>
+        </EmptyState>
+      ) : (
+        <>
+          <Button variant="secondary" onClick={() => alert('TODO')}>
+            Add hook
+          </Button>
+          <h1>TODO: table here</h1>
+        </>
+      )}
     </>
   );
 };

--- a/src/app/Plans/components/Wizard/HooksForm.tsx
+++ b/src/app/Plans/components/Wizard/HooksForm.tsx
@@ -24,6 +24,8 @@ const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFor
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
   // TODO show the AddEditHookModal from Gilles' PR with a isWizardMode flag or something, to add the extra fields?
 
+  // TODO disable add button if both a pre and post hook are already added
+
   return (
     <>
       <TextContent className={spacing.mbMd}>
@@ -50,7 +52,10 @@ const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFor
         </>
       )}
       {isAddEditModalOpen ? (
-        <PlanAddEditHookModal onClose={toggleAddEditModal} hookBeingEdited={null} />
+        <PlanAddEditHookModal
+          onClose={toggleAddEditModal}
+          instanceBeingEdited={null} // TODO
+        />
       ) : null}
     </>
   );

--- a/src/app/Plans/components/Wizard/HooksForm.tsx
+++ b/src/app/Plans/components/Wizard/HooksForm.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { PlanWizardFormState } from './PlanWizard';
+
+interface IHooksFormProps {
+  form: PlanWizardFormState['hooks'];
+}
+
+const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFormProps) => {
+  return <p>TODO</p>;
+};
+
+export default HooksForm;

--- a/src/app/Plans/components/Wizard/HooksForm.tsx
+++ b/src/app/Plans/components/Wizard/HooksForm.tsx
@@ -10,11 +10,8 @@ import {
   EmptyStateIcon,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-
-/// TODO replace this!
-interface IHook {
-  hello: string;
-}
+import PlanAddEditHookModal from './PlanAddEditHookModal';
+import { IHook } from '@app/queries/types';
 
 interface IHooksFormProps {
   form: PlanWizardFormState['hooks'];
@@ -52,6 +49,9 @@ const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFor
           <h1>TODO: table here</h1>
         </>
       )}
+      {isAddEditModalOpen ? (
+        <PlanAddEditHookModal onClose={toggleAddEditModal} hookBeingEdited={null} />
+      ) : null}
     </>
   );
 };

--- a/src/app/Plans/components/Wizard/HooksForm.tsx
+++ b/src/app/Plans/components/Wizard/HooksForm.tsx
@@ -1,12 +1,47 @@
 import * as React from 'react';
+import TableEmptyState from '@app/common/components/TableEmptyState';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 import { PlanWizardFormState } from './PlanWizard';
+import { TextContent, Text, Button } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+
+/// TODO replace this!
+interface IHook {
+  hello: string;
+}
 
 interface IHooksFormProps {
   form: PlanWizardFormState['hooks'];
 }
 
 const HooksForm: React.FunctionComponent<IHooksFormProps> = ({ form }: IHooksFormProps) => {
-  return <p>TODO</p>;
+  const hooks: IHook[] = []; // TODO load from a query based on what's in the plan? or prefilled form state?
+
+  const table =
+    hooks.length === 0 ? (
+      <TableEmptyState
+        icon={PlusCircleIcon}
+        bodyText="No hooks have been added to this migration plan"
+      />
+    ) : (
+      <>
+        <TextContent className={spacing.mbMd}>
+          <Text component="p">
+            Hooks are contained in Ansible playbooks that can be run before or after the migration.
+          </Text>
+        </TextContent>
+        <h1>TODO</h1>
+      </>
+    );
+
+  return (
+    <>
+      <Button variant="secondary" onClick={() => alert('TODO')}>
+        Add hook
+      </Button>
+      {table}
+    </>
+  );
 };
 
 export default HooksForm;

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -184,6 +184,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
         <Flex direction={{ default: 'column' }} className={spacing.mbMd}>
           {!form.values.isPrefilled ? (
             <FlexItem>
+              {/* TODO: candidate for new shared component with PlanAddEditHookModal: SelectNewOrExisting<T> */}
               <FormGroup isRequired fieldId="mappingSelect">
                 <Select
                   id="mappingSelect"

--- a/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -1,0 +1,72 @@
+import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
+import { ResolvedQuery } from '@app/common/components/ResolvedQuery';
+import { usePausedPollingEffect } from '@app/common/context';
+import HookDefinitionInputs from '@app/Hooks/components/HookDefinitionInputs';
+import { useHooksQuery } from '@app/queries';
+import { IHook } from '@app/queries/types';
+import { Modal, Stack, Flex, Button, Form } from '@patternfly/react-core';
+import * as React from 'react';
+
+interface IPlanAddEditHookModalProps {
+  onClose: () => void;
+  hookBeingEdited: IHook | null;
+}
+
+const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModalProps> = ({
+  onClose,
+  hookBeingEdited,
+}: IPlanAddEditHookModalProps) => {
+  usePausedPollingEffect();
+
+  const hooksQuery = useHooksQuery();
+
+  // TODO useFormState here that is a superset of the useHookDefintionFormState? how does that fold into the plan wizard?
+  const hookForm = {
+    isDirty: false,
+    isValid: false,
+  };
+
+  return (
+    <Modal
+      className="AddEditHookModal"
+      variant="small"
+      title={`${!hookBeingEdited ? 'Create' : 'Edit'} hook`}
+      isOpen
+      onClose={onClose}
+      footer={
+        <Stack hasGutter>
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <Button
+              id="modal-confirm-button"
+              key="confirm"
+              variant="primary"
+              isDisabled={!hookForm.isDirty || !hookForm.isValid}
+              // TODO: To be addressed when hook backend is ready
+              // onClick={() => {
+              //   mutateHook(hookForm.values);
+              // }}
+            >
+              {!hookBeingEdited ? 'Create' : 'Save'}
+            </Button>
+            <Button id="modal-cancel-button" key="cancel" variant="link" onClick={() => onClose()}>
+              Cancel
+            </Button>
+          </Flex>
+        </Stack>
+      }
+    >
+      <ResolvedQuery result={hooksQuery} errorTitle="Error loading hooks">
+        <h1>TODO</h1>
+        {/*!isDonePrefilling ? (
+          <LoadingEmptyState />
+        ) : (
+          <Form>
+            <HookDefinitionInputs fields={hookForm.fields} hookBeingEdited={hookBeingEdited} />
+          </Form>
+        )*/}
+      </ResolvedQuery>
+    </Modal>
+  );
+};
+
+export default PlanAddEditHookModal;

--- a/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -1,36 +1,106 @@
-import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
+import * as React from 'react';
+import * as yup from 'yup';
 import { ResolvedQuery } from '@app/common/components/ResolvedQuery';
 import { usePausedPollingEffect } from '@app/common/context';
-import HookDefinitionInputs from '@app/Hooks/components/HookDefinitionInputs';
-import { useHooksQuery } from '@app/queries';
+import { HookStep, useHookDefinitionFields } from '@app/Hooks/components/helpers';
+import { filterSharedHooks, useHooksQuery } from '@app/queries';
 import { IHook } from '@app/queries/types';
-import { Modal, Stack, Flex, Button, Form } from '@patternfly/react-core';
-import * as React from 'react';
+import { getFormGroupProps, useFormField, useFormState } from '@konveyor/lib-ui';
+import {
+  Modal,
+  Stack,
+  Flex,
+  Button,
+  Form,
+  FormGroup,
+  FlexItem,
+  Select,
+  SelectOptionObject,
+  SelectOption,
+  SelectGroup,
+} from '@patternfly/react-core';
+import { IKubeList } from '@app/client/types';
+import { QueryResult } from 'react-query';
+import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
+import HookDefinitionInputs from '@app/Hooks/components/HookDefinitionInputs';
+import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
+import { isSameResource } from '@app/queries/helpers';
+
+const usePlanHookInstanceFormState = (
+  hooksQuery: QueryResult<IKubeList<IHook>>,
+  editingHookName: string | null
+) => {
+  const isCreateHookSelected = useFormField(false, yup.boolean().required());
+  return useFormState({
+    isCreateHookSelected,
+    selectedExistingHook: useFormField<IHook | null>(null, yup.mixed<IHook | null>()),
+    ...useHookDefinitionFields(hooksQuery, editingHookName, isCreateHookSelected.value),
+    step: useFormField<HookStep | null>(
+      null,
+      yup.mixed().oneOf(['PreHook', 'PostHook']).required()
+    ),
+    // TODO do we need service account name? what about environment variables? see variants of mockups...
+    // TODO do we need an isPrefilled here? prefill hook?
+  });
+};
+
+export type PlanHookInstanceFormState = ReturnType<typeof usePlanHookInstanceFormState>;
+export type PlanHookInstance = PlanHookInstanceFormState['values'];
 
 interface IPlanAddEditHookModalProps {
   onClose: () => void;
-  hookBeingEdited: IHook | null;
+  instanceBeingEdited: PlanHookInstance | null;
 }
 
 const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModalProps> = ({
   onClose,
-  hookBeingEdited,
+  instanceBeingEdited,
 }: IPlanAddEditHookModalProps) => {
   usePausedPollingEffect();
 
   const hooksQuery = useHooksQuery();
 
-  // TODO useFormState here that is a superset of the useHookDefintionFormState? how does that fold into the plan wizard?
-  const hookForm = {
-    isDirty: false,
-    isValid: false,
+  const instanceForm = usePlanHookInstanceFormState(hooksQuery, instanceBeingEdited?.name || null);
+
+  const [isExistingHookSelectOpen, setIsExistingHookSelectOpen] = React.useState(false);
+  const newHookOption = {
+    toString: () => 'Create a new hook',
+    value: 'new',
   };
+  const filteredHooks = filterSharedHooks(hooksQuery.data?.items);
+  const hookOptions = Object.values(filteredHooks).map(
+    (hook) =>
+      ({
+        toString: () => hook.metadata.name,
+        value: hook,
+      } as OptionWithValue<IHook>)
+  );
+
+  const populateFromExistingHook = (hook: IHook | null) => {
+    instanceForm.fields.name.setValue(hook?.metadata.name || '');
+    instanceForm.fields.url.setValue(hook?.spec.url || '');
+    instanceForm.fields.branch.setValue(hook?.spec.url || '');
+  };
+
+  const isDonePrefilling = true; // TODO
+
+  // TODO disable step options that already have a hook instance that isn't the one being edited!
+  const stepOptions: OptionWithValue<HookStep>[] = [
+    {
+      toString: () => 'Pre-migration',
+      value: 'PreHook',
+    },
+    {
+      toString: () => 'Post-migration',
+      value: 'PostHook',
+    },
+  ];
 
   return (
     <Modal
       className="AddEditHookModal"
       variant="small"
-      title={`${!hookBeingEdited ? 'Create' : 'Edit'} hook`}
+      title={`${!instanceBeingEdited ? 'Add' : 'Edit'} hook`}
       isOpen
       onClose={onClose}
       footer={
@@ -40,13 +110,12 @@ const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModalProps> 
               id="modal-confirm-button"
               key="confirm"
               variant="primary"
-              isDisabled={!hookForm.isDirty || !hookForm.isValid}
-              // TODO: To be addressed when hook backend is ready
+              isDisabled={!instanceForm.isDirty || !instanceForm.isValid}
+              // TODO: Add it to the wizard's form state here and close the modal
               // onClick={() => {
-              //   mutateHook(hookForm.values);
               // }}
             >
-              {!hookBeingEdited ? 'Create' : 'Save'}
+              {!instanceBeingEdited ? 'Add' : 'Save'}
             </Button>
             <Button id="modal-cancel-button" key="cancel" variant="link" onClick={() => onClose()}>
               Cancel
@@ -56,14 +125,91 @@ const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModalProps> 
       }
     >
       <ResolvedQuery result={hooksQuery} errorTitle="Error loading hooks">
-        <h1>TODO</h1>
-        {/*!isDonePrefilling ? (
+        {!isDonePrefilling ? (
           <LoadingEmptyState />
         ) : (
           <Form>
-            <HookDefinitionInputs fields={hookForm.fields} hookBeingEdited={hookBeingEdited} />
+            {!instanceBeingEdited ? (
+              <FlexItem>
+                {/* TODO: candidate for new shared component with MappingForm: SelectNewOrExisting<T> */}
+                <FormGroup isRequired fieldId="existing-hook-select">
+                  <Select
+                    id="existing-hook-select"
+                    aria-label="Add an existing hook or create a new one"
+                    placeholderText="Select..."
+                    isGrouped
+                    isOpen={isExistingHookSelectOpen}
+                    onToggle={setIsExistingHookSelectOpen}
+                    onSelect={(_event, selection: SelectOptionObject) => {
+                      const sel = selection as OptionWithValue<IHook | 'new'>;
+                      if (sel.value === 'new') {
+                        instanceForm.fields.isCreateHookSelected.setValue(true);
+                        instanceForm.fields.selectedExistingHook.setValue(null);
+                        populateFromExistingHook(null);
+                      } else {
+                        instanceForm.fields.isCreateHookSelected.setValue(false);
+                        instanceForm.fields.selectedExistingHook.setValue(sel.value);
+                        populateFromExistingHook(sel.value);
+                      }
+                      setIsExistingHookSelectOpen(false);
+                    }}
+                    selections={
+                      instanceForm.values.isCreateHookSelected
+                        ? [newHookOption]
+                        : instanceForm.values.selectedExistingHook
+                        ? [
+                            hookOptions.find((option) =>
+                              isSameResource(
+                                option.value.metadata,
+                                instanceForm.values.selectedExistingHook?.metadata
+                              )
+                            ),
+                          ]
+                        : []
+                    }
+                  >
+                    <SelectOption key={newHookOption.toString()} value={newHookOption} />
+                    <SelectGroup
+                      label={hookOptions.length > 0 ? 'Existing hooks' : 'No existing hooks'}
+                    >
+                      {hookOptions.map((option) => (
+                        <SelectOption key={option.toString()} value={option} {...option.props} />
+                      ))}
+                    </SelectGroup>
+                  </Select>
+                </FormGroup>
+              </FlexItem>
+            ) : null}
+            <HookDefinitionInputs
+              fields={instanceForm.fields}
+              editingHookName={instanceBeingEdited?.name || null}
+              hideName={!!instanceForm.values.selectedExistingHook}
+            >
+              <FormGroup
+                label="Step when the hook will be run"
+                isRequired
+                fieldId="hook-step-select"
+                {...getFormGroupProps(instanceForm.fields.step)}
+              >
+                <SimpleSelect
+                  id="hook-step-select"
+                  toggleId="hook-step-select-toggle"
+                  aria-label="Step when the hook will be run"
+                  options={stepOptions}
+                  value={[
+                    stepOptions.find((option) => option.value === instanceForm.fields.step.value),
+                  ]}
+                  onChange={(selection) =>
+                    instanceForm.fields.step.setValue(
+                      (selection as OptionWithValue<HookStep>).value
+                    )
+                  }
+                  placeholderText="Select..."
+                />
+              </FormGroup>
+            </HookDefinitionInputs>
           </Form>
-        )*/}
+        )}
       </ResolvedQuery>
     </Modal>
   );

--- a/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -81,7 +81,7 @@ const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModalProps> 
   const populateFromExistingHook = (hook: IHook | null) => {
     instanceForm.fields.name.setValue(hook?.metadata.name || '');
     instanceForm.fields.url.setValue(hook?.spec.url || '');
-    instanceForm.fields.branch.setValue(hook?.spec.url || '');
+    instanceForm.fields.branch.setValue(hook?.spec.branch || '');
   };
 
   const isDonePrefilling = true; // TODO

--- a/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -130,55 +130,57 @@ const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModalProps> 
         ) : (
           <Form>
             {!instanceBeingEdited ? (
-              <FlexItem>
-                {/* TODO: candidate for new shared component with MappingForm: SelectNewOrExisting<T> */}
-                <FormGroup isRequired fieldId="existing-hook-select">
-                  <Select
-                    id="existing-hook-select"
-                    aria-label="Add an existing hook or create a new one"
-                    placeholderText="Select..."
-                    isGrouped
-                    isOpen={isExistingHookSelectOpen}
-                    onToggle={setIsExistingHookSelectOpen}
-                    onSelect={(_event, selection: SelectOptionObject) => {
-                      const sel = selection as OptionWithValue<IHook | 'new'>;
-                      if (sel.value === 'new') {
-                        instanceForm.fields.isCreateHookSelected.setValue(true);
-                        instanceForm.fields.selectedExistingHook.setValue(null);
-                        populateFromExistingHook(null);
-                      } else {
-                        instanceForm.fields.isCreateHookSelected.setValue(false);
-                        instanceForm.fields.selectedExistingHook.setValue(sel.value);
-                        populateFromExistingHook(sel.value);
-                      }
-                      setIsExistingHookSelectOpen(false);
-                    }}
-                    selections={
-                      instanceForm.values.isCreateHookSelected
-                        ? [newHookOption]
-                        : instanceForm.values.selectedExistingHook
-                        ? [
-                            hookOptions.find((option) =>
-                              isSameResource(
-                                option.value.metadata,
-                                instanceForm.values.selectedExistingHook?.metadata
-                              )
-                            ),
-                          ]
-                        : []
+              // TODO: candidate for new shared component with MappingForm: SelectNewOrExisting<T>
+              <FormGroup
+                label="Add an existing hook or create a new one"
+                isRequired
+                fieldId="existing-hook-select"
+              >
+                <Select
+                  id="existing-hook-select"
+                  aria-label="Add an existing hook or create a new one"
+                  placeholderText="Select..."
+                  isGrouped
+                  isOpen={isExistingHookSelectOpen}
+                  onToggle={setIsExistingHookSelectOpen}
+                  onSelect={(_event, selection: SelectOptionObject) => {
+                    const sel = selection as OptionWithValue<IHook | 'new'>;
+                    if (sel.value === 'new') {
+                      instanceForm.fields.isCreateHookSelected.setValue(true);
+                      instanceForm.fields.selectedExistingHook.setValue(null);
+                      populateFromExistingHook(null);
+                    } else {
+                      instanceForm.fields.isCreateHookSelected.setValue(false);
+                      instanceForm.fields.selectedExistingHook.setValue(sel.value);
+                      populateFromExistingHook(sel.value);
                     }
+                    setIsExistingHookSelectOpen(false);
+                  }}
+                  selections={
+                    instanceForm.values.isCreateHookSelected
+                      ? [newHookOption]
+                      : instanceForm.values.selectedExistingHook
+                      ? [
+                          hookOptions.find((option) =>
+                            isSameResource(
+                              option.value.metadata,
+                              instanceForm.values.selectedExistingHook?.metadata
+                            )
+                          ),
+                        ]
+                      : []
+                  }
+                >
+                  <SelectOption key={newHookOption.toString()} value={newHookOption} />
+                  <SelectGroup
+                    label={hookOptions.length > 0 ? 'Existing hooks' : 'No existing hooks'}
                   >
-                    <SelectOption key={newHookOption.toString()} value={newHookOption} />
-                    <SelectGroup
-                      label={hookOptions.length > 0 ? 'Existing hooks' : 'No existing hooks'}
-                    >
-                      {hookOptions.map((option) => (
-                        <SelectOption key={option.toString()} value={option} {...option.props} />
-                      ))}
-                    </SelectGroup>
-                  </Select>
-                </FormGroup>
-              </FlexItem>
+                    {hookOptions.map((option) => (
+                      <SelectOption key={option.toString()} value={option} {...option.props} />
+                    ))}
+                  </SelectGroup>
+                </Select>
+              </FormGroup>
             ) : null}
             <HookDefinitionInputs
               fields={instanceForm.fields}

--- a/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -82,6 +82,12 @@ const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModalProps> 
     instanceForm.fields.name.setValue(hook?.metadata.name || '');
     instanceForm.fields.url.setValue(hook?.spec.url || '');
     instanceForm.fields.branch.setValue(hook?.spec.branch || '');
+    if (hook) {
+      instanceForm.fields.name.setIsTouched(true);
+      instanceForm.fields.step.setIsTouched(true);
+      instanceForm.fields.url.setIsTouched(true);
+      instanceForm.fields.branch.setIsTouched(true);
+    }
   };
 
   const isDonePrefilling = true; // TODO

--- a/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -30,10 +30,15 @@ const usePlanHookInstanceFormState = (
   editingHookName: string | null
 ) => {
   const isCreateHookSelected = useFormField(false, yup.boolean().required());
+  const selectedExistingHook = useFormField<IHook | null>(null, yup.mixed<IHook | null>());
   return useFormState({
     isCreateHookSelected,
-    selectedExistingHook: useFormField<IHook | null>(null, yup.mixed<IHook | null>()),
-    ...useHookDefinitionFields(hooksQuery, editingHookName, isCreateHookSelected.value),
+    selectedExistingHook,
+    ...useHookDefinitionFields(
+      hooksQuery,
+      editingHookName || selectedExistingHook.value?.metadata.name || null,
+      isCreateHookSelected.value
+    ),
     step: useFormField<HookStep | null>(
       null,
       yup.mixed<HookStep | null>().label('Step').required()

--- a/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -49,11 +49,13 @@ export type PlanHookInstance = PlanHookInstanceFormState['values'];
 
 interface IPlanAddEditHookModalProps {
   onClose: () => void;
+  onSave: (instance: PlanHookInstance) => void;
   instanceBeingEdited: PlanHookInstance | null;
 }
 
 const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModalProps> = ({
   onClose,
+  onSave,
   instanceBeingEdited,
 }: IPlanAddEditHookModalProps) => {
   usePausedPollingEffect();
@@ -111,9 +113,7 @@ const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModalProps> 
               key="confirm"
               variant="primary"
               isDisabled={!instanceForm.isDirty || !instanceForm.isValid}
-              // TODO: Add it to the wizard's form state here and close the modal
-              // onClick={() => {
-              // }}
+              onClick={() => onSave(instanceForm.values)}
             >
               {!instanceBeingEdited ? 'Add' : 'Save'}
             </Button>

--- a/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -13,7 +13,6 @@ import {
   Button,
   Form,
   FormGroup,
-  FlexItem,
   Select,
   SelectOptionObject,
   SelectOption,
@@ -37,7 +36,7 @@ const usePlanHookInstanceFormState = (
     ...useHookDefinitionFields(hooksQuery, editingHookName, isCreateHookSelected.value),
     step: useFormField<HookStep | null>(
       null,
-      yup.mixed().oneOf(['PreHook', 'PostHook']).required()
+      yup.mixed<HookStep | null>().label('Step').required()
     ),
     // TODO do we need service account name? what about environment variables? see variants of mockups...
     // TODO do we need an isPrefilled here? prefill hook?

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -8,6 +8,7 @@ import {
   PageSection,
   Title,
   Wizard,
+  WizardStep,
   WizardStepFunctionType,
 } from '@patternfly/react-core';
 import { Link, Prompt, Redirect, useHistory, useRouteMatch } from 'react-router-dom';
@@ -246,7 +247,7 @@ const PlanWizard: React.FunctionComponent = () => {
 
   const selectedVMs = getSelectedVMsFromIds(forms.selectVMs.values.selectedVMIds, vmsQuery);
 
-  const steps = [
+  const steps: WizardStep[] = [
     {
       id: StepId.General,
       name: 'General',

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -20,8 +20,10 @@ import WizardStepContainer from './WizardStepContainer';
 import GeneralForm from './GeneralForm';
 import FilterVMsForm from './FilterVMsForm';
 import SelectVMsForm from './SelectVMsForm';
-import Review from './Review';
 import MappingForm from './MappingForm';
+import TypeForm from './TypeForm';
+import HooksForm from './HooksForm';
+import Review from './Review';
 import {
   IOpenShiftProvider,
   IPlan,
@@ -52,10 +54,9 @@ import { dnsLabelNameSchema } from '@app/common/constants';
 import { IKubeList } from '@app/client/types';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
-import TypeForm from './TypeForm';
+import { PlanHookInstance } from './PlanAddEditHookModal';
 
 import './PlanWizard.css';
-import HooksForm from './HooksForm';
 
 const useMappingFormState = (mappingsQuery: QueryResult<IKubeList<Mapping>>) => {
   const isSaveNewMapping = useFormField(false, yup.boolean().required());
@@ -117,7 +118,7 @@ const usePlanWizardFormState = (
       type: useFormField<PlanType>('Cold', yup.mixed().oneOf(['Cold', 'Warm']).required()),
     }),
     hooks: useFormState({
-      helloWorld: useFormField('', yup.string().required()), // TODO replace me
+      instances: useFormField<PlanHookInstance[]>([], yup.array<PlanHookInstance>()),
     }),
   };
 

--- a/src/app/common/components/TableEmptyState.tsx
+++ b/src/app/common/components/TableEmptyState.tsx
@@ -10,6 +10,7 @@ import {
   Button,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 export interface ITableEmptyStateProps {
   icon?: EmptyStateIconProps['icon'];
@@ -21,8 +22,8 @@ export interface ITableEmptyStateProps {
 
 const TableEmptyState: React.FunctionComponent<ITableEmptyStateProps> = ({
   icon = SearchIcon,
-  titleText = 'No results found',
-  bodyText = 'No results match the filter criteria. Remove filters or clear all filters to show results.',
+  titleText,
+  bodyText,
   onClearFiltersClick,
   isHiddenActions = false,
 }: ITableEmptyStateProps) => (
@@ -30,10 +31,14 @@ const TableEmptyState: React.FunctionComponent<ITableEmptyStateProps> = ({
     <FlexItem>
       <EmptyState variant="small">
         <EmptyStateIcon icon={icon} />
-        <Title headingLevel="h5" size="lg">
-          {titleText}
-        </Title>
-        <EmptyStateBody>{bodyText}</EmptyStateBody>
+        {titleText ? (
+          <Title headingLevel="h5" size="lg">
+            {titleText}
+          </Title>
+        ) : null}
+        {bodyText ? (
+          <EmptyStateBody className={!titleText ? spacing.mt_0 : ''}>{bodyText}</EmptyStateBody>
+        ) : null}
         {onClearFiltersClick && !isHiddenActions && (
           <Button variant="link" onClick={onClearFiltersClick}>
             Clear all filters

--- a/src/app/queries/hooks.ts
+++ b/src/app/queries/hooks.ts
@@ -111,11 +111,10 @@ export const useDeleteHookMutation = (
 
 export const getHookNameSchema = (
   hooksQuery: QueryResult<IKubeList<IHook>>,
-  hookBeingEdited: IHook | null
+  editingHookName: string | null
 ): yup.StringSchema =>
   dnsLabelNameSchema.test('unique-name', 'A hook with this name already exists', (value) => {
-    if (hookBeingEdited && (hookBeingEdited.metadata as IMetaObjectMeta).name === value)
-      return true;
+    if (editingHookName && editingHookName === value) return true;
     if (
       hooksQuery.data?.items.find(
         (hook) => hook && (hook.metadata as IMetaObjectMeta).name === value
@@ -124,3 +123,9 @@ export const getHookNameSchema = (
       return false;
     return true;
   });
+
+// TODO add the shared annotation explicitly to IHook and check logic for shared/private hooks everywhere
+export const filterSharedHooks = (hooks?: IHook[]): IHook[] =>
+  (hooks || []).filter(
+    (hook) => hook.metadata.annotations?.['forklift.konveyor.io/shared'] !== 'false'
+  ) || null;


### PR DESCRIPTION
For the purposes of this wizard step, I'm using the term "instance" to refer to a hook that has been added to the plan and its associated options (which step to run on, any future fields in the modal).

This PR adds the Hooks step to the wizard, with an empty state and a modal to add a new hook instance. It is currently missing the table of hook instances (once an instance is added, JSON of the new form state is shown as a placeholder), and the modal doesn't yet support editing an instance (prefill logic).

There is some magic going on here to reduce duplication between this modal and the `AddEditHookModal` on the main Hooks page. I've factored out the form state for the "hook definition" fields (currently name, url and branch fields, but I know we're changing those) into a common `useHookDefinitionFields` hook. This returns an object of those `useFormField` calls, which is separately passed into the two different `useFormState` calls in `AddEditHookModal` and the new `PlanAddEditHookModal`, with the latter including additional fields.

I've also factored out the JSX for these field inputs into `HookDefinitionInputs` which is also used in both modals. That component is weird... it can hide the name field where necessary with a prop, and it can take children to render between the name field and other fields. We may need to change that structure a bit if we need more control over the order of the fields, or just give up on abstracting that. The `fields` prop of that component is fancy though, it can take any `fields` object from a `useFormState` call that includes the shared fields. That's why TS is happy with us passing the `form.fields` from the forms in both of these modals.

The `PlanAddEditHookModal` contains its own form state for the instance currently being added/edited. When the save button is clicked, the values from that form are passed to a handler in the `HooksForm` so they can be added to the actual plan wizard form state. This involves more magic: There is a type `PlanHookInstance` which is just the value types inferred from the `useFormState` in the `PlanAddEditHookModal`. That is the type used for the wizard's `forms.hooks.fields.instances` field, it's simply an array of those instances. So when we change the fields in these forms, the plan wizard's form state won't need to be changed, everything will match up. The `useFormState` call in `PlanAddEditHookModal` is the source of truth for these fields.

The Add functionality works! The values from the modal's form are just pushed into the plan's form state. Edit and remove will also be pretty similar to implement. You can even populate the form correctly by selecting an existing hook, using a pattern I borrowed from `MappingForm` (there is a possible opportunity to factor out a common component there).

I'm saving the Edit and Remove actions, and the table of hook instances, for another PR.