### PR TITLE
Bug 1962276: Fix wizard performance in large environments: Memoize queries and make tree traversal asynchronous

### DIFF
--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -53,12 +53,8 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   sourceProvider,
   selectedVMs,
 }: ISelectVMsFormProps) => {
-  const hostTreeQuery = useVMwareTreeQuery<IVMwareHostTree>(
-    sourceProvider,
-    VMwareTreeType.Host,
-    false
-  );
-  const vmTreeQuery = useVMwareTreeQuery<IVMwareVMTree>(sourceProvider, VMwareTreeType.VM, false);
+  const hostTreeQuery = useVMwareTreeQuery<IVMwareHostTree>(sourceProvider, VMwareTreeType.Host);
+  const vmTreeQuery = useVMwareTreeQuery<IVMwareVMTree>(sourceProvider, VMwareTreeType.VM);
   const vmsQuery = useVMwareVMsQuery(sourceProvider);
 
   // Even if some of the already-selected VMs don't match the filter, include them in the list.
@@ -78,12 +74,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
 
   const [treePathInfoByVM, setTreePathInfoByVM] = React.useState<IVMTreePathInfoByVM | null>(null);
   React.useEffect(() => {
-    if (
-      !treePathInfoByVM &&
-      (availableVMs || []).length > 0 &&
-      hostTreeQuery.data &&
-      vmTreeQuery.data
-    ) {
+    if ((availableVMs || []).length > 0 && hostTreeQuery.data && vmTreeQuery.data) {
       setTreePathInfoByVM(
         getVMTreePathInfoByVM(
           availableVMs?.map((vm) => vm.selfLink) || [],
@@ -92,7 +83,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
         )
       );
     }
-  }, [treePathInfoByVM, availableVMs, hostTreeQuery.data, vmTreeQuery.data]);
+  }, [availableVMs, hostTreeQuery.data, vmTreeQuery.data]);
   const getVMTreeInfo = (vm: IVMwareVM): IVMTreePathInfo => {
     if (treePathInfoByVM) return treePathInfoByVM[vm.selfLink];
     return { datacenter: null, cluster: null, host: null, folders: null, folderPathStr: null };

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -65,6 +65,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   const selectedVMsOnMount = React.useRef(selectedVMs);
   const availableVMs = React.useMemo(() => {
     if (!vmsQuery.data) return [];
+    console.log('running memoized availableVMs func');
     const filteredVMs = getAvailableVMs(selectedTreeNodes, vmsQuery.data || []);
     return [
       ...selectedVMsOnMount.current,

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -180,7 +180,7 @@ export interface IVMTreePathInfo {
 
 // Using the breadcrumbs for the VM in each tree, grab the column values for the Select VMs table.
 export const findVMTreePathInfo = (
-  vm: IVMwareVM,
+  vmSelfLink: string,
   hostTree: IVMwareHostTree | null,
   vmTree: IVMwareVMTree | null
 ): IVMTreePathInfo => {
@@ -193,8 +193,8 @@ export const findVMTreePathInfo = (
       folderPathStr: null,
     };
   }
-  const hostTreePath = findVMTreePath(hostTree, vm.selfLink);
-  const vmTreePath = findVMTreePath(vmTree, vm.selfLink);
+  const hostTreePath = findVMTreePath(hostTree, vmSelfLink);
+  const vmTreePath = findVMTreePath(vmTree, vmSelfLink);
   const folders =
     (vmTreePath
       ?.filter((node) => !!node && node.kind === 'Folder')
@@ -213,17 +213,19 @@ export interface IVMTreePathInfoByVM {
 }
 
 export const getVMTreePathInfoByVM = (
-  vms: IVMwareVM[],
+  vmSelfLinks: string[],
   hostTree: IVMwareHostTree | null,
   vmTree: IVMwareVMTree | null
-): IVMTreePathInfoByVM =>
-  vms.reduce(
-    (newObj, vm) => ({
+): IVMTreePathInfoByVM | null => {
+  if (vmSelfLinks.length === 0) return null;
+  return vmSelfLinks.reduce(
+    (newObj, vmSelfLink) => ({
       ...newObj,
-      [vm.selfLink]: findVMTreePathInfo(vm, hostTree, vmTree),
+      [vmSelfLink]: findVMTreePathInfo(vmSelfLink, hostTree, vmTree),
     }),
     {}
   );
+};
 
 export const findMatchingNodeAndDescendants = (
   tree: VMwareTree | null,

--- a/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
+++ b/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
@@ -27,6 +27,7 @@ export interface IResolvedQueriesProps {
   spinnerProps?: Partial<SpinnerProps>;
   alertProps?: Partial<AlertProps>;
   className?: string;
+  forceLoadingState?: boolean;
   children?: React.ReactNode;
 }
 
@@ -40,6 +41,7 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
   spinnerProps = {},
   alertProps = {},
   className = '',
+  forceLoadingState = false,
   children = null,
 }: IResolvedQueriesProps) => {
   const status = getAggregateQueryStatus(results);
@@ -55,7 +57,7 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
 
   return (
     <>
-      {status === QueryStatus.Loading ? (
+      {status === QueryStatus.Loading || forceLoadingState ? (
         spinner
       ) : status === QueryStatus.Error ? (
         <div>

--- a/src/app/queries/datastores.ts
+++ b/src/app/queries/datastores.ts
@@ -1,6 +1,6 @@
 import { usePollingContext } from '@app/common/context';
 import { QueryResult } from 'react-query';
-import { getInventoryApiUrl, sortResultsByName, useMockableQuery } from './helpers';
+import { getInventoryApiUrl, useResultsSortedByName, useMockableQuery } from './helpers';
 import { MOCK_VMWARE_DATASTORES } from './mocks/datastores.mock';
 import { IVMwareDatastore, IVMwareProvider, MappingType } from './types';
 import { useAuthorizedFetch } from './fetchHelpers';
@@ -22,5 +22,5 @@ export const useDatastoresQuery = (
     },
     MOCK_VMWARE_DATASTORES
   );
-  return sortResultsByName(result);
+  return useResultsSortedByName(result);
 };

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { KubeClientError, IKubeList } from '@app/client/types';
 import { CLUSTER_API_VERSION, PlanStatusType } from '@app/common/constants';
 import { hasCondition } from '@app/common/helpers';
@@ -133,34 +134,38 @@ export const sortByName = <T extends IHasName>(data?: T[]): T[] => {
   return (data || []).sort((a: T, b: T) => (getName(a) < getName(b) ? -1 : 1));
 };
 
+export const useResultsSortedByName = <T extends IHasName>(
+  result: QueryResult<T[]>
+): QueryResult<T[]> => ({
+  ...result,
+  data: React.useMemo(() => sortByName(result.data), [result.data]),
+});
+
 export const sortIndexedDataByName = <TItem extends { name: string }, TIndexed>(
   data: TIndexed | undefined
 ): TIndexed | undefined => sortIndexedData<TItem, TIndexed>(data, (item: TItem) => item.name);
 
-export const sortResultsByName = <T extends IHasName>(
-  result: QueryResult<T[]>
-): QueryResult<T[]> => ({
-  ...result,
-  data: sortByName(result.data),
-});
-
-export const sortKubeResultsByName = <T>(
-  result: QueryResult<IKubeList<T>>
-): QueryResult<IKubeList<T>> => ({
-  ...result,
-  data: result.data
-    ? {
-        ...result.data,
-        items: sortByName(result.data.items || []),
-      }
-    : undefined,
-});
-
-export const sortIndexedResultsByName = <TItem extends { name: string }, TIndexed>(
+export const useIndexedResultsSortedByName = <TIndexed>(
   result: QueryResult<TIndexed>
 ): QueryResult<TIndexed> => ({
   ...result,
-  data: sortIndexedDataByName<TItem, TIndexed>(result.data),
+  data: React.useMemo(() => sortIndexedDataByName(result.data), [result.data]),
+});
+
+export const useKubeResultsSortedByName = <T>(
+  result: QueryResult<IKubeList<T>>
+): QueryResult<IKubeList<T>> => ({
+  ...result,
+  data: React.useMemo(
+    () =>
+      result.data
+        ? {
+            ...result.data,
+            items: sortByName(result.data.items || []),
+          }
+        : undefined,
+    [result.data]
+  ),
 });
 
 export const sortTreeItemsByName = <T extends VMwareTree>(tree?: T): T | undefined =>
@@ -176,13 +181,6 @@ export const sortTreeItemsByName = <T extends VMwareTree>(tree?: T): T | undefin
           }),
       }
     : undefined;
-
-export const sortTreeResultsByName = <T extends VMwareTree>(
-  result: QueryResult<T>
-): QueryResult<T> => ({
-  ...result,
-  data: sortTreeItemsByName(result.data),
-});
 
 export const nameAndNamespace = (
   ref: Partial<INameNamespaceRef> | null | undefined

--- a/src/app/queries/hooks.ts
+++ b/src/app/queries/hooks.ts
@@ -6,7 +6,7 @@ import { ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
 import { IKubeList } from '@app/client/types';
 import { META } from '@app/common/constants';
 import { usePollingContext } from '@app/common/context';
-import { mockKubeList, sortKubeResultsByName, useMockableQuery } from './helpers';
+import { mockKubeList, useKubeResultsSortedByName, useMockableQuery } from './helpers';
 import { MOCK_HOOKS } from './mocks/hooks.mock';
 import { IHook } from './types';
 import { useAuthorizedK8sClient } from './fetchHelpers';
@@ -25,7 +25,7 @@ export const useHooksQuery = (): QueryResult<IKubeList<IHook>> => {
     },
     mockKubeList(MOCK_HOOKS, 'Hook')
   );
-  return sortKubeResultsByName(result);
+  return useKubeResultsSortedByName(result);
 };
 
 export const playbookSchema = yup

--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -3,11 +3,11 @@ import { usePollingContext } from '@app/common/context';
 import {
   useMockableQuery,
   getInventoryApiUrl,
-  sortResultsByName,
   isSameResource,
   useMockableMutation,
   nameAndNamespace,
   mockKubeList,
+  useResultsSortedByName,
 } from './helpers';
 import { MOCK_HOSTS, MOCK_HOST_CONFIGS } from './mocks/hosts.mock';
 import { IHost, IHostConfig, INameNamespaceRef, ISecret, IVMwareProvider } from './types';
@@ -35,7 +35,7 @@ export const useHostsQuery = (provider: IVMwareProvider | null): QueryResult<IHo
     },
     MOCK_HOSTS
   );
-  return sortResultsByName<IHost>(result);
+  return useResultsSortedByName(result);
 };
 
 export const useHostConfigsQuery = (): QueryResult<IKubeList<IHostConfig>> => {

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -15,7 +15,7 @@ import {
   getAggregateQueryStatus,
   getFirstQueryError,
   mockKubeList,
-  sortKubeResultsByName,
+  useKubeResultsSortedByName,
   useMockableMutation,
   useMockableQuery,
 } from './helpers';
@@ -53,7 +53,7 @@ export const useMappingsQuery = (mappingType: MappingType): QueryResult<IKubeLis
       ? mockKubeList(MOCK_NETWORK_MAPPINGS, 'NetworkMapList')
       : mockKubeList(MOCK_STORAGE_MAPPINGS, 'StorageMapList')
   );
-  return sortKubeResultsByName(result);
+  return useKubeResultsSortedByName(result);
 };
 
 export const useCreateMappingMutation = (

--- a/src/app/queries/migrations.ts
+++ b/src/app/queries/migrations.ts
@@ -6,7 +6,7 @@ import {
   isSameResource,
   mockKubeList,
   nameAndNamespace,
-  sortKubeResultsByName,
+  useKubeResultsSortedByName,
   useMockableMutation,
   useMockableQuery,
 } from './helpers';
@@ -71,7 +71,7 @@ export const useMigrationsQuery = (): QueryResult<IKubeList<IMigration>> => {
     },
     mockKubeList(MOCK_MIGRATIONS, 'Migration')
   );
-  return sortKubeResultsByName(result);
+  return useKubeResultsSortedByName(result);
 };
 
 export const findLatestMigration = (

--- a/src/app/queries/namespaces.ts
+++ b/src/app/queries/namespaces.ts
@@ -1,6 +1,6 @@
 import { usePollingContext } from '@app/common/context';
 import { QueryResult } from 'react-query';
-import { getInventoryApiUrl, sortResultsByName, useMockableQuery } from './helpers';
+import { getInventoryApiUrl, useResultsSortedByName, useMockableQuery } from './helpers';
 import { IOpenShiftProvider } from './types';
 import { useAuthorizedFetch } from './fetchHelpers';
 import { IOpenShiftNamespace } from './types/namespaces.types';
@@ -20,5 +20,5 @@ export const useNamespacesQuery = (
     },
     MOCK_OPENSHIFT_NAMESPACES
   );
-  return sortResultsByName(result);
+  return useResultsSortedByName(result);
 };

--- a/src/app/queries/networks.ts
+++ b/src/app/queries/networks.ts
@@ -1,7 +1,7 @@
 import { usePollingContext } from '@app/common/context';
 import { ProviderType } from '@app/common/constants';
 import { QueryResult } from 'react-query';
-import { useMockableQuery, getInventoryApiUrl, sortResultsByName } from './helpers';
+import { useMockableQuery, getInventoryApiUrl, useResultsSortedByName } from './helpers';
 import { MOCK_OPENSHIFT_NETWORKS, MOCK_VMWARE_NETWORKS } from './mocks/networks.mock';
 import {
   IOpenShiftNetwork,
@@ -32,7 +32,7 @@ export const useNetworksQuery = <T extends IVMwareNetwork | IOpenShiftNetwork>(
     },
     mockNetworks
   );
-  return sortResultsByName<T>(result);
+  return useResultsSortedByName(result);
 };
 
 export const useVMwareNetworksQuery = (

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -7,7 +7,7 @@ import { MutationResultPair, QueryResult, useQueryCache } from 'react-query';
 import {
   mockKubeList,
   nameAndNamespace,
-  sortKubeResultsByName,
+  useKubeResultsSortedByName,
   useMockableMutation,
   useMockableQuery,
 } from './helpers';
@@ -34,7 +34,7 @@ export const usePlansQuery = (): QueryResult<IKubeList<IPlan>> => {
     },
     mockKubeList(MOCK_PLANS, 'Plan')
   );
-  return sortKubeResultsByName(result);
+  return useKubeResultsSortedByName(result);
 };
 
 export const useCreatePlanMutation = (

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -6,11 +6,11 @@ import { usePollingContext } from '@app/common/context';
 import {
   useMockableQuery,
   getInventoryApiUrl,
-  sortIndexedResultsByName,
   useMockableMutation,
   isSameResource,
   nameAndNamespace,
   mockKubeList,
+  useIndexedResultsSortedByName,
 } from './helpers';
 import { MOCK_CLUSTER_PROVIDERS, MOCK_INVENTORY_PROVIDERS } from './mocks/providers.mock';
 import {
@@ -62,7 +62,7 @@ export const useInventoryProvidersQuery = (): QueryResult<IProvidersByType> => {
     MOCK_INVENTORY_PROVIDERS
   );
 
-  return sortIndexedResultsByName<InventoryProvider, IProvidersByType>(result);
+  return useIndexedResultsSortedByName(result);
 };
 
 export const useCreateProviderMutation = (

--- a/src/app/queries/tree.ts
+++ b/src/app/queries/tree.ts
@@ -9,18 +9,16 @@ import { useAuthorizedFetch } from './fetchHelpers';
 
 export const useVMwareTreeQuery = <T extends VMwareTree>(
   provider: IVMwareProvider | null,
-  treeType: VMwareTreeType,
-  isRefetchEnabled = true
+  treeType: VMwareTreeType
 ): QueryResult<T> => {
   const apiSlug = treeType === VMwareTreeType.Host ? '/tree/host' : '/tree/vm';
-  const refetchInterval = usePollingContext().refetchInterval;
   const result = useMockableQuery<T>(
     {
       queryKey: ['vmware-tree', provider?.name, treeType],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}${apiSlug}`)),
       config: {
         enabled: !!provider,
-        refetchInterval: isRefetchEnabled ? refetchInterval : false,
+        refetchInterval: usePollingContext().refetchInterval,
       },
     },
     (treeType === VMwareTreeType.Host ? MOCK_VMWARE_HOST_TREE : MOCK_VMWARE_VM_TREE) as T

--- a/src/app/queries/tree.ts
+++ b/src/app/queries/tree.ts
@@ -1,6 +1,7 @@
+import * as React from 'react';
 import { usePollingContext } from '@app/common/context';
 import { QueryResult } from 'react-query';
-import { getInventoryApiUrl, sortTreeResultsByName, useMockableQuery } from './helpers';
+import { getInventoryApiUrl, sortTreeItemsByName, useMockableQuery } from './helpers';
 import { MOCK_VMWARE_HOST_TREE, MOCK_VMWARE_VM_TREE } from './mocks/tree.mock';
 import { IVMwareProvider } from './types';
 import { VMwareTree, VMwareTreeType } from './types/tree.types';
@@ -24,5 +25,9 @@ export const useVMwareTreeQuery = <T extends VMwareTree>(
     },
     (treeType === VMwareTreeType.Host ? MOCK_VMWARE_HOST_TREE : MOCK_VMWARE_VM_TREE) as T
   );
-  return sortTreeResultsByName(result);
+  const sortedData = React.useMemo(() => sortTreeItemsByName(result.data), [result.data]);
+  return {
+    ...result,
+    data: sortedData,
+  };
 };

--- a/src/app/queries/tree.ts
+++ b/src/app/queries/tree.ts
@@ -8,16 +8,18 @@ import { useAuthorizedFetch } from './fetchHelpers';
 
 export const useVMwareTreeQuery = <T extends VMwareTree>(
   provider: IVMwareProvider | null,
-  treeType: VMwareTreeType
+  treeType: VMwareTreeType,
+  isRefetchEnabled = true
 ): QueryResult<T> => {
   const apiSlug = treeType === VMwareTreeType.Host ? '/tree/host' : '/tree/vm';
+  const refetchInterval = usePollingContext().refetchInterval;
   const result = useMockableQuery<T>(
     {
       queryKey: ['vmware-tree', provider?.name, treeType],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}${apiSlug}`)),
       config: {
         enabled: !!provider,
-        refetchInterval: usePollingContext().refetchInterval,
+        refetchInterval: isRefetchEnabled ? refetchInterval : false,
       },
     },
     (treeType === VMwareTreeType.Host ? MOCK_VMWARE_HOST_TREE : MOCK_VMWARE_VM_TREE) as T

--- a/src/app/queries/vms.ts
+++ b/src/app/queries/vms.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { QueryResult } from 'react-query';
 import { usePollingContext } from '@app/common/context';
 import { useAuthorizedFetch } from './fetchHelpers';
@@ -20,9 +21,13 @@ export const useVMwareVMsQuery = (provider: IVMwareProvider | null): QueryResult
     },
     MOCK_VMWARE_VMS
   );
+  const sortedData = React.useMemo(
+    () => sortByName((result.data || []).filter((vm) => !vm.isTemplate)),
+    [result.data]
+  );
   return {
     ...result,
-    data: sortByName((result.data || []).filter((vm) => !vm.isTemplate)),
+    data: sortedData,
   };
 };
 

--- a/src/app/queries/vms.ts
+++ b/src/app/queries/vms.ts
@@ -27,7 +27,7 @@ export const useVMwareVMsQuery = (provider: IVMwareProvider | null): QueryResult
   );
   return {
     ...result,
-    data: sortedData,
+    data: result.data ? sortedData : undefined,
   };
 };
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1962276

With large numbers of VMs (over 4,000 in this test), the Select VMs step was hanging for long periods of time. Particularly when first mounting (clicking the Next button on the previous step was not responding for several seconds) and when clicking checkboxes on the VM rows.

The culprit turned out to (mostly) be the very expensive `getVMTreePathInfoByVM` function being called synchronously on every single render of the Select VMs step. This function has to traverse the tree data recursively once per selected node in the Filter step, so it can take a few seconds. This PR moves the VM-indexed tree data to local state and shows a spinner until it is first defined. I also gave the `getAvailableVMs` call the same treatment, although that bottleneck was much smaller.

Another thing I noticed while fixing this was that all of our query hooks which return sorted data were performing that sort and returning a new immutable copy every single time any of the query state changed at all, which happens several times when the query is first mounted and goes through its fetch lifecycle. I used `React.useMemo` to only perform these sorts when the data changes, so now we get only one render per fetch instead of several, across all of our pages.