### PR TITLE
Block restarting a plan with the Succeeded condition

### DIFF
--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -77,7 +77,8 @@ export const canPlanBeStarted = (plan: IPlan): boolean => {
   const conditions = plan.status?.conditions || [];
   if (
     !hasCondition(conditions, PlanStatusType.Ready) ||
-    hasCondition(conditions, PlanStatusType.Executing)
+    hasCondition(conditions, PlanStatusType.Executing) ||
+    hasCondition(conditions, PlanStatusType.Succeeded)
   ) {
     return false;
   }


### PR DESCRIPTION
Changes requested by @mansam . Addressing an issue where the controller would re-migrate succeeded VMs. If the user wants to re-migrate canceled VMs in a plan that contains succeeded VMs they can start a new plan (you can still retry fully failed or canceled plans). We can improve the UX for that use case later on (related to kubev2v/forklift-console-plugin#135 and/or kubev2v/forklift-ui#581)