### PR TITLE
fix(toolbar): improve toolbar items layout

### DIFF
--- a/src/app/Plans/components/CreatePlanButton.tsx
+++ b/src/app/Plans/components/CreatePlanButton.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Button, ButtonProps } from '@patternfly/react-core';
-import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import ConditionalTooltip from '@app/common/components/ConditionalTooltip';
 import { useHasSufficientProvidersQuery } from '@app/queries';
 import { useHistory } from 'react-router-dom';
@@ -20,16 +19,15 @@ const CreatePlanButton: React.FunctionComponent<ICreatePlanButtonProps> = ({
       isTooltipEnabled={!hasSufficientProviders}
       content="You must add at least one VMware provider and one OpenShift Virtualization provider in order to create a migration plan."
     >
-      <div className={`${spacing.mtMd}`}>
-        <Button
-          onClick={() => history.push('/plans/create')}
-          isDisabled={!hasSufficientProviders}
-          variant={variant}
-          id="create-plan-button"
-        >
-          Create plan
-        </Button>
-      </div>
+      <Button
+        isSmall
+        onClick={() => history.push('/plans/create')}
+        isDisabled={!hasSufficientProviders}
+        variant={variant}
+        id="create-plan-button"
+      >
+        Create plan
+      </Button>
     </ConditionalTooltip>
   );
 };

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import {
   Flex,
   FlexItem,
-  Level,
-  LevelItem,
+  Split,
+  SplitItem,
   Pagination,
   Progress,
   ProgressMeasureLocation,
@@ -36,7 +36,7 @@ import PlanActionsDropdown from './PlanActionsDropdown';
 import { useSortState, usePaginationState } from '@app/common/hooks';
 import { IPlan } from '@app/queries/types';
 import { PlanStatusDisplayType, PlanStatusType } from '@app/common/constants';
-import CreatePlanButton from './CreatePlanButton';
+import CreatePlanButton from '@app/Plans/components/CreatePlanButton';
 import { FilterToolbar, FilterType, FilterCategory } from '@app/common/components/FilterToolbar';
 import { useFilterState } from '@app/common/hooks/useFilterState';
 import { hasCondition } from '@app/common/helpers';
@@ -361,28 +361,23 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
 
   return (
     <>
-      <Level>
-        <LevelItem>
-          <Flex>
-            <FlexItem
-              alignSelf={{ default: 'alignSelfFlexStart' }}
-              spacer={{ default: 'spacerNone' }}
-            >
-              <FilterToolbar<IPlan>
-                filterCategories={filterCategories}
-                filterValues={filterValues}
-                setFilterValues={setFilterValues}
-              />
-            </FlexItem>
-            <FlexItem>
-              <CreatePlanButton variant="secondary" />
-            </FlexItem>
-          </Flex>
-        </LevelItem>
-        <LevelItem>
-          <Pagination {...paginationProps} widgetId="plans-table-pagination-top" />
-        </LevelItem>
-      </Level>
+      <Split>
+        <SplitItem isFilled>
+          <FilterToolbar<IPlan>
+            filterCategories={filterCategories}
+            filterValues={filterValues}
+            setFilterValues={setFilterValues}
+            toolbarItems={<CreatePlanButton variant="secondary" />}
+          />
+        </SplitItem>
+        <SplitItem>
+          <Pagination
+            className={spacing.mtMd}
+            {...paginationProps}
+            widgetId="plans-table-pagination-top"
+          />
+        </SplitItem>
+      </Split>
       {filteredItems.length > 0 ? (
         <Table
           aria-label="Migration Plans table"

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -8,13 +8,11 @@ import {
   Pagination,
   PageSection,
   Title,
-  Level,
-  LevelItem,
+  Split,
+  SplitItem,
   Button,
-  Flex,
   List,
   ListItem,
-  FlexItem,
 } from '@patternfly/react-core';
 import {
   Table,
@@ -344,17 +342,13 @@ const VMMigrationDetails: React.FunctionComponent = () => {
         >
           <Card>
             <CardBody>
-              <Level>
-                <LevelItem>
-                  <Flex>
-                    <FlexItem spacer={{ default: 'spacerNone' }}>
-                      <FilterToolbar<IVMStatus>
-                        filterCategories={filterCategories}
-                        filterValues={filterValues}
-                        setFilterValues={setFilterValues}
-                      />
-                    </FlexItem>
-                    <FlexItem>
+              <Split>
+                <SplitItem isFilled>
+                  <FilterToolbar<IVMStatus>
+                    filterCategories={filterCategories}
+                    filterValues={filterValues}
+                    setFilterValues={setFilterValues}
+                    toolbarItems={
                       <Button
                         variant="secondary"
                         isDisabled={selectedItems.length === 0 || cancelVMsResult.isLoading}
@@ -362,13 +356,17 @@ const VMMigrationDetails: React.FunctionComponent = () => {
                       >
                         Cancel
                       </Button>
-                    </FlexItem>
-                  </Flex>
-                </LevelItem>
-                <LevelItem>
-                  <Pagination {...paginationProps} widgetId="migration-vms-table-pagination-top" />
-                </LevelItem>
-              </Level>
+                    }
+                  />
+                </SplitItem>
+                <SplitItem>
+                  <Pagination
+                    className={spacing.mtMd}
+                    {...paginationProps}
+                    widgetId="migration-vms-table-pagination-top"
+                  />
+                </SplitItem>
+              </Split>
               {filteredItems.length > 0 ? (
                 <Table
                   className="migration-details-table"

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Pagination, TextContent, Text, Level, LevelItem } from '@patternfly/react-core';
+import {
+  Pagination,
+  TextContent,
+  Text,
+  Level,
+  LevelItem,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import {
   Table,
@@ -313,18 +321,22 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
               analytics service.
             </Text>
           </TextContent>
-          <Level>
-            <LevelItem>
+          <Split>
+            <SplitItem isFilled>
               <FilterToolbar<SourceVM>
                 filterCategories={filterCategories}
                 filterValues={filterValues}
                 setFilterValues={setFilterValues}
               />
-            </LevelItem>
-            <LevelItem>
-              <Pagination {...paginationProps} widgetId="vms-table-pagination-top" />
-            </LevelItem>
-          </Level>
+            </SplitItem>
+            <SplitItem>
+              <Pagination
+                className={spacing.mtMd}
+                {...paginationProps}
+                widgetId="vms-table-pagination-top"
+              />
+            </SplitItem>
+          </Split>
           {filteredItems.length > 0 ? (
             <Table
               aria-label="VMware VMs table"

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -5,6 +5,7 @@ import {
   ToolbarContent,
   ToolbarToggleGroup,
   ToolbarItem,
+  ToolbarGroup,
   Dropdown,
   DropdownToggle,
   DropdownItem,
@@ -49,12 +50,14 @@ export interface IFilterToolbarProps<T> {
   filterCategories: FilterCategory<T>[];
   filterValues: IFilterValues;
   setFilterValues: (values: IFilterValues) => void;
+  toolbarItems?: JSX.Element;
 }
 
 export const FilterToolbar = <T,>({
   filterCategories,
   filterValues,
   setFilterValues,
+  toolbarItems,
 }: React.PropsWithChildren<IFilterToolbarProps<T>>): JSX.Element | null => {
   const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = React.useState(false);
   const [currentCategoryKey, setCurrentCategoryKey] = React.useState(filterCategories[0].key);
@@ -74,7 +77,7 @@ export const FilterToolbar = <T,>({
   return (
     <Toolbar id="pv-table-filter-toolbar" clearAllFilters={() => setFilterValues({})}>
       <ToolbarContent>
-        <ToolbarToggleGroup variant="filter-group" toggleIcon={<FilterIcon />} breakpoint="xl">
+        <ToolbarToggleGroup variant="filter-group" toggleIcon={<FilterIcon />} breakpoint="2xl">
           <ToolbarItem>
             <Dropdown
               toggle={
@@ -90,6 +93,7 @@ export const FilterToolbar = <T,>({
               ))}
             />
           </ToolbarItem>
+
           {filterCategories.map((category) => (
             <FilterControl<T>
               key={category.key}
@@ -100,6 +104,12 @@ export const FilterToolbar = <T,>({
             />
           ))}
         </ToolbarToggleGroup>
+
+        {toolbarItems && (
+          <ToolbarGroup>
+            <ToolbarItem>{toolbarItems}</ToolbarItem>
+          </ToolbarGroup>
+        )}
       </ToolbarContent>
     </Toolbar>
   );

--- a/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
+++ b/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
@@ -63,6 +63,7 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
         <div>
           {erroredResults.map((result, index) => (
             <Alert
+              isLiveRegion
               key={`error-${index}`}
               variant="danger"
               isInline={errorsInline}


### PR DESCRIPTION
This PR swaps Level layout for Split in the filter toolbar area for the toolbars in PlansTable, VMMigrationDetails, and SelectVMsForm.

Best way to test is check at various sceen widths the migration plans view, a migration detail view, and the select VM step in plan creation flow, they all received a same treatment.

I also fixed a small issue where an Alert wasn't being announced to screen reader users.

Should help close https://github.com/konveyor/forklift-ui/issues/218

<img width="420" alt="Screen Shot 2021-06-09 at 3 25 04 PM" src="https://user-images.githubusercontent.com/5942899/121416684-135a4780-c937-11eb-8274-74eda429300e.png">

<img width="420" alt="Screen Shot 2021-06-09 at 3 25 49 PM" src="https://user-images.githubusercontent.com/5942899/121416715-1e14dc80-c937-11eb-86a5-9b0a4ad08f9c.png">

