### PR TITLE
fix(cleanup): fix skip to content link page refresh issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ cd forklift-ui
 npm install
 ```
 
-Create a meta.dev.json file in the config directory using [`config/meta.dev.example.json`](https://github.com/konveyor/forklift-ui/blob/main/config/meta.example.json) as a template. Set the `inventoryApi` property to the root URL of your forklift-controller inventory API, and set the `clusterApi` property to the root URL of your host OpenShift cluster API. And also to be able to use VMware provider data to be analysed by Migration Analytics set the `inventoryPayloadApi` property to the root URL of your forklift-controller inventory Payload API.
+Create a meta.dev.json file in the config directory using [`config/meta.dev.example.json`](./config/meta.dev.example.json) as a template. Set the `inventoryApi` property to the root URL of your forklift-controller inventory API, and set the `clusterApi` property to the root URL of your host OpenShift cluster API. And also to be able to use VMware provider data to be analysed by Migration Analytics set the `inventoryPayloadApi` property to the root URL of your forklift-controller inventory Payload API.
 
-**Optional**: If you plan to run webpack directly or run in production mode, you can create a file named `.env` in the repository root, using [`.env.example`](https://github.com/konveyor/forklift-ui/blob/main/.env.example) as a template. Here you can set persistent environment variables:
+### Environment variables:
 
 - `DATA_SOURCE` - either `mock` or `remote`
   (unnecessary if you use `npm run [start:dev|build]:[mock|remote]` scripts)
 - `META_FILE` path (for running in prod mode with `npm run start`)
 - `BRAND_TYPE` - either `Konveyor` (default) or `RedHat`
 
-Run the UI with webpack-dev-server at http://localhost:9000:
+Run the UI with webpack-dev-server at [localhost:9000](http://localhost:9000):
 
 ```sh
 npm run start:dev:remote  # uses data from the API URLs in your config/meta.dev.json file

--- a/src/app/AppLayout/AppLayout.css
+++ b/src/app/AppLayout/AppLayout.css
@@ -13,3 +13,9 @@
 .brand-redhat .pf-c-about-modal-box__brand {
   display: none;
 }
+
+.logo.pf-c-button {
+  font-size: var(--pf-global--FontSize--2xl);
+  --pf-c-button--PaddingRight: .5rem;
+  --pf-c-button--PaddingLeft: .5rem;
+}

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { NavLink, useRouteMatch, useLocation } from 'react-router-dom';
+import { NavLink, useRouteMatch, useLocation, useHistory } from 'react-router-dom';
 import {
+  Button,
   Nav,
   NavList,
   NavItem,
@@ -9,10 +10,10 @@ import {
   PageSidebar,
   SkipToContent,
   NavExpandable,
-  Title,
   PageHeaderTools,
 } from '@patternfly/react-core';
 import { routes, IAppRoute, IAppRouteGroup } from '@app/routes';
+import { accessibleRouteChangeHandler } from '@app/utils/utils';
 import { APP_TITLE } from '@app/common/constants';
 import logoRedHat from './logoRedHat.svg';
 import logoKonveyor from './logoKonveyor.svg';
@@ -42,10 +43,22 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
   const location = useLocation();
   const welcomePageMatch = useRouteMatch('/welcome');
   const isNavEnabled = !welcomePageMatch;
+  const history = useHistory();
 
   const Header = (
     <PageHeader
-      logo={<Title headingLevel="h1">{APP_TITLE}</Title>}
+      logo={
+        <Button
+          className="logo"
+          aria-label={`${APP_TITLE} logo`}
+          variant="plain"
+          onClick={() => {
+            history.push('/');
+          }}
+        >
+          {APP_TITLE}
+        </Button>
+      }
       logoComponent="span"
       showNavToggle={isNavEnabled}
       isNavOpen={isNavEnabled && isNavOpen}
@@ -110,12 +123,23 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
       isNavOpen={isMobileView ? isNavOpenMobile : isNavOpen}
     />
   );
+
+  const pageId = 'primary-app-container';
+
   const PageSkipToContent = (
-    <SkipToContent href="#primary-app-container">Skip to Content</SkipToContent>
+    <SkipToContent
+      onClick={(event) => {
+        event.preventDefault();
+        accessibleRouteChangeHandler(pageId);
+      }}
+      href={`#${pageId}`}
+    >
+      Skip to Content
+    </SkipToContent>
   );
   return (
     <Page
-      mainContainerId="primary-app-container"
+      mainContainerId={pageId}
       header={Header}
       sidebar={isNavEnabled ? Sidebar : null}
       onPageResize={onPageResize}

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -8,6 +8,14 @@ describe('App', () => {
   test('renders welcome page without errors', async () => {
     process.env['DATA_SOURCE'] = '';
     render(<App />);
-    expect(screen.getByRole('heading', { name: new RegExp(APP_TITLE) })).toBeInTheDocument;
+    expect(
+      screen.getByRole('button', { name: `${APP_TITLE} logo`, hidden: true })
+    ).toHaveTextContent(APP_TITLE);
+  });
+
+  test('renders help menu', async () => {
+    process.env['DATA_SOURCE'] = '';
+    render(<App />);
+    expect(screen.getByRole('button', { name: new RegExp('Help menu') })).toBeInTheDocument;
   });
 });

--- a/src/app/common/components/LoadingEmptyState.tsx
+++ b/src/app/common/components/LoadingEmptyState.tsx
@@ -22,9 +22,11 @@ const LoadingEmptyState: React.FunctionComponent<ILoadingEmptyStateProps> = ({
   <Bullseye className={className}>
     <EmptyState variant="large">
       <div className="pf-c-empty-state__icon">
-        <Spinner size="xl" {...spinnerProps} />
+        <Spinner aria-labelledby="loadingPrefLabel" size="xl" {...spinnerProps} />
       </div>
-      <Title headingLevel="h2">Loading...</Title>
+      <Title id="loadingPrefLabel" headingLevel="h2">
+        Loading...
+      </Title>
       {body ? <EmptyStateBody>{body}</EmptyStateBody> : null}
     </EmptyState>
   </Bullseye>

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -1,6 +1,6 @@
-export function accessibleRouteChangeHandler() {
+export function accessibleRouteChangeHandler(pageId = 'primary-app-container') {
   return window.setTimeout(() => {
-    const mainContainer = document.getElementById('primary-app-container');
+    const mainContainer = document.getElementById(pageId);
     if (mainContainer) {
       mainContainer.focus();
     }


### PR DESCRIPTION
This PR is mostly just some small housekeeping items. The link in quickstart for the example json content was out of date, I updated and also made it a relative path so it works as expected on forks.

I'm unsure what [.env.example](https://github.com/konveyor/forklift-ui/blob/main/.env.example) is supposed to point to?

I also noticed when selecting the SkipToContent link the whole page refreshes, this should be fixed now.

Lastly, the spinner just needed an accessible name
<img width="1469" alt="Screen Shot 2021-06-01 at 12 59 35 PM" src="https://user-images.githubusercontent.com/5942899/120372907-c0084980-c2e5-11eb-99f5-acbce92075de.png">
