### PR TITLE
feat(Mappings): consolidate storage/network mappings pages

### DIFF
--- a/src/app/Mappings/Mappings.test.tsx
+++ b/src/app/Mappings/Mappings.test.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Mappings from '@app/Mappings/Mappings';
+import { MappingType } from '@app/queries/types';
+
+describe('Mappings', () => {
+  const noop = jest.fn();
+  test('renders mappings component initially in loading state', async () => {
+    render(
+      <Mappings
+        openEditMappingModal={noop}
+        toggleModalAndResetEdit={noop}
+        mappingType={'Network' as MappingType}
+      />
+    );
+
+    const result = await screen.getByText('Loading...');
+  });
+});

--- a/src/app/Mappings/Mappings.tsx
+++ b/src/app/Mappings/Mappings.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import {
+  Title,
+  EmptyState,
+  Card,
+  CardBody,
+  EmptyStateIcon,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { Mapping, MappingType } from '@app/queries/types';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import MappingsTable from './components/MappingsTable';
+import {
+  filterSharedMappings,
+  useClusterProvidersQuery,
+  useHasSufficientProvidersQuery,
+  useMappingsQuery,
+} from '@app/queries';
+import CreateMappingButton from './components/CreateMappingButton';
+import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
+
+interface IMappingsProps {
+  mappingType: MappingType;
+  toggleModalAndResetEdit: () => void;
+  openEditMappingModal: (mapping: Mapping) => void;
+}
+
+const Mappings: React.FunctionComponent<IMappingsProps> = ({
+  mappingType,
+  toggleModalAndResetEdit,
+  openEditMappingModal,
+}: IMappingsProps) => {
+  const sufficientProvidersQuery = useHasSufficientProvidersQuery();
+  const clusterProvidersQuery = useClusterProvidersQuery();
+  const mappingsQuery = useMappingsQuery(mappingType);
+  const filteredMappings = filterSharedMappings(mappingsQuery.data?.items);
+
+  return (
+    <ResolvedQueries
+      results={[sufficientProvidersQuery.result, clusterProvidersQuery, mappingsQuery]}
+      errorTitles={[
+        'Error loading provider inventory data',
+        'Error loading providers from cluster',
+        'Error loading mappings',
+      ]}
+      errorsInline={false}
+    >
+      <Card>
+        <CardBody>
+          {!filteredMappings ? null : filteredMappings.length === 0 ? (
+            <EmptyState className={spacing.my_2xl}>
+              <EmptyStateIcon icon={PlusCircleIcon} />
+              <Title headingLevel="h2" size="lg">
+                No {mappingType.toLowerCase()} mappings
+              </Title>
+              <EmptyStateBody>
+                {mappingType === MappingType.Network
+                  ? 'Map source provider networks to target provider networks.'
+                  : 'Map source provider datastores to target provider storage classes.'}
+              </EmptyStateBody>
+              <CreateMappingButton onClick={toggleModalAndResetEdit} />
+            </EmptyState>
+          ) : (
+            <MappingsTable
+              mappings={filteredMappings || []}
+              mappingType={mappingType}
+              openEditMappingModal={openEditMappingModal}
+            />
+          )}
+        </CardBody>
+      </Card>
+    </ResolvedQueries>
+  );
+};
+export default Mappings;

--- a/src/app/Mappings/MappingsPage.test.tsx
+++ b/src/app/Mappings/MappingsPage.test.tsx
@@ -6,18 +6,22 @@ import { MappingsPage } from '@app/Mappings/MappingsPage';
 describe('MappingsPage', () => {
   test('renders mappings page without errors', async () => {
     render(<MappingsPage />);
-    const defaultTab = await screen.getByText('Network Mappings');
-    screen.getByRole('button', {
-      name: /Create mapping/i,
-    });
+    const heading = await screen.getByText('Mappings');
+    expect(heading).toBeDefined();
 
-    expect(defaultTab).toBeDefined();
+    screen.getByRole('button', {
+      name: /Create network mapping/i,
+    });
 
     const storageTabBtn = screen.getByRole('button', {
       name: /Storage/i,
     });
     storageTabBtn.click();
-    const newlySelectedTab = await screen.getByText('Storage Mappings');
-    expect(newlySelectedTab).toBeDefined();
+
+    const createMappingBtn = screen.getByRole('button', {
+      name: /Create storage mapping/i,
+    });
+
+    expect(createMappingBtn).toBeDefined();
   });
 });

--- a/src/app/Mappings/MappingsPage.test.tsx
+++ b/src/app/Mappings/MappingsPage.test.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { MappingsPage } from '@app/Mappings/MappingsPage';
+
+describe('MappingsPage', () => {
+  test('renders mappings page without errors', async () => {
+    render(<MappingsPage />);
+    const defaultTab = await screen.getByText('Network Mappings');
+    screen.getByRole('button', {
+      name: /Create mapping/i,
+    });
+
+    expect(defaultTab).toBeDefined();
+
+    const storageTabBtn = screen.getByRole('button', {
+      name: /Storage/i,
+    });
+    storageTabBtn.click();
+    const newlySelectedTab = await screen.getByText('Storage Mappings');
+    expect(newlySelectedTab).toBeDefined();
+  });
+});

--- a/src/app/Mappings/MappingsPage.tsx
+++ b/src/app/Mappings/MappingsPage.tsx
@@ -46,10 +46,11 @@ const MappingsPage: React.FunctionComponent = () => {
       <PageSection variant="light" className={spacing.pb_0}>
         <Level>
           <LevelItem>
-            <Title headingLevel="h1">{activeMapType} Mappings</Title>
+            <Title headingLevel="h1">Mappings</Title>
           </LevelItem>
           <LevelItem>
             <CreateMappingButton
+              aria-label={`Create ${activeMapType} mapping`}
               variant="secondary"
               label="Create mapping"
               onClick={toggleModalAndResetEdit}

--- a/src/app/Mappings/MappingsPage.tsx
+++ b/src/app/Mappings/MappingsPage.tsx
@@ -2,38 +2,31 @@ import * as React from 'react';
 import {
   PageSection,
   Title,
-  EmptyState,
-  Card,
-  CardBody,
-  EmptyStateIcon,
-  EmptyStateBody,
+  Level,
+  LevelItem,
+  Tabs,
+  Tab,
+  TabTitleText,
 } from '@patternfly/react-core';
-import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { Mapping, MappingType } from '@app/queries/types';
-import { PlusCircleIcon } from '@patternfly/react-icons';
-import MappingsTable from './components/MappingsTable';
-import AddEditMappingModal from './components/AddEditMappingModal';
-import {
-  filterSharedMappings,
-  useClusterProvidersQuery,
-  useHasSufficientProvidersQuery,
-  useMappingsQuery,
-} from '@app/queries';
-import CreateMappingButton from './components/CreateMappingButton';
-import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
+import CreateMappingButton from '@app/Mappings/components/CreateMappingButton';
+import AddEditMappingModal from '@app/Mappings/components/AddEditMappingModal';
+import Mappings from '@app/Mappings/Mappings';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
-interface IMappingsPageProps {
-  mappingType: MappingType;
-}
+const MappingsPage: React.FunctionComponent = () => {
+  enum MapType {
+    'Network',
+    'Storage',
+  }
 
-const MappingsPage: React.FunctionComponent<IMappingsPageProps> = ({
-  mappingType,
-}: IMappingsPageProps) => {
-  const sufficientProvidersQuery = useHasSufficientProvidersQuery();
-  const clusterProvidersQuery = useClusterProvidersQuery();
-  const mappingsQuery = useMappingsQuery(mappingType);
+  const [activeTabKey, setActiveTabKey] = React.useState<React.ReactText>(0);
+  const [activeMapType, setActiveMapType] = React.useState('Network');
 
-  const filteredMappings = filterSharedMappings(mappingsQuery.data?.items);
+  const handleTabSelect = (event: React.MouseEvent, tabIndex: React.ReactText) => {
+    setActiveTabKey(tabIndex);
+    setActiveMapType(MapType[tabIndex]);
+  };
 
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
   const [mappingBeingEdited, setMappingBeingEdited] = React.useState<Mapping | null>(null);
@@ -50,55 +43,46 @@ const MappingsPage: React.FunctionComponent<IMappingsPageProps> = ({
 
   return (
     <>
-      <PageSection variant="light">
-        <Title headingLevel="h1">{mappingType} mappings</Title>
+      <PageSection variant="light" className={spacing.pb_0}>
+        <Level>
+          <LevelItem>
+            <Title headingLevel="h1">{activeMapType} Mappings</Title>
+          </LevelItem>
+          <LevelItem>
+            <CreateMappingButton
+              variant="secondary"
+              label="Create mapping"
+              onClick={toggleModalAndResetEdit}
+            />
+          </LevelItem>
+        </Level>
+
+        <Tabs className={spacing.mtSm} activeKey={activeTabKey} onSelect={handleTabSelect}>
+          <Tab eventKey={0} title={<TabTitleText>Network</TabTitleText>} />
+          <Tab eventKey={1} title={<TabTitleText>Storage</TabTitleText>} />
+        </Tabs>
       </PageSection>
+
       <PageSection>
-        <ResolvedQueries
-          results={[sufficientProvidersQuery.result, clusterProvidersQuery, mappingsQuery]}
-          errorTitles={[
-            'Error loading provider inventory data',
-            'Error loading providers from cluster',
-            'Error loading mappings',
-          ]}
-          errorsInline={false}
-        >
-          <Card>
-            <CardBody>
-              {!filteredMappings ? null : filteredMappings.length === 0 ? (
-                <EmptyState className={spacing.my_2xl}>
-                  <EmptyStateIcon icon={PlusCircleIcon} />
-                  <Title headingLevel="h2" size="lg">
-                    No {mappingType.toLowerCase()} mappings
-                  </Title>
-                  <EmptyStateBody>
-                    {mappingType === MappingType.Network
-                      ? 'Map source provider networks to target provider networks.'
-                      : 'Map source provider datastores to target provider storage classes.'}
-                  </EmptyStateBody>
-                  <CreateMappingButton onClick={toggleModalAndResetEdit} />
-                </EmptyState>
-              ) : (
-                <MappingsTable
-                  mappings={filteredMappings || []}
-                  mappingType={mappingType}
-                  openCreateMappingModal={toggleModalAndResetEdit}
-                  openEditMappingModal={openEditMappingModal}
-                />
-              )}
-            </CardBody>
-          </Card>
-        </ResolvedQueries>
+        <Mappings
+          mappingType={MappingType[activeMapType]}
+          key={activeMapType.toLowerCase()}
+          toggleModalAndResetEdit={toggleModalAndResetEdit}
+          openEditMappingModal={openEditMappingModal}
+        />
       </PageSection>
+
       {isAddEditModalOpen ? (
         <AddEditMappingModal
-          title={`${!mappingBeingEdited ? 'Create' : 'Edit'} ${mappingType.toLowerCase()} mapping`}
+          title={`${
+            !mappingBeingEdited ? 'Create' : 'Edit'
+          } ${activeMapType.toLowerCase()} mapping`}
           onClose={toggleModalAndResetEdit}
-          mappingType={mappingType}
+          mappingType={MappingType[activeMapType]}
           mappingBeingEdited={mappingBeingEdited}
         />
       ) : null}
     </>
   );
 };
-export default MappingsPage;
+export { MappingsPage };

--- a/src/app/Mappings/NetworkMappingsPage.tsx
+++ b/src/app/Mappings/NetworkMappingsPage.tsx
@@ -1,9 +1,0 @@
-import * as React from 'react';
-import { MappingType } from '@app/queries/types';
-import MappingsPage from './MappingsPage';
-
-const NetworkMappingsPage: React.FunctionComponent = () => (
-  <MappingsPage mappingType={MappingType.Network} key="network" />
-);
-
-export default NetworkMappingsPage;

--- a/src/app/Mappings/StorageMappingsPage.tsx
+++ b/src/app/Mappings/StorageMappingsPage.tsx
@@ -1,9 +1,0 @@
-import * as React from 'react';
-import { MappingType } from '@app/queries/types';
-import MappingsPage from './MappingsPage';
-
-const StorageMappingsPage: React.FunctionComponent = () => (
-  <MappingsPage mappingType={MappingType.Storage} key="storage" />
-);
-
-export default StorageMappingsPage;

--- a/src/app/Mappings/components/CreateMappingButton.tsx
+++ b/src/app/Mappings/components/CreateMappingButton.tsx
@@ -13,6 +13,7 @@ const CreateMappingButton: React.FunctionComponent<ICreateMappingButtonProps> = 
   onClick,
   variant = 'primary',
   label = 'Create mapping',
+  ...props
 }: ICreateMappingButtonProps) => {
   const sufficientProvidersQuery = useHasSufficientProvidersQuery();
   const { hasSufficientProviders } = sufficientProvidersQuery;
@@ -22,7 +23,7 @@ const CreateMappingButton: React.FunctionComponent<ICreateMappingButtonProps> = 
       content="You must add at least one VMware provider and one OpenShift Virtualization provider in order to create a mapping."
     >
       <div>
-        <Button onClick={onClick} isDisabled={!hasSufficientProviders} variant={variant}>
+        <Button {...props} onClick={onClick} isDisabled={!hasSufficientProviders} variant={variant}>
           {label}
         </Button>
       </div>

--- a/src/app/Mappings/components/CreateMappingButton.tsx
+++ b/src/app/Mappings/components/CreateMappingButton.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Button, ButtonProps } from '@patternfly/react-core';
-import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import ConditionalTooltip from '@app/common/components/ConditionalTooltip';
 import { useHasSufficientProvidersQuery } from '@app/queries';
 
@@ -22,7 +21,7 @@ const CreateMappingButton: React.FunctionComponent<ICreateMappingButtonProps> = 
       isTooltipEnabled={!hasSufficientProviders}
       content="You must add at least one VMware provider and one OpenShift Virtualization provider in order to create a mapping."
     >
-      <div className={`${spacing.mtMd}`}>
+      <div>
         <Button onClick={onClick} isDisabled={!hasSufficientProviders} variant={variant}>
           {label}
         </Button>

--- a/src/app/Mappings/components/MappingsTable.tsx
+++ b/src/app/Mappings/components/MappingsTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Level, LevelItem, Pagination, Form } from '@patternfly/react-core';
+import { Pagination, Form } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import {
   Table,
@@ -17,21 +17,18 @@ import { useSortState, usePaginationState } from '@app/common/hooks';
 import { IMetaObjectMeta, Mapping, MappingType } from '@app/queries/types';
 import MappingsActionsDropdown from './MappingsActionsDropdown';
 import MappingDetailView from './MappingDetailView';
-import CreateMappingButton from './CreateMappingButton';
 import MappingStatus from './MappingStatus';
 import { isSameResource } from '@app/queries/helpers';
 
 interface IMappingsTableProps {
   mappings: Mapping[];
   mappingType: MappingType;
-  openCreateMappingModal: () => void;
   openEditMappingModal: (mapping: Mapping) => void;
 }
 
 const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
   mappings,
   mappingType,
-  openCreateMappingModal,
   openEditMappingModal,
 }: IMappingsTableProps) => {
   const getSortValues = (mapping: Mapping) => {
@@ -121,18 +118,7 @@ const MappingsTable: React.FunctionComponent<IMappingsTableProps> = ({
 
   return (
     <>
-      <Level>
-        <LevelItem>
-          <CreateMappingButton
-            variant="secondary"
-            label="Create mapping"
-            onClick={openCreateMappingModal}
-          />
-        </LevelItem>
-        <LevelItem>
-          <Pagination {...paginationProps} widgetId="mappings-table-pagination-top" />
-        </LevelItem>
-      </Level>
+      <Pagination {...paginationProps} widgetId="mappings-table-pagination-top" />
       <Table
         aria-label="Mappings table"
         cells={columns}

--- a/src/app/NotFound.tsx
+++ b/src/app/NotFound.tsx
@@ -1,13 +1,6 @@
 import * as React from 'react';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import {
-  PageSection,
-  Title,
-  Button,
-  EmptyState,
-  EmptyStateIcon,
-  EmptyStateBody,
-} from '@patternfly/react-core';
+import { PageSection, Title, Button, EmptyState, EmptyStateIcon } from '@patternfly/react-core';
 import { useHistory } from 'react-router-dom';
 
 const NotFound: React.FunctionComponent = () => {

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -8,8 +8,7 @@ import { APP_TITLE } from '@app/common/constants';
 import WelcomePage from '@app/Welcome/WelcomePage';
 import ProvidersPage from '@app/Providers/ProvidersPage';
 import PlansPage from '@app/Plans/PlansPage';
-import NetworkMappingsPage from '@app/Mappings/NetworkMappingsPage';
-import StorageMappingsPage from '@app/Mappings/StorageMappingsPage';
+import { MappingsPage } from '@app/Mappings/MappingsPage';
 import { HostsPage } from './Providers/HostsPage';
 import PlanWizard from '@app/Plans/components/Wizard/PlanWizard';
 import VMMigrationDetails from '@app/Plans/components/VMMigrationDetails';
@@ -110,25 +109,12 @@ export const routes: AppRouteConfig[] = [
     isProtected: true,
   },
   {
+    component: MappingsPage,
+    exact: true,
     label: 'Mappings',
-    routes: [
-      {
-        component: NetworkMappingsPage,
-        exact: true,
-        label: 'Network',
-        path: '/mappings/network',
-        title: `${APP_TITLE} | Network Mappings`,
-        isProtected: true,
-      },
-      {
-        component: StorageMappingsPage,
-        exact: true,
-        label: 'Storage',
-        path: '/mappings/storage',
-        title: `${APP_TITLE} | Storage Mappings`,
-        isProtected: true,
-      },
-    ],
+    path: '/mappings',
+    title: `${APP_TITLE} | Network and Storage Mappings`,
+    isProtected: true,
   },
 ];
 

--- a/src/app/utils/useDocumentTitle.ts
+++ b/src/app/utils/useDocumentTitle.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 // a custom hook for setting the page title
-export function useDocumentTitle(title: string) {
+export function useDocumentTitle(title: string): void {
   React.useEffect(() => {
     const originalTitle = document.title;
     document.title = title;


### PR DESCRIPTION
This PR updates the primary nav to go from two sub-menus for the different types of mappings to a single "Mappings" view with tabs for the mapping type options, modeled after the Providers page layout. There shouldn't be any functional changes, but please do test this out as I'm new to the project 😅 

<img width="1000" alt="Screen Shot 2021-06-04 at 10 19 30 AM" src="https://user-images.githubusercontent.com/5942899/120816482-c6cdd100-c51e-11eb-9e11-65d98df9cfab.png">

Should help close https://github.com/konveyor/forklift-ui/issues/112

[issue-112] marry network/storagem mapping pages