### PR TITLE
Filter VMs tree view: exclude hosts, be explicit about which kinds of nodes are selectable, properly exclude deselected child folders

### DIFF
--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -31,10 +31,7 @@ interface IFilterVMsFormProps {
   planBeingEdited: IPlan | null;
 }
 
-// TODO switch to new cluster tree, update mock data, test against Jeff's cluster
-// TODO figure out if it makes sense to change Select VMs list so it comes from filtering on VM properties matching selected tree nodes
-//      instead of using the leaf nodes. otherwise, see if it makes sense to limit to only the direct child leaves.
-
+// TODO figure out why Templates folder VMs are coming up even though that folder isn't selected
 // TODO also for the folder path column, make a hash of folder ids to tree nodes, so we can walk up their parents to build the path string
 
 const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -92,7 +92,8 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
     <div className="plan-wizard-filter-vms-form">
       <TextContent>
         <Text component="p">
-          Refine the list of VMs selectable for migration by clusters or by folders.
+          Refine the list of VMs selectable for migration by clusters
+          {sourceProvider?.type === 'vsphere' ? ' or by folders' : ''}.
         </Text>
       </TextContent>
       {sourceProvider?.type === 'vsphere' ? (

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -92,7 +92,7 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
     <div className="plan-wizard-filter-vms-form">
       <TextContent>
         <Text component="p">
-          Refine the list of VMs selectable for migration by clusters and hosts or by folder.
+          Refine the list of VMs selectable for migration by clusters or by folders.
         </Text>
       </TextContent>
       {sourceProvider?.type === 'vsphere' ? (
@@ -102,9 +102,9 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
           className={spacing.mtMd}
         >
           <Tab
-            key={InventoryTreeType.Host}
-            eventKey={InventoryTreeType.Host}
-            title={<TabTitleText>By clusters and hosts</TabTitleText>}
+            key={InventoryTreeType.Cluster}
+            eventKey={InventoryTreeType.Cluster}
+            title={<TabTitleText>By clusters</TabTitleText>}
           />
           <Tab
             key={InventoryTreeType.VM}

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -28,6 +28,15 @@ interface IFilterVMsFormProps {
   planBeingEdited: IPlan | null;
 }
 
+// TODO switch to new cluster tree, update mock data, test against Jeff's cluster
+// TODO hide hosts entirely
+// TODO figure out if it makes sense to change Select VMs list so it comes from filtering on VM properties matching selected tree nodes
+//      instead of using the leaf nodes. otherwise, see if it makes sense to limit to only the direct child leaves.
+// TODO figure out if we need to change how selection and deselection works in terms of auto-toggling descendants, and having indeterminates.
+//      maybe the only state we save is which (displayed) leaves are selected, and the rest is render logic.
+//      (i.e. there is no such thing as selecting a parent, a parent is only shown as selected if all its children are).
+// See notes in Typora scratch
+
 const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
   form,
   sourceProvider,

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -31,7 +31,6 @@ interface IFilterVMsFormProps {
   planBeingEdited: IPlan | null;
 }
 
-// TODO figure out why Templates folder VMs are coming up even though that folder isn't selected
 // TODO also for the folder path column, make a hash of folder ids to tree nodes, so we can walk up their parents to build the path string
 
 const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -96,7 +96,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
 
   // Cache these queries as soon as a source provider is selected so they are ready in later wizard steps
   useSourceVMsQuery(form.values.sourceProvider);
-  useInventoryTreeQuery(form.values.sourceProvider, InventoryTreeType.Host);
+  useInventoryTreeQuery(form.values.sourceProvider, InventoryTreeType.Cluster);
   useInventoryTreeQuery(form.values.sourceProvider, InventoryTreeType.VM);
 
   return (

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -291,6 +291,7 @@ const PlanWizard: React.FunctionComponent = () => {
             <WizardStepContainer title="Select VMs">
               <SelectVMsForm
                 form={forms.selectVMs}
+                treeType={forms.filterVMs.values.treeType}
                 selectedTreeNodes={forms.filterVMs.values.selectedTreeNodes}
                 sourceProvider={forms.general.values.sourceProvider}
                 selectedVMs={selectedVMs}

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -104,7 +104,7 @@ const usePlanWizardFormState = (
     }),
     filterVMs: useFormState({
       treeType: useFormField<InventoryTreeType>(
-        InventoryTreeType.Host,
+        InventoryTreeType.Cluster,
         yup.mixed<InventoryTreeType>()
       ),
       selectedTreeNodes: useFormField<InventoryTree[]>(

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -65,7 +65,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
 }: ISelectVMsFormProps) => {
   const hostTreeQuery = useInventoryTreeQuery<IInventoryHostTree>(
     sourceProvider,
-    InventoryTreeType.Host
+    InventoryTreeType.Cluster
   );
   const vmTreeQuery = useInventoryTreeQuery<IVMwareFolderTree>(
     sourceProvider,

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -52,6 +52,7 @@ import { LONG_LOADING_MESSAGE } from '@app/queries/constants';
 
 interface ISelectVMsFormProps {
   form: PlanWizardFormState['selectVMs'];
+  treeType: InventoryTreeType;
   selectedTreeNodes: InventoryTree[];
   sourceProvider: SourceInventoryProvider | null;
   selectedVMs: SourceVM[];
@@ -59,6 +60,7 @@ interface ISelectVMsFormProps {
 
 const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   form,
+  treeType,
   selectedTreeNodes,
   sourceProvider,
   selectedVMs,
@@ -78,7 +80,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   const [availableVMs, setAvailableVMs] = React.useState<SourceVM[] | null>(null);
   React.useEffect(() => {
     if (vmsQuery.data) {
-      const filteredVMs = getAvailableVMs(selectedTreeNodes, vmsQuery.data || []);
+      const filteredVMs = getAvailableVMs(selectedTreeNodes, vmsQuery.data || [], treeType);
       setAvailableVMs([
         ...selectedVMsOnMount.current,
         ...filteredVMs.filter(
@@ -86,7 +88,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
         ),
       ]);
     }
-  }, [vmsQuery.data, selectedTreeNodes]);
+  }, [vmsQuery.data, selectedTreeNodes, treeType]);
 
   const [treePathInfoByVM, setTreePathInfoByVM] = React.useState<IVMTreePathInfoByVM | null>(null);
   React.useEffect(() => {

--- a/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -103,9 +103,7 @@ describe('<AddEditProviderModal />', () => {
     userEvent.click(nextButton);
 
     expect(screen.getByRole('heading', { name: /Filter by VM location/ })).toBeInTheDocument();
-    expect(
-      screen.getByRole('checkbox', { name: /Select Host esx13.v2v.bos.redhat.com/ })
-    ).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Select Cluster V2V_Cluster/ })).toBeChecked();
     expect(nextButton).toBeEnabled();
     userEvent.click(nextButton);
 

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -551,7 +551,7 @@ export const useEditingPlanPrefillEffect = (
     providersQuery
   );
   const vmsQuery = useSourceVMsQuery(sourceProvider);
-  const hostTreeQuery = useInventoryTreeQuery(sourceProvider, InventoryTreeType.Host);
+  const hostTreeQuery = useInventoryTreeQuery(sourceProvider, InventoryTreeType.Cluster);
 
   const networkMappingResourceQueries = useMappingResourceQueries(
     sourceProvider,
@@ -598,7 +598,7 @@ export const useEditingPlanPrefillEffect = (
   const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
   const [isDonePrefilling, setIsDonePrefilling] = React.useState(!isEditMode);
 
-  const defaultTreeType = InventoryTreeType.Host;
+  const defaultTreeType = InventoryTreeType.Cluster;
   const isNodeSelectable = useIsNodeSelectableCallback(defaultTreeType);
 
   React.useEffect(() => {

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -75,7 +75,7 @@ export const useIsNodeSelectableCallback = (
     (node: InventoryTree) => {
       if (isIncludedLeafNode(node)) return true;
       if (treeType === InventoryTreeType.VM) {
-        return node.kind === 'Folder' || node.kind === 'Cluster';
+        return node.kind === 'Folder' || node.kind === 'Datacenter';
       }
       return false;
     },
@@ -228,7 +228,7 @@ export const getAllVMChildren = (
         // Only include direct children of nodes in the folder tree so we can exclude subfolders
         if (
           node.kind === 'Folder' ||
-          (treeType === InventoryTreeType.VM && node.kind === 'Cluster')
+          (treeType === InventoryTreeType.VM && node.kind === 'Datacenter')
         )
           return getDirectVMChildren(node);
         // Otherwise, we might have VMs under hidden descendants like hosts
@@ -243,7 +243,6 @@ export const getAvailableVMs = (
   allVMs: SourceVM[],
   treeType: InventoryTreeType
 ): SourceVM[] => {
-  console.log({ selectedTreeNodes });
   const treeVMs = getAllVMChildren(selectedTreeNodes, treeType)
     .map((node) => node.object)
     .filter((object) => !!object) as ICommonTreeObject[];

--- a/src/app/queries/mocks/tree.mock.ts
+++ b/src/app/queries/mocks/tree.mock.ts
@@ -431,15 +431,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               {
                 kind: 'Folder',
                 object: {
-                  id: 'vm-2685',
-                  name: 'pemcg-discovery01',
-                  selfLink: '/providers/vsphere/test/vms/vm-2685',
-                },
-                children: null,
-              },
-              {
-                kind: 'Folder',
-                object: {
                   id: 'group-v2831',
                   name: 'Linux',
                   selfLink: '/providers/vsphere/test4/folders/group-v2831',

--- a/src/app/queries/mocks/tree.mock.ts
+++ b/src/app/queries/mocks/tree.mock.ts
@@ -470,30 +470,21 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
                           name: 'jortel',
                           selfLink: '/providers/vsphere/test4/folders/group-v2838',
                         },
-                        children: null,
+                        children: [
+                          {
+                            kind: 'VM',
+                            object: {
+                              id: 'vm-1008',
+                              name: 'fdupont-test-migration-centos',
+                              selfLink: '/providers/vsphere/test/vms/vm-1008',
+                            },
+                            children: null,
+                          },
+                        ],
                       },
                     ],
                   },
                 ],
-              },
-            ],
-          },
-          {
-            kind: 'Folder',
-            object: {
-              id: 'group-v162',
-              name: 'v2v dev',
-              selfLink: '/providers/vsphere/test4/folders/group-v162',
-            },
-            children: [
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-1008',
-                  name: 'fdupont-test-migration-centos',
-                  selfLink: '/providers/vsphere/test/vms/vm-1008',
-                },
-                children: null,
               },
             ],
           },

--- a/src/app/queries/mocks/tree.mock.ts
+++ b/src/app/queries/mocks/tree.mock.ts
@@ -381,9 +381,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     ],
   };
 
-  // TODO fix this data, there are duplicate VM leaves, they need to all be unique
-  // TODO it looks like we need to make datacenters directly selectable again if there can be VMs directly under them?
-
   MOCK_VMWARE_VM_TREE = {
     kind: '',
     object: null,
@@ -408,45 +405,9 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           {
             kind: 'VM',
             object: {
-              id: 'vm-1630',
-              name: 'fdupont-test-migration',
-              selfLink: '/providers/vsphere/test/vms/vm-1630',
-            },
-            children: null,
-          },
-          {
-            kind: 'VM',
-            object: {
-              id: 'vm-template-test',
-              name: 'vm-template-test',
-              selfLink: '/providers/vsphere/test/vms/vm-template-test',
-            },
-            children: null,
-          },
-          {
-            kind: 'VM',
-            object: {
               id: 'vm-2844',
               name: 'fdupont%2ftest',
               selfLink: '/providers/vsphere/test/vms/vm-2844',
-            },
-            children: null,
-          },
-          {
-            kind: 'VM',
-            object: {
-              id: 'vm-1008',
-              name: 'fdupont-test-migration-centos',
-              selfLink: '/providers/vsphere/test/vms/vm-1008',
-            },
-            children: null,
-          },
-          {
-            kind: 'VM',
-            object: {
-              id: 'vm-2685',
-              name: 'pemcg-discovery01',
-              selfLink: '/providers/vsphere/test/vms/vm-2685',
             },
             children: null,
           },
@@ -467,42 +428,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               selfLink: '/providers/vsphere/test4/folders/group-v1001',
             },
             children: [
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-1630',
-                  name: 'fdupont-test-migration',
-                  selfLink: '/providers/vsphere/test/vms/vm-1630',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-template-test',
-                  name: 'vm-template-test',
-                  selfLink: '/providers/vsphere/test/vms/vm-template-test',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-2844',
-                  name: 'fdupont%2ftest',
-                  selfLink: '/providers/vsphere/test/vms/vm-2844',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-1008',
-                  name: 'fdupont-test-migration-centos',
-                  selfLink: '/providers/vsphere/test/vms/vm-1008',
-                },
-                children: null,
-              },
               {
                 kind: 'Folder',
                 object: {
@@ -529,24 +454,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
                     },
                     children: null,
                   },
-                  {
-                    kind: 'VM',
-                    object: {
-                      id: 'vm-template-test',
-                      name: 'vm-template-test',
-                      selfLink: '/providers/vsphere/test/vms/vm-template-test',
-                    },
-                    children: null,
-                  },
-                  {
-                    kind: 'VM',
-                    object: {
-                      id: 'vm-2844',
-                      name: 'fdupont%2ftest',
-                      selfLink: '/providers/vsphere/test/vms/vm-2844',
-                    },
-                    children: null,
-                  },
                 ],
               },
               {
@@ -557,24 +464,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
                   selfLink: '/providers/vsphere/test4/folders/group-v2835',
                 },
                 children: [
-                  {
-                    kind: 'VM',
-                    object: {
-                      id: 'vm-1630',
-                      name: 'fdupont-test-migration',
-                      selfLink: '/providers/vsphere/test/vms/vm-1630',
-                    },
-                    children: null,
-                  },
-                  {
-                    kind: 'VM',
-                    object: {
-                      id: 'vm-template-test',
-                      name: 'vm-template-test',
-                      selfLink: '/providers/vsphere/test/vms/vm-template-test',
-                    },
-                    children: null,
-                  },
                   {
                     kind: 'Folder',
                     object: {
@@ -609,33 +498,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               {
                 kind: 'VM',
                 object: {
-                  id: 'vm-1630',
-                  name: 'fdupont-test-migration',
-                  selfLink: '/providers/vsphere/test/vms/vm-1630',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-template-test',
-                  name: 'vm-template-test',
-                  selfLink: '/providers/vsphere/test/vms/vm-template-test',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-2844',
-                  name: 'fdupont%2ftest',
-                  selfLink: '/providers/vsphere/test/vms/vm-2844',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
                   id: 'vm-1008',
                   name: 'fdupont-test-migration-centos',
                   selfLink: '/providers/vsphere/test/vms/vm-1008',
@@ -655,98 +517,6 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               {
                 kind: 'VM',
                 object: {
-                  id: 'vm-1630',
-                  name: 'fdupont-test-migration',
-                  selfLink: '/providers/vsphere/test/vms/vm-1630',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-template-test',
-                  name: 'vm-template-test',
-                  selfLink: '/providers/vsphere/test/vms/vm-template-test',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-2844',
-                  name: 'fdupont%2ftest',
-                  selfLink: '/providers/vsphere/test/vms/vm-2844',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-1008',
-                  name: 'fdupont-test-migration-centos',
-                  selfLink: '/providers/vsphere/test/vms/vm-1008',
-                },
-                children: null,
-              },
-            ],
-          },
-          {
-            kind: 'Folder',
-            object: {
-              id: 'group-v39',
-              name: 'V2V',
-              selfLink: '/providers/vsphere/test4/folders/group-v39',
-            },
-            children: [
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-1630',
-                  name: 'fdupont-test-migration',
-                  selfLink: '/providers/vsphere/test/vms/vm-1630',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-template-test',
-                  name: 'vm-template-test',
-                  selfLink: '/providers/vsphere/test/vms/vm-template-test',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-2844',
-                  name: 'fdupont%2ftest',
-                  selfLink: '/providers/vsphere/test/vms/vm-2844',
-                },
-                children: null,
-              },
-            ],
-          },
-          {
-            kind: 'Folder',
-            object: {
-              id: 'group-v38',
-              name: 'Infrastructure',
-              selfLink: '/providers/vsphere/test4/folders/group-v38',
-            },
-            children: [
-              {
-                kind: 'VM',
-                object: {
-                  id: 'vm-1630',
-                  name: 'fdupont-test-migration',
-                  selfLink: '/providers/vsphere/test/vms/vm-1630',
-                },
-                children: null,
-              },
-              {
-                kind: 'VM',
-                object: {
                   id: 'vm-template-test',
                   name: 'vm-template-test',
                   selfLink: '/providers/vsphere/test/vms/vm-template-test',
@@ -762,7 +532,17 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
               name: 'Discovered virtual machine',
               selfLink: '/providers/vsphere/test4/folders/group-v28',
             },
-            children: null,
+            children: [
+              {
+                kind: 'VM',
+                object: {
+                  id: 'vm-2685',
+                  name: 'pemcg-discovery01',
+                  selfLink: '/providers/vsphere/test/vms/vm-2685',
+                },
+                children: null,
+              },
+            ],
           },
         ],
       },

--- a/src/app/queries/mocks/tree.mock.ts
+++ b/src/app/queries/mocks/tree.mock.ts
@@ -381,6 +381,9 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     ],
   };
 
+  // TODO fix this data, there are duplicate VM leaves, they need to all be unique
+  // TODO it looks like we need to make datacenters directly selectable again if there can be VMs directly under them?
+
   MOCK_VMWARE_VM_TREE = {
     kind: '',
     object: null,

--- a/src/app/queries/tree.ts
+++ b/src/app/queries/tree.ts
@@ -12,8 +12,8 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
   treeType: InventoryTreeType
 ): QueryResult<T> => {
   // VMware providers have both Host and VM trees, but RHV only has Host trees.
-  const isValidQuery = provider?.type === 'vsphere' || treeType === InventoryTreeType.Host;
-  const apiSlug = treeType === InventoryTreeType.Host ? '/tree/host' : '/tree/vm';
+  const isValidQuery = provider?.type === 'vsphere' || treeType === InventoryTreeType.Cluster;
+  const apiSlug = treeType === InventoryTreeType.Cluster ? '/tree/host' : '/tree/vm';
   const result = useMockableQuery<T>(
     {
       queryKey: ['inventory-tree', provider?.name, treeType],
@@ -23,7 +23,7 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
         refetchInterval: usePollingContext().refetchInterval,
       },
     },
-    (treeType === InventoryTreeType.Host
+    (treeType === InventoryTreeType.Cluster
       ? provider?.type === 'vsphere'
         ? MOCK_VMWARE_HOST_TREE
         : MOCK_RHV_HOST_TREE

--- a/src/app/queries/tree.ts
+++ b/src/app/queries/tree.ts
@@ -13,7 +13,12 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
 ): QueryResult<T> => {
   // VMware providers have both Host and VM trees, but RHV only has Host trees.
   const isValidQuery = provider?.type === 'vsphere' || treeType === InventoryTreeType.Cluster;
-  const apiSlug = treeType === InventoryTreeType.Cluster ? '/tree/host' : '/tree/vm';
+  const apiSlug =
+    treeType === InventoryTreeType.Cluster
+      ? provider?.type === 'vsphere'
+        ? '/tree/host' // TODO in the future, this vsphere tree will also be at /tree/cluster
+        : '/tree/cluster'
+      : '/tree/vm';
   const result = useMockableQuery<T>(
     {
       queryKey: ['inventory-tree', provider?.name, treeType],

--- a/src/app/queries/types/tree.types.ts
+++ b/src/app/queries/types/tree.types.ts
@@ -1,5 +1,5 @@
 export enum InventoryTreeType {
-  Host = 'Host',
+  Cluster = 'Cluster',
   VM = 'VM',
 }
 


### PR DESCRIPTION
Based on discussions with @jortel.

This PR solves two issues with the Filter VMs step of the wizard.

1. The structure of the RHV tree has VMs as peers of hosts rather than children, and the VMware cluster tree will be changing to share this flattened structure. This means that selecting a host would never result in any VMs showing up on the next step, because host tree nodes will never have VM children. We decided it makes sense to just remove Hosts from the UI tree entirely, since they are not very meaningful for the user anyway.
2. There is currently a bug in the cluster/host tree where selecting a datacenter and then deselecting one or all of the child clusters results in the datacenter still being selected. This doesn't make sense because datacenters will never have VM children in that tree. However, in the folder tree, we need to retain this behavior because there can be VM children of a parent folder that are not in a child folder, so we want to be able to exclude child folders and retain the VMs in the parent.

To solve these with as little hard-coded logic about the tree node kinds as possible, I introduced two new helpers: `isIncludedNode` and `isNodeSelectable`. `isIncludedNode` is a constant, which just excludes hosts from the tree (preventing them from appearing in the tree and from being considered leaf nodes for selection logic purposes). `isNodeSelectable` can be passed into these tree helpers, so that it can differ by tree type or whatever other conditions we need. The one defined by `useIsNodeSelectableCallback` (which is only defined as a hook so it can use React.useCallback to prevent triggering the useEffect that performs all this logic on every render) only allows leaf nodes (clusters) to be selected in the cluster tree, and allows any folders or datacenters to be selected in the folder tree. The `isFullyChecked` and `isPartiallyChecked` logic has been abstracted out to use these so that the non-selectable nodes correctly render as checked/indeterminate/unchecked based on the checked state of their selectable descendants.

You can verify this behavior by checking the box on a datacenter, then unchecking one of its cluster children and observing that the datacenter checkbox becomes indeterminate rather than staying selected, and observing that this *doesn't* happen with folders.

I also cleaned up the tree mock data a bit, there were duplicate VMs in the folder tree that made it difficult to verify this excluded-child fix.

I noticed a few more opportunities to simplify some of this tree code in future PRs, but I didn't want this PR to get any larger so I will follow up later. In particular, I left a TODO comment about optimizing `getVMTreePathInfoByVM` which could be performed once for the entire tree at query time rather than on every render. This optimization would remove a lot of the need for caching / useEffect in SelectVMsStep as well.