### PR TITLE
[Backport] Fix BZ#1958649 and BZ#1958652: Use correct query when looking up storage mappings for prefilling wizard in edit mode (#591)

### DIFF
--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -154,7 +154,7 @@ const PlanWizard: React.FunctionComponent = () => {
   );
 
   enum StepId {
-    General = 1,
+    General = 0,
     FilterVMs,
     SelectVMs,
     NetworkMapping,

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -163,13 +163,17 @@ const PlanWizard: React.FunctionComponent = () => {
     Review,
   }
 
-  let stepIdReached = StepId.General;
-  if (forms.general.isValid) stepIdReached = StepId.FilterVMs;
-  if (forms.filterVMs.isValid) stepIdReached = StepId.SelectVMs;
-  if (forms.selectVMs.isValid) stepIdReached = StepId.NetworkMapping;
-  if (forms.networkMapping.isValid) stepIdReached = StepId.StorageMapping;
-  if (forms.storageMapping.isValid) stepIdReached = StepId.Type;
-  if (forms.type.isValid) stepIdReached = StepId.Review;
+  const stepForms = [
+    forms.general,
+    forms.filterVMs,
+    forms.selectVMs,
+    forms.networkMapping,
+    forms.storageMapping,
+    forms.type,
+  ];
+  const firstInvalidFormIndex = stepForms.findIndex((form) => !form.isValid);
+  const stepIdReached: StepId =
+    firstInvalidFormIndex === -1 ? StepId.Review : firstInvalidFormIndex;
 
   const isFirstRender = React.useRef(true);
 

--- a/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -125,7 +125,7 @@ describe('<AddEditProviderModal />', () => {
     expect(screen.getByRole('heading', { name: /Storage mapping/ })).toBeInTheDocument();
     expect(screen.getByText(/vmware-datastore-1/i)).toBeInTheDocument();
     const storageTarget = screen.getByRole('textbox', { name: /select target.../i });
-    expect(storageTarget).toHaveValue('standard (default)');
+    expect(storageTarget).toHaveValue('large');
     expect(screen.getByRole('checkbox', { name: /save mapping checkbox/ })).not.toBeChecked();
     await waitFor(() => expect(nextButton).toBeEnabled());
     userEvent.click(nextButton);
@@ -144,7 +144,7 @@ describe('<AddEditProviderModal />', () => {
     expect(screen.getByText(/ocp-network-2/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /1/i })).toBeEnabled();
     expect(networkTarget).toHaveValue('openshift-migration / ocp-network-1');
-    expect(storageTarget).toHaveValue('standard (default)');
+    expect(storageTarget).toHaveValue('large');
 
     expect(screen.getByRole('button', { name: /Finish/i })).toBeEnabled();
   });

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -473,7 +473,7 @@ export const useEditingPlanPrefillEffect = (
       const networkMapping = networkMappingsQuery.data?.items.find((mapping) =>
         isSameResource(mapping.metadata, planBeingEdited.spec.map.network)
       );
-      const storageMapping = networkMappingsQuery.data?.items.find((mapping) =>
+      const storageMapping = storageMappingsQuery.data?.items.find((mapping) =>
         isSameResource(mapping.metadata, planBeingEdited.spec.map.storage)
       );
 

--- a/src/app/queries/mocks/mappings.mock.ts
+++ b/src/app/queries/mocks/mappings.mock.ts
@@ -29,7 +29,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             id: MOCK_VMWARE_DATASTORES[0].id,
           },
           destination: {
-            storageClass: MOCK_STORAGE_CLASSES_BY_PROVIDER['ocpv-1'][0].name,
+            storageClass: MOCK_STORAGE_CLASSES_BY_PROVIDER['ocpv-1'][1].name,
           },
         },
       ],

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -90,6 +90,7 @@ export const useCreatePlanMutation = (
     {
       onSuccess: () => {
         queryCache.invalidateQueries('plans');
+        queryCache.invalidateQueries('mappings');
         pollFasterAfterMutation();
         onSuccess && onSuccess();
       },
@@ -128,6 +129,7 @@ export const usePatchPlanMutation = (
     {
       onSuccess: () => {
         queryCache.invalidateQueries('plans');
+        queryCache.invalidateQueries('mappings');
         pollFasterAfterMutation();
         onSuccess && onSuccess();
       },
@@ -145,6 +147,7 @@ export const useDeletePlanMutation = (
     {
       onSuccess: () => {
         queryCache.invalidateQueries('plans');
+        queryCache.invalidateQueries('mappings');
         onSuccess && onSuccess();
       },
     }


### PR DESCRIPTION
Backports kubev2v/forklift-ui#591.

Note: this PR includes additional changes related to these bugs, since I happened to fix part of it on the main branch in https://github.com/konveyor/forklift-ui/pull/585. The commit https://github.com/konveyor/forklift-ui/commit/785ea0760d8d235bf3bdeee88f91ea057c9f9d27 replicates the changes from https://github.com/konveyor/forklift-ui/pull/585/commits/406b0982cd06309308f472d68f4d91eb3aa49885#diff-55b411ad333b40962073e7eb43e4f9db265aaada61377172a4e4b5e98384ec07R163-R185 in order to properly prevent the user from opening wizard steps that depend on earlier steps with invalid values. This means if the mappings are somehow still invalid after prefilling even with these fixes, the user will be forced to visit those steps and fix the mappings before proceeding. See https://github.com/konveyor/forklift-ui/issues/590.