### PR TITLE
selectvms table adjustments

### DIFF
--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -18,6 +18,7 @@ import {
   ICell,
   IRow,
   wrappable,
+  truncate,
 } from '@patternfly/react-table';
 
 import {
@@ -240,14 +241,15 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   const columns: ICell[] = [
     {
       title: 'Migration assessment',
-      transforms: [sortable, wrappable],
+      transforms: [sortable],
+      cellTransforms: [truncate],
     },
-    { title: 'VM name', transforms: [sortable, wrappable] },
-    { title: 'Datacenter', transforms: [sortable] },
-    { title: 'Cluster', transforms: [sortable] },
-    { title: 'Host', transforms: [sortable] },
+    { title: 'VM name', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'Datacenter', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'Cluster', transforms: [sortable], cellTransforms: [truncate] },
+    { title: 'Host', transforms: [sortable, wrappable], cellTransforms: [truncate] },
     ...(sourceProvider?.type === 'vsphere'
-      ? [{ title: 'Folder path', transforms: [sortable, wrappable] }]
+      ? [{ title: 'Folder path', transforms: [sortable, wrappable], cellTransforms: [truncate] }]
       : []),
   ];
 

--- a/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.css
+++ b/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.css
@@ -1,9 +1,3 @@
-.pf-c-table.provider-inner-hosts-table tbody > tr > td.pf-c-table__check {
-  padding-bottom: var(--pf-c-table--tbody--cell--PaddingBottom);
-  vertical-align: middle;
-}
-
 .pf-c-table.provider-inner-hosts-table tbody > tr > td.pf-c-table__check > input {
-  vertical-align: middle;
-  margin-top: 0;
+  margin-top: 6px;
 }


### PR DESCRIPTION
This PR updates the select vm table to truncate column headers for better space mgmt. Further addresses https://github.com/konveyor/forklift-ui/issues/217. 

<img width="500" alt="Screen Shot 2021-06-09 at 10 20 07 PM" src="https://user-images.githubusercontent.com/5942899/121454831-81bbfb80-c971-11eb-9666-d899f0fcbf8c.png">

Also, I pulled some recently added styles for provider hosts table back out, they seemed necessary before but now was causing issues. I tested in FF and chrome, seems to be find but could use a second set of 👀