### PR TITLE
Revert #593 ("Block restarting a plan with the Succeeded condition")

### DIFF
--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -77,8 +77,7 @@ export const canPlanBeStarted = (plan: IPlan): boolean => {
   const conditions = plan.status?.conditions || [];
   if (
     !hasCondition(conditions, PlanStatusType.Ready) ||
-    hasCondition(conditions, PlanStatusType.Executing) ||
-    hasCondition(conditions, PlanStatusType.Succeeded)
+    hasCondition(conditions, PlanStatusType.Executing)
   ) {
     return false;
   }


### PR DESCRIPTION
This reverts commit b42445b12e505a542a63b848f2ac1c3394635a98 from #593. After discussions about the UX for retrying canceled migrations, it was decided the user should not be blocked in this case.