### PR TITLE
Fix BZ#1958649 and BZ#1958652: Use correct query when looking up storage mappings for prefilling wizard in edit mode

### DIFF
--- a/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -125,7 +125,7 @@ describe('<AddEditProviderModal />', () => {
     expect(screen.getByRole('heading', { name: /Storage mapping/ })).toBeInTheDocument();
     expect(screen.getByText(/vmware-datastore-1/i)).toBeInTheDocument();
     const storageTarget = screen.getByRole('textbox', { name: /select target.../i });
-    expect(storageTarget).toHaveValue('standard (default)');
+    expect(storageTarget).toHaveValue('large');
     expect(screen.getByRole('checkbox', { name: /save mapping checkbox/ })).not.toBeChecked();
     await waitFor(() => expect(nextButton).toBeEnabled());
     userEvent.click(nextButton);
@@ -150,7 +150,7 @@ describe('<AddEditProviderModal />', () => {
     expect(screen.getByText(/ocp-network-2/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /1/i })).toBeEnabled();
     expect(networkTarget).toHaveValue('openshift-migration / ocp-network-1');
-    expect(storageTarget).toHaveValue('standard (default)');
+    expect(storageTarget).toHaveValue('large');
 
     expect(screen.getByRole('button', { name: /Finish/i })).toBeEnabled();
   });

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -473,7 +473,7 @@ export const useEditingPlanPrefillEffect = (
       const networkMapping = networkMappingsQuery.data?.items.find((mapping) =>
         isSameResource(mapping.metadata, planBeingEdited.spec.map.network)
       );
-      const storageMapping = networkMappingsQuery.data?.items.find((mapping) =>
+      const storageMapping = storageMappingsQuery.data?.items.find((mapping) =>
         isSameResource(mapping.metadata, planBeingEdited.spec.map.storage)
       );
 

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -29,7 +29,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             id: MOCK_VMWARE_DATASTORES[0].id,
           },
           destination: {
-            storageClass: MOCK_STORAGE_CLASSES_BY_PROVIDER['ocpv-1'][0].name,
+            storageClass: MOCK_STORAGE_CLASSES_BY_PROVIDER['ocpv-1'][1].name,
           },
         },
       ],

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -90,6 +90,7 @@ export const useCreatePlanMutation = (
     {
       onSuccess: () => {
         queryCache.invalidateQueries('plans');
+        queryCache.invalidateQueries('mappings');
         pollFasterAfterMutation();
         onSuccess && onSuccess();
       },
@@ -128,6 +129,7 @@ export const usePatchPlanMutation = (
     {
       onSuccess: () => {
         queryCache.invalidateQueries('plans');
+        queryCache.invalidateQueries('mappings');
         pollFasterAfterMutation();
         onSuccess && onSuccess();
       },
@@ -145,6 +147,7 @@ export const useDeletePlanMutation = (
     {
       onSuccess: () => {
         queryCache.invalidateQueries('plans');
+        queryCache.invalidateQueries('mappings');
         onSuccess && onSuccess();
       },
     }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1958649
https://bugzilla.redhat.com/show_bug.cgi?id=1958652

Whoops.

In the `useEditingPlanPrefillEffect`, which is used to populate the wizard when opening a plan for editing, the line that looks up the embedded storage mapping CR associated with the plan was accidentally using the network mappings query due to a typo, so it would never actually find it. This led to BZ#1958649 because the storage mapping fields in the form state never get prefilled, so if you skip to the Review step you get a blank mapping summary. It also led to BZ#1958652 because once you reach the storage mapping step, since there is no existing form data, it fills in default mapping targets as if you're creating a new plan.

Note: In BZ#1958649, the screenshot also shows an empty network mapping summary. This PR won't fix that, so I suspect there is something else going on. I can't reproduce that in mock mode, nor with creating a new plan on the mgn03 PSI cluster where the bug was found. So there must have been something strange about the specific plan. Perhaps a source or target network that had been mapped was removed before editing the plan. We should handle that more gracefully. Opened https://github.com/konveyor/forklift-ui/issues/590 for that.