### PR TITLE
chore(styling): tidy styles for tables

### DIFF
--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -10,6 +10,7 @@ import {
   classNames as classNamesTransform,
   IRow,
   expandable,
+  truncate,
 } from '@patternfly/react-table';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
 import { useSelectionState } from '@konveyor/lib-ui';
@@ -62,7 +63,12 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
   });
 
   const columns: ICell[] = [
-    { title: 'Name', transforms: [sortable], cellFormatters: [expandable] },
+    {
+      title: 'Name',
+      transforms: [sortable],
+      cellFormatters: [expandable],
+      cellTransforms: [truncate],
+    },
     { title: 'Source provider', transforms: [sortable] },
     { title: 'Target provider', transforms: [sortable] },
     { title: 'Status' },
@@ -127,6 +133,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
     <>
       <Pagination {...paginationProps} widgetId="mappings-table-pagination-top" />
       <Table
+        variant="compact"
         aria-label="Mappings table"
         cells={columns}
         rows={rows}

--- a/src/app/Plans/components/PlansTable.css
+++ b/src/app/Plans/components/PlansTable.css
@@ -29,3 +29,7 @@
   width: 100%;
   text-align: left;
 }
+
+.plans-table .pf-c-progress {
+  --pf-c-progress--GridGap: var(--pf-global--spacer--xs)
+}

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -17,7 +17,6 @@ import {
   ICell,
   IRow,
   sortable,
-  wrappable,
   expandable,
   classNames,
   cellWidth,
@@ -26,8 +25,10 @@ import {
   Td,
   Th,
   Tr,
+  truncate,
 } from '@patternfly/react-table';
 import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignment';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { Link } from 'react-router-dom';
 import { useSelectionState } from '@konveyor/lib-ui';
 
@@ -173,13 +174,25 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
   };
 
   const columns: ICell[] = [
-    { title: 'Name', transforms: [sortable, wrappable], cellFormatters: [expandable] },
-    { title: 'Type', transforms: [sortable] },
-    { title: 'Plan status', transforms: [sortable, cellWidth(30)] },
+    {
+      title: 'Name',
+      transforms: [sortable, cellWidth(20)],
+      cellFormatters: [expandable],
+    },
+    {
+      title: 'Type',
+      transforms: [sortable, cellWidth(10)],
+      cellTransforms: [truncate],
+    },
+    {
+      title: 'Plan status',
+      transforms: [sortable, cellWidth(60)],
+      cellTransforms: [truncate],
+    },
     {
       title: '',
       transforms: [cellWidth(10)],
-      columnTransforms: [classNames(alignment.textAlignRight)],
+      columnTransforms: [classNames(alignment.textAlignRight, spacing.pxSm)],
     },
   ];
 

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -241,6 +241,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
     {
       title: 'Name',
       transforms: [sortable, wrappable],
+      cellTransforms: [truncate],
       cellFormatters: planStarted ? [expandable] : [],
     },
     ...(!isShowingPrecopyView

--- a/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.css
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.css
@@ -1,3 +1,9 @@
 ul.pf-c-list.provider-storage-classes-list {
   list-style: none;
 }
+
+@-moz-document url-prefix() {
+  .pf-c-table__compound-expansion-toggle.center-cell {
+    vertical-align: bottom;
+  }
+}

--- a/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
@@ -7,8 +7,10 @@ import {
   sortable,
   compoundExpand,
   classNames as classNamesTransform,
+  cellWidth,
   ICell,
   IRow,
+  truncate,
 } from '@patternfly/react-table';
 import { DatabaseIcon, NetworkIcon } from '@patternfly/react-icons';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
@@ -19,9 +21,11 @@ import ProviderActionsDropdown from '../ProviderActionsDropdown';
 import StatusCondition from '@app/common/components/StatusCondition';
 import { MappingType } from '@app/queries/types';
 import { getMostSeriousCondition, hasCondition, numStr } from '@app/common/helpers';
+import { centerCellTransform } from '@app/utils/utils';
 
 import './OpenShiftProvidersTable.css';
-import { PlanStatusType } from '@app/common/constants';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { PlanStatusType, ProviderType } from '@app/common/constants';
 import { isSameResource } from '@app/queries/helpers';
 import OpenShiftNetworkList from './OpenShiftNetworkList';
 import SelectOpenShiftNetworkModal from '@app/common/components/SelectOpenShiftNetworkModal';
@@ -47,13 +51,43 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
     (storageClassesQuery.data && storageClassesQuery.data[provider.metadata.name]) || [];
 
   const columns: ICell[] = [
-    { title: 'Name', transforms: [sortable] },
-    { title: 'Endpoint', transforms: [sortable] },
-    { title: 'VMs', transforms: [sortable] },
-    { title: 'Networks', transforms: [sortable], cellTransforms: [compoundExpand] },
-    { title: 'Storage classes', transforms: [sortable], cellTransforms: [compoundExpand] },
-    { title: 'Status', transforms: [sortable] },
-    { title: '', columnTransforms: [classNamesTransform(tableStyles.tableAction)] },
+    {
+      title: 'Name',
+      transforms: [sortable],
+      cellTransforms: [truncate],
+    },
+    {
+      title: 'Endpoint',
+      transforms: [sortable],
+      cellTransforms: [truncate],
+    },
+    {
+      title: 'VMs',
+      transforms: [sortable, cellWidth(10)],
+      cellTransforms: [truncate],
+    },
+    {
+      title: 'Networks',
+      transforms: [sortable],
+      cellTransforms: [compoundExpand, truncate, centerCellTransform],
+    },
+    {
+      title: 'Storage classes',
+      transforms: [sortable],
+      cellTransforms: [compoundExpand, truncate, centerCellTransform],
+    },
+    {
+      title: 'Status',
+      transforms: [sortable],
+      cellTransforms: [truncate],
+    },
+    {
+      title: '',
+      columnTransforms: [classNamesTransform(tableStyles.tableAction)],
+      props: {
+        className: spacing.prXs,
+      },
+    },
   ];
 
   const getSortValues = (provider: ICorrelatedProvider<IOpenShiftProvider>) => {
@@ -166,7 +200,7 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
 
   return (
     <>
-      <Level>
+      <Level className={spacing.pbSm}>
         <LevelItem>
           <Button
             variant="secondary"
@@ -181,6 +215,7 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
         </LevelItem>
       </Level>
       <Table
+        variant="compact"
         aria-label="OpenShift Virtualization providers table"
         cells={columns}
         rows={rows}

--- a/src/app/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
@@ -8,7 +8,7 @@ import {
   classNames as classNamesTransform,
   ICell,
   IRow,
-  fitContent,
+  truncate,
 } from '@patternfly/react-table';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
 
@@ -106,14 +106,19 @@ const SourceProvidersTable: React.FunctionComponent<ISourceProvidersTableProps> 
       columnTransforms: [classNamesTransform(tableStyles.tableCheck)],
     },
     */
-    { title: 'Name', transforms: [sortable] },
-    { title: 'Endpoint', transforms: [sortable] },
-    { title: 'Clusters', transforms: [sortable] },
-    { title: 'Hosts', transforms: [sortable] },
-    { title: 'VMs', transforms: [sortable] },
-    { title: 'Networks', transforms: [sortable] },
-    { title: getStorageTitle(providerType, true), transforms: [sortable, fitContent] },
-    { title: 'Status', transforms: [sortable] },
+
+    { title: 'Name', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'Endpoint', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'Clusters', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'Hosts', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'VMs', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'Networks', transforms: [sortable], cellTransforms: [truncate] },
+    {
+      title: getStorageTitle(providerType, true),
+      transforms: [sortable],
+      cellTransforms: [truncate],
+    },
+    { title: 'Status', transforms: [sortable], cellTransforms: [truncate] },
     { title: '', columnTransforms: [classNamesTransform(tableStyles.tableAction)] },
   ];
 
@@ -198,6 +203,7 @@ const SourceProvidersTable: React.FunctionComponent<ISourceProvidersTableProps> 
       </Level>
       <Table
         aria-label={`${PROVIDER_TYPE_NAMES[providerType]} providers table`}
+        variant="compact"
         cells={columns}
         rows={rows}
         sortBy={sortBy}

--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -8,6 +8,7 @@ import {
   ICell,
   IRow,
   cellWidth,
+  truncate,
 } from '@patternfly/react-table';
 import { usePaginationState, useSortState } from '@app/common/hooks';
 import { useSelectionState } from '@konveyor/lib-ui';
@@ -33,11 +34,15 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
   const hostConfigs = hostConfigsQuery.data?.items || [];
 
   const columns: ICell[] = [
-    { title: 'Name', transforms: [sortable] },
-    { title: 'Network for migration data transfer', transforms: [sortable, cellWidth(30)] },
-    { title: 'Bandwidth', transforms: [sortable] },
-    { title: 'MTU', transforms: [sortable] },
-    { title: 'Status', transforms: [sortable] },
+    { title: 'Name', transforms: [sortable], cellTransforms: [truncate] },
+    {
+      title: 'Network for migration data transfer',
+      transforms: [sortable, cellWidth(30)],
+      cellTransforms: [truncate],
+    },
+    { title: 'Bandwidth', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'MTU', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'Status', transforms: [sortable], cellTransforms: [truncate] },
   ];
 
   const getCells = (host: IHost) => {
@@ -121,6 +126,7 @@ const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHostsTabl
         </LevelItem>
       </Level>
       <Table
+        variant="compact"
         className="provider-inner-hosts-table"
         aria-label={`Hosts table for provider ${provider.name}`}
         cells={columns}

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -6,3 +6,7 @@ export function accessibleRouteChangeHandler(pageId = 'primary-app-container') {
     }
   }, 50);
 }
+
+export const centerCellTransform = () => {
+  return { className: 'center-cell' };
+};


### PR DESCRIPTION
This PR applies some styling enhancement to various tables in the UI. I tried to fine-tune them as best I could without making major changes to the way the data is output. It's not perfect in the sense that at certain viewport widths, the rows still slightly overflow their container, but it's to a lesser degree now.

### Before/after Migration details table:
<img width="420" alt="Screen Shot 2021-06-03 at 1 23 36 PM" src="https://user-images.githubusercontent.com/5942899/120690104-cb3cb000-c472-11eb-8236-b136b67f737e.png">

<img width="420" alt="Screen Shot 2021-06-03 at 1 23 16 PM" src="https://user-images.githubusercontent.com/5942899/120690101-cb3cb000-c472-11eb-9b38-99dd76a74a60.png">


### Before/after Providers table:
<img width="420" alt="Screen Shot 2021-06-02 at 2 34 43 PM" src="https://user-images.githubusercontent.com/5942899/120690283-0212c600-c473-11eb-89b3-d7073df8f8fd.png">

<img width="420" alt="Screen Shot 2021-06-09 at 11 50 18 AM" src="https://user-images.githubusercontent.com/5942899/121388090-2bbb6980-c919-11eb-953c-c4590e73082c.png">


Steps toward resolving https://github.com/konveyor/forklift-ui/issues/168 and https://github.com/konveyor/forklift-ui/issues/217