### PR TITLE
chore(mappings): allow for specifying mapping type during mapping creation flow

### DIFF
--- a/src/app/Mappings/MappingsPage.tsx
+++ b/src/app/Mappings/MappingsPage.tsx
@@ -8,18 +8,13 @@ import {
   Tab,
   TabTitleText,
 } from '@patternfly/react-core';
-import { Mapping, MappingType } from '@app/queries/types';
+import { Mapping, MappingType, MapType } from '@app/queries/types';
 import CreateMappingButton from '@app/Mappings/components/CreateMappingButton';
 import AddEditMappingModal from '@app/Mappings/components/AddEditMappingModal';
 import Mappings from '@app/Mappings/Mappings';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 const MappingsPage: React.FunctionComponent = () => {
-  enum MapType {
-    'Network',
-    'Storage',
-  }
-
   const [activeTabKey, setActiveTabKey] = React.useState<React.ReactText>(0);
   const [activeMapType, setActiveMapType] = React.useState('Network');
 
@@ -75,12 +70,12 @@ const MappingsPage: React.FunctionComponent = () => {
 
       {isAddEditModalOpen ? (
         <AddEditMappingModal
-          title={`${
-            !mappingBeingEdited ? 'Create' : 'Edit'
-          } ${activeMapType.toLowerCase()} mapping`}
+          title={`${!mappingBeingEdited ? 'Create' : 'Edit'} mapping`}
           onClose={toggleModalAndResetEdit}
           mappingType={MappingType[activeMapType]}
           mappingBeingEdited={mappingBeingEdited}
+          setActiveTabKey={setActiveTabKey}
+          setActiveMapType={setActiveMapType}
         />
       ) : null}
     </>

--- a/src/app/Mappings/MappingsPage.tsx
+++ b/src/app/Mappings/MappingsPage.tsx
@@ -8,19 +8,18 @@ import {
   Tab,
   TabTitleText,
 } from '@patternfly/react-core';
-import { Mapping, MappingType, MapType } from '@app/queries/types';
+import { Mapping, MappingType } from '@app/queries/types';
 import CreateMappingButton from '@app/Mappings/components/CreateMappingButton';
 import AddEditMappingModal from '@app/Mappings/components/AddEditMappingModal';
 import Mappings from '@app/Mappings/Mappings';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 const MappingsPage: React.FunctionComponent = () => {
-  const [activeTabKey, setActiveTabKey] = React.useState<React.ReactText>(0);
-  const [activeMapType, setActiveMapType] = React.useState('Network');
+  const defaultMappingType = MappingType.Network;
+  const [activeMapType, setActiveMapType] = React.useState(defaultMappingType);
 
   const handleTabSelect = (event: React.MouseEvent, tabIndex: React.ReactText) => {
-    setActiveTabKey(tabIndex);
-    setActiveMapType(MapType[tabIndex]);
+    setActiveMapType(MappingType[tabIndex]);
   };
 
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
@@ -53,9 +52,9 @@ const MappingsPage: React.FunctionComponent = () => {
           </LevelItem>
         </Level>
 
-        <Tabs className={spacing.mtSm} activeKey={activeTabKey} onSelect={handleTabSelect}>
-          <Tab eventKey={0} title={<TabTitleText>Network</TabTitleText>} />
-          <Tab eventKey={1} title={<TabTitleText>Storage</TabTitleText>} />
+        <Tabs className={spacing.mtSm} activeKey={activeMapType} onSelect={handleTabSelect}>
+          <Tab eventKey={MappingType.Network} title={<TabTitleText>Network</TabTitleText>} />
+          <Tab eventKey={MappingType.Storage} title={<TabTitleText>Storage</TabTitleText>} />
         </Tabs>
       </PageSection>
 
@@ -74,7 +73,6 @@ const MappingsPage: React.FunctionComponent = () => {
           onClose={toggleModalAndResetEdit}
           mappingType={MappingType[activeMapType]}
           mappingBeingEdited={mappingBeingEdited}
-          setActiveTabKey={setActiveTabKey}
           setActiveMapType={setActiveMapType}
         />
       ) : null}

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -1,12 +1,27 @@
 import * as React from 'react';
 import * as yup from 'yup';
-import { Modal, Button, Form, Grid, GridItem, Stack, Flex } from '@patternfly/react-core';
+import {
+  Modal,
+  Button,
+  Form,
+  Grid,
+  GridItem,
+  Stack,
+  Flex,
+  FormGroup,
+} from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useFormField, useFormState, ValidatedTextInput } from '@konveyor/lib-ui';
-
+import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
 import { MappingBuilder, IMappingBuilderItem, mappingBuilderItemsSchema } from './MappingBuilder';
 import { getMappingFromBuilderItems } from './MappingBuilder/helpers';
-import { MappingType, IOpenShiftProvider, IVMwareProvider, Mapping } from '@app/queries/types';
+import {
+  MappingType,
+  MapType,
+  IOpenShiftProvider,
+  IVMwareProvider,
+  Mapping,
+} from '@app/queries/types';
 import {
   useInventoryProvidersQuery,
   useMappingResourceQueries,
@@ -37,6 +52,8 @@ interface IAddEditMappingModalProps {
   onClose: () => void;
   mappingType: MappingType;
   mappingBeingEdited: Mapping | null;
+  setActiveTabKey: React.Dispatch<React.SetStateAction<React.ReactText>>;
+  setActiveMapType: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const useMappingFormState = (
@@ -69,6 +86,8 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
   onClose,
   mappingType,
   mappingBeingEdited,
+  setActiveMapType,
+  setActiveTabKey,
 }: IAddEditMappingModalProps) => {
   usePausedPollingEffect();
 
@@ -110,6 +129,11 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
   const [patchMapping, patchMappingResult] = usePatchMappingMutation(mappingType, onClose);
   const mutateMapping = !mappingBeingEdited ? createMapping : patchMapping;
   const mutationResult = !mappingBeingEdited ? createMappingResult : patchMappingResult;
+
+  const MAPPING_TYPE_OPTIONS = Object.values(MappingType).map((type) => ({
+    toString: () => MappingType[type],
+    value: type,
+  })) as OptionWithValue<MappingType>[];
 
   return (
     <Modal
@@ -172,8 +196,26 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
             <LoadingEmptyState />
           ) : (
             <>
-              <Grid className={spacing.mbMd}>
-                <GridItem sm={12} md={5} className={spacing.mbMd}>
+              <Grid hasGutter className={spacing.mbMd}>
+                <GridItem md={6}>
+                  <FormGroup label="Type" isRequired fieldId="mapping-type">
+                    <SimpleSelect
+                      id="mapping-type"
+                      aria-label="Mapping type"
+                      options={MAPPING_TYPE_OPTIONS}
+                      value={[MAPPING_TYPE_OPTIONS.find((option) => option.value === mappingType)]}
+                      onChange={(selection) => {
+                        setActiveMapType(selection.toString());
+                        setActiveTabKey(MapType[selection.toString()]);
+                      }}
+                      placeholderText="Select a mapping type..."
+                      isDisabled={!!mappingBeingEdited}
+                      menuAppendTo="parent"
+                      maxHeight="40vh"
+                    />
+                  </FormGroup>
+                </GridItem>
+                <GridItem md={6} className={spacing.mbMd}>
                   <ValidatedTextInput
                     field={form.fields.name}
                     label="Name"
@@ -184,8 +226,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                     }}
                   />
                 </GridItem>
-                <GridItem />
-                <GridItem sm={12} md={5}>
+                <GridItem md={6}>
                   <ProviderSelect
                     label="Source provider"
                     providerType={ProviderType.vsphere}
@@ -195,8 +236,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                     maxHeight="40vh"
                   />
                 </GridItem>
-                <GridItem sm={1} />
-                <GridItem sm={12} md={5}>
+                <GridItem md={6}>
                   <ProviderSelect
                     label="Target provider"
                     providerType={ProviderType.openshift}
@@ -205,7 +245,6 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                     maxHeight="40vh"
                   />
                 </GridItem>
-                <GridItem sm={1} />
               </Grid>
               {form.values.sourceProvider && form.values.targetProvider ? (
                 <ResolvedQueries

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -15,13 +15,7 @@ import { useFormField, useFormState, ValidatedTextInput } from '@konveyor/lib-ui
 import SimpleSelect, { OptionWithValue } from '@app/common/components/SimpleSelect';
 import { MappingBuilder, IMappingBuilderItem, mappingBuilderItemsSchema } from './MappingBuilder';
 import { getMappingFromBuilderItems } from './MappingBuilder/helpers';
-import {
-  MappingType,
-  MapType,
-  IOpenShiftProvider,
-  IVMwareProvider,
-  Mapping,
-} from '@app/queries/types';
+import { MappingType, IOpenShiftProvider, IVMwareProvider, Mapping } from '@app/queries/types';
 import {
   useInventoryProvidersQuery,
   useMappingResourceQueries,
@@ -52,8 +46,7 @@ interface IAddEditMappingModalProps {
   onClose: () => void;
   mappingType: MappingType;
   mappingBeingEdited: Mapping | null;
-  setActiveTabKey: React.Dispatch<React.SetStateAction<React.ReactText>>;
-  setActiveMapType: React.Dispatch<React.SetStateAction<string>>;
+  setActiveMapType: React.Dispatch<React.SetStateAction<MappingType>>;
 }
 
 const useMappingFormState = (
@@ -87,7 +80,6 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
   mappingType,
   mappingBeingEdited,
   setActiveMapType,
-  setActiveTabKey,
 }: IAddEditMappingModalProps) => {
   usePausedPollingEffect();
 
@@ -205,8 +197,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                       options={MAPPING_TYPE_OPTIONS}
                       value={[MAPPING_TYPE_OPTIONS.find((option) => option.value === mappingType)]}
                       onChange={(selection) => {
-                        setActiveMapType(selection.toString());
-                        setActiveTabKey(MapType[selection.toString()]);
+                        setActiveMapType(MappingType[selection.toString()]);
                       }}
                       placeholderText="Select a mapping type..."
                       isDisabled={!!mappingBeingEdited}

--- a/src/app/queries/types/mappings.types.ts
+++ b/src/app/queries/types/mappings.types.ts
@@ -9,6 +9,11 @@ export enum MappingType {
   Storage = 'Storage',
 }
 
+export enum MapType {
+  'Network',
+  'Storage',
+}
+
 export interface INetworkMappingItem {
   source: {
     id: string;

--- a/src/app/queries/types/mappings.types.ts
+++ b/src/app/queries/types/mappings.types.ts
@@ -9,11 +9,6 @@ export enum MappingType {
   Storage = 'Storage',
 }
 
-export enum MapType {
-  'Network',
-  'Storage',
-}
-
 export interface INetworkMappingItem {
   source: {
     id: string;


### PR DESCRIPTION
This PR adds a dropdown to the mapping creation flow that's pre-selected to whatever resource type is selected in the tabs.

<img width="420" alt="Screen Shot 2021-06-08 at 11 14 42 AM" src="https://user-images.githubusercontent.com/5942899/121211868-d7e24f00-c84a-11eb-82be-c105beeece52.png">
