### PR TITLE
Fix post/pre hook type depending on migration type

### DIFF
--- a/src/app/Plans/components/PlanDetails.tsx
+++ b/src/app/Plans/components/PlanDetails.tsx
@@ -54,6 +54,8 @@ const PlanDetails: React.FunctionComponent<IPlanDetailsProps> = ({
     ? warmCriticalConcerns.filter((label) => someVMHasConcern(vms as SourceVM[], label))
     : [];
 
+  const hookStepPostfix = plan.spec.warm ? 'cutover' : 'migration';
+
   return (
     <Grid hasGutter className={`${spacing.mtSm} ${spacing.mbMd}`}>
       <GridItem md={12}></GridItem>
@@ -197,7 +199,9 @@ const PlanDetails: React.FunctionComponent<IPlanDetailsProps> = ({
                 <Text className={text.fontWeightBold}>Migration step</Text>
                 {hooksDetails.map((hookDetail) => (
                   <Text key={hookDetail.step}>
-                    {hookDetail.step === 'PreHook' ? 'Pre-migration' : 'Post-migration'}
+                    {hookDetail.step === 'PreHook'
+                      ? `Pre-${hookStepPostfix}`
+                      : `Post-${hookStepPostfix}`}
                   </Text>
                 ))}
               </GridItem>


### PR DESCRIPTION
PlansDetails to display "Pre-cutover" or "Post-cutover" respectively when in warm migration and "Pre-migration", "Post-migration" for a cold migration

![Screenshot from 2021-06-11 17-27-08](https://user-images.githubusercontent.com/1901741/121710955-5f91bd00-cada-11eb-843a-b869c06632ea.png)

![Screenshot from 2021-06-11 17-27-31](https://user-images.githubusercontent.com/1901741/121710941-5d2f6300-cada-11eb-875f-c08b2689101a.png)
