### PR TITLE
Temporarily disable codecov while it is broken

### DIFF
--- a/.github/workflows/tests-ci.yaml
+++ b/.github/workflows/tests-ci.yaml
@@ -21,9 +21,3 @@ jobs:
         run: npm install
       - name: Run tests
         run: npm run ci
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          fail_ci_if_error: true
-          path_to_write_report: ./coverage/codecov_report.txt
-          verbose: true

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm run lint # or lint:fix to automatically fix certain issues
 npm run test # or test:watch to auto-rerun tests on file changes
 ```
 
-Note: the `npm run test` script will create a coverage report at `coverage/lcov-report/index.html`. This is useful to inspect locally before opening a PR. Open PRs will also report their coverage to Codecov and a report will be posted in the PR.
+Note: the `npm run test` script will create a coverage report at `coverage/lcov-report/index.html`. This is useful to inspect locally before opening a PR.
 
 [Prettier](https://prettier.io/) code formatting is enforced by ESLint. To run Prettier and format your code (do this before committing if you don't run Prettier in your editor):
 


### PR DESCRIPTION
There's a problem with our Codecov configuration that is blocking PRs from being merged. This PR disables that part of the CI workflow so we can unblock other PRs, we can revisit codecov later.