### PR TITLE
Add message warning about load times for large environments in the wizard

### DIFF
--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -92,6 +92,7 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
       <ResolvedQueries
         results={[vmsQuery, treeQuery]}
         errorTitles={['Error loading VMs', 'Error loading VMware tree data']}
+        emptyStateBody="For large environments, loading may take a few minutes."
       >
         <TreeView
           data={filterAndConvertVMwareTree(

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -259,6 +259,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
         'Error loading VMware VM tree data',
         'Error loading VMs',
       ]}
+      emptyStateBody="For large environments, loading may take a few minutes."
     >
       {availableVMs.length === 0 ? (
         <TableEmptyState

--- a/src/app/common/components/LoadingEmptyState.tsx
+++ b/src/app/common/components/LoadingEmptyState.tsx
@@ -1,14 +1,23 @@
-import { Bullseye, EmptyState, Spinner, SpinnerProps, Title } from '@patternfly/react-core';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  Spinner,
+  SpinnerProps,
+  Title,
+} from '@patternfly/react-core';
 import * as React from 'react';
 
 interface ILoadingEmptyStateProps {
   className?: string;
   spinnerProps?: Partial<SpinnerProps>;
+  body?: React.ReactNode;
 }
 
 const LoadingEmptyState: React.FunctionComponent<ILoadingEmptyStateProps> = ({
   className = '',
   spinnerProps = {},
+  body = null,
 }: ILoadingEmptyStateProps) => (
   <Bullseye className={className}>
     <EmptyState variant="large">
@@ -16,6 +25,7 @@ const LoadingEmptyState: React.FunctionComponent<ILoadingEmptyStateProps> = ({
         <Spinner size="xl" {...spinnerProps} />
       </div>
       <Title headingLevel="h2">Loading...</Title>
+      {body ? <EmptyStateBody>{body}</EmptyStateBody> : null}
     </EmptyState>
   </Bullseye>
 );

--- a/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
+++ b/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
@@ -23,6 +23,7 @@ export interface IResolvedQueriesProps {
   errorTitles: string[];
   errorsInline?: boolean;
   spinnerMode?: QuerySpinnerMode;
+  emptyStateBody?: React.ReactNode;
   spinnerProps?: Partial<SpinnerProps>;
   alertProps?: Partial<AlertProps>;
   className?: string;
@@ -35,6 +36,7 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
   errorTitles,
   errorsInline = true,
   spinnerMode = QuerySpinnerMode.EmptyState,
+  emptyStateBody = null,
   spinnerProps = {},
   alertProps = {},
   className = '',
@@ -48,7 +50,7 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
   if (spinnerMode === QuerySpinnerMode.Inline) {
     spinner = <Spinner size="lg" className={className} {...spinnerProps} />;
   } else if (spinnerMode === QuerySpinnerMode.EmptyState) {
-    spinner = <LoadingEmptyState spinnerProps={spinnerProps} />;
+    spinner = <LoadingEmptyState spinnerProps={spinnerProps} body={emptyStateBody} />;
   }
 
   return (


### PR DESCRIPTION
![Screen Shot 2021-05-19 at 11 49 08 AM](https://user-images.githubusercontent.com/811963/118843962-8cb2cd00-b898-11eb-8f11-05bfae4f7875.png)

Additional text "For large environments, loading may take a few minutes." appears below the spinner on both the Filter and Select VMs steps of the wizard.