### PR TITLE
fix(mappings): remove unnecessary div around create mappings button

### DIFF
--- a/src/app/Mappings/components/CreateMappingButton.tsx
+++ b/src/app/Mappings/components/CreateMappingButton.tsx
@@ -22,11 +22,9 @@ const CreateMappingButton: React.FunctionComponent<ICreateMappingButtonProps> = 
       isTooltipEnabled={!hasSufficientProviders}
       content="You must add at least one VMware or Red Hat Virtualization provider and one OpenShift Virtualization provider in order to create a mapping."
     >
-      <div>
-        <Button {...props} onClick={onClick} isDisabled={!hasSufficientProviders} variant={variant}>
-          {label}
-        </Button>
-      </div>
+      <Button {...props} onClick={onClick} isDisabled={!hasSufficientProviders} variant={variant}>
+        {label}
+      </Button>
     </ConditionalTooltip>
   );
 };


### PR DESCRIPTION
This PR fixes a spacing issue for the empty state of the mappings page. By removing the unnecessary div, PatternFly styles seem to do the expected thing without any modification. Should help close https://github.com/konveyor/forklift-ui/issues/641

<img width="873" alt="Screen Shot 2021-06-11 at 8 28 23 AM" src="https://user-images.githubusercontent.com/5942899/121688565-998aa100-ca91-11eb-8622-dd023c609386.png">
