### PR TITLE
Add the 'may take several seconds' message everywhere the list of VMs is loaded

### DIFF
--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -63,6 +63,7 @@ import ConfirmModal from '@app/common/components/ConfirmModal';
 import { getWarmPlanState } from './helpers';
 import VMStatusPrecopyTable from './VMStatusPrecopyTable';
 import VMWarmCopyStatus, { getWarmVMCopyState } from './VMWarmCopyStatus';
+import { LONG_LOADING_MESSAGE } from '@app/queries/constants';
 
 export interface IPlanMatchParams {
   url: string;
@@ -330,6 +331,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
             'Error loading VMs',
           ]}
           errorsInline={false}
+          emptyStateBody={LONG_LOADING_MESSAGE}
         >
           <Card>
             <CardBody>

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -15,6 +15,7 @@ import { PlanWizardFormState } from './PlanWizard';
 
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { usePausedPollingEffect } from '@app/common/context';
+import { LONG_LOADING_MESSAGE } from '@app/queries/constants';
 
 interface IFilterVMsFormProps {
   form: PlanWizardFormState['filterVMs'];
@@ -92,7 +93,7 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
       <ResolvedQueries
         results={[vmsQuery, treeQuery]}
         errorTitles={['Error loading VMs', 'Error loading VMware tree data']}
-        emptyStateBody="For large environments, this may take several seconds."
+        emptyStateBody={LONG_LOADING_MESSAGE}
       >
         <TreeView
           data={filterAndConvertVMwareTree(

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -57,6 +57,7 @@ import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { PlanHookInstance } from './PlanAddEditHookModal';
 
 import './PlanWizard.css';
+import { LONG_LOADING_MESSAGE } from '@app/queries/constants';
 
 const useMappingFormState = (mappingsQuery: QueryResult<IKubeList<Mapping>>) => {
   const isSaveNewMapping = useFormField(false, yup.boolean().required());
@@ -392,6 +393,7 @@ const PlanWizard: React.FunctionComponent = () => {
       ]}
       errorsInline={false}
       className={spacing.mMd}
+      emptyStateBody={LONG_LOADING_MESSAGE}
     >
       {!isDonePrefilling ? (
         <LoadingEmptyState />

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -39,6 +39,7 @@ import { FilterToolbar, FilterType, FilterCategory } from '@app/common/component
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import VMConcernsIcon from './VMConcernsIcon';
 import VMConcernsDescription from './VMConcernsDescription';
+import { LONG_LOADING_MESSAGE } from '@app/queries/constants';
 
 interface ISelectVMsFormProps {
   form: PlanWizardFormState['selectVMs'];
@@ -275,7 +276,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
         'Error loading VMware VM tree data',
         'Error loading VMs',
       ]}
-      emptyStateBody="For large environments, this may take several seconds."
+      emptyStateBody={LONG_LOADING_MESSAGE}
       forceLoadingState={!availableVMs}
     >
       {(availableVMs || []).length === 0 ? (

--- a/src/app/queries/constants.ts
+++ b/src/app/queries/constants.ts
@@ -1,3 +1,5 @@
 export const POLLING_INTERVAL = 5000;
 export const POLLING_INTERVAL_AFTER_MUTATION = 2000;
 export const AFTER_MUTATION_WINDOW = 6000;
+
+export const LONG_LOADING_MESSAGE = 'For large environments, this may take several seconds.';


### PR DESCRIPTION
Bare minimum to address https://bugzilla.redhat.com/show_bug.cgi?id=1962276#c2. When the user first visits a page that requests the entire list of VMs (migration details, plan wizard in edit mode, plan wizard filter/select steps in create mode) there is a risk of the request taking some time. This PR adds the message from #598 / #602 to all of those views.

Note: reproducing on Naayan's environment, on the migration details page specifically, the latency appears to be mostly in the API request itself.