### PR TITLE
React query v3 upgrade

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
   // includes the typescript specific rules found here: https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules
   "plugins": ["@typescript-eslint", "react-hooks", "eslint-plugin-react-hooks"],
   "rules": {
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3353,6 +3353,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "dev": true
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -3525,6 +3531,29 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.6.0.tgz",
+      "integrity": "sha512-0x87tKJULniTOfECZP/LCsqWyMEbz0Oa+4yJ4i5dosOMxWUjx6mZ6nt9QmD2ox0r3MaCPojHrTQ2dj4ASZupeA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
+      },
+      "dependencies": {
+        "detect-node": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+          "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+          "dev": true
+        }
       }
     },
     "browser-process-hrtime": {
@@ -10267,6 +10296,12 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10829,12 +10864,12 @@
       }
     },
     "match-sorter": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-4.2.1.tgz",
-      "integrity": "sha512-s+3h9TiZU9U1pWhIERHf8/f4LmBN6IXaRgo2CI17+XGByGS1GvG5VvXK9pcGyCjGe3WM3mSYRC3ipGrd5UEVgw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+      "integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.5",
+        "@babel/runtime": "^7.12.5",
         "remove-accents": "0.4.2"
       }
     },
@@ -10913,6 +10948,12 @@
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
       }
+    },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==",
+      "dev": true
     },
     "mime": {
       "version": "1.6.0",
@@ -11079,6 +11120,15 @@
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "dev": true,
       "optional": true
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanoclone": {
       "version": "0.2.1",
@@ -12513,20 +12563,14 @@
       "dev": true
     },
     "react-query": {
-      "version": "2.26.4",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-2.26.4.tgz",
-      "integrity": "sha512-sXGG0gh1ah11AcfptYOCRpGDoYMnssq6riQUpQaLSM2EOodVkexp3zNLk1MFDgfRGuXQst40Tnu17oNwni66aA==",
-      "requires": {
-        "@babel/runtime": "^7.5.5"
-      }
-    },
-    "react-query-devtools": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/react-query-devtools/-/react-query-devtools-2.6.3.tgz",
-      "integrity": "sha512-pSvWq5Q8zgIP7QbF0+4BerCHLaLn5HPzce7sIXYqz4XEizcYJHkJtcrAwn6bUkCu5JmAt1Y7fViQtZwOIG2SYA==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.17.0.tgz",
+      "integrity": "sha512-/qUNb6ESCz75Z/bR5p/ztp5ipRj8IQSiIpHK3AkCLTT4IqZsceAoD+9B+wbitA0LkxsR3snGrpgKUc9MMYQ/Ow==",
       "dev": true,
       "requires": {
-        "match-sorter": "^4.1.0"
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
       }
     },
     "react-router": {
@@ -14778,6 +14822,16 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
+    },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "raw-loader": "^4.0.2",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-hot-loader": "^4.13.0",
-    "react-query-devtools": "^2.6.3",
+    "react-query": "^3.17.0",
     "react-router-dom": "^5.2.0",
     "regenerator-runtime": "^0.13.7",
     "rimraf": "^3.0.2",
@@ -114,7 +114,6 @@
     "q": "^1.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-query": "^2.26.4",
     "react-router-last-location": "^2.0.1",
     "react-syntax-highlighter": "^15.4.3",
     "yup": "^0.32.9"

--- a/src/app/Mappings/Mappings.test.tsx
+++ b/src/app/Mappings/Mappings.test.tsx
@@ -3,18 +3,23 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import Mappings from '@app/Mappings/Mappings';
 import { MappingType } from '@app/queries/types';
+import { QueryClientProvider, QueryClient } from 'react-query';
+const queryClient = new QueryClient();
 
 describe('Mappings', () => {
   const noop = jest.fn();
   test('renders mappings component initially in loading state', async () => {
     render(
-      <Mappings
-        openEditMappingModal={noop}
-        toggleModalAndResetEdit={noop}
-        mappingType={'Network' as MappingType}
-      />
+      <QueryClientProvider client={queryClient}>
+        <Mappings
+          openEditMappingModal={noop}
+          toggleModalAndResetEdit={noop}
+          mappingType={MappingType.Network}
+        />
+      </QueryClientProvider>
     );
 
     const result = await screen.getByText('Loading...');
+    expect(result).toBeDefined();
   });
 });

--- a/src/app/Mappings/MappingsPage.test.tsx
+++ b/src/app/Mappings/MappingsPage.test.tsx
@@ -2,10 +2,16 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { MappingsPage } from '@app/Mappings/MappingsPage';
+import { QueryClientProvider, QueryClient } from 'react-query';
+const queryClient = new QueryClient();
 
 describe('MappingsPage', () => {
   test('renders mappings page without errors', async () => {
-    render(<MappingsPage />);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MappingsPage />
+      </QueryClientProvider>
+    );
     const heading = await screen.getByText('Mappings');
     expect(heading).toBeDefined();
 

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -121,16 +121,13 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form.values.sourceProvider, form.values.targetProvider]);
 
-  const createMappingMutationResult = useCreateMappingMutation(mappingType, onClose);
-  const { mutate: createMapping } = createMappingMutationResult;
+  const createMappingMutation = useCreateMappingMutation(mappingType, onClose);
+  const patchMappingMutation = usePatchMappingMutation(mappingType, onClose);
 
-  const patchMappingMutationResult = usePatchMappingMutation(mappingType, onClose);
-  const { mutate: patchMapping } = patchMappingMutationResult;
-
-  const mutateMapping = !mappingBeingEdited ? createMapping : patchMapping;
-  const mutationResult = !mappingBeingEdited
-    ? createMappingMutationResult
-    : patchMappingMutationResult;
+  const mutateMapping = !mappingBeingEdited
+    ? createMappingMutation.mutate
+    : patchMappingMutation.mutate;
+  const mutationResult = !mappingBeingEdited ? createMappingMutation : patchMappingMutation;
 
   const MAPPING_TYPE_OPTIONS = Object.values(MappingType).map((type) => ({
     toString: () => MappingType[type],

--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -35,7 +35,7 @@ import { usePausedPollingEffect } from '@app/common/context';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 
 import './AddEditMappingModal.css';
-import { QueryResult } from 'react-query';
+import { UseQueryResult } from 'react-query';
 import { useEditingMappingPrefillEffect } from './helpers';
 import { IKubeList } from '@app/client/types';
 import {
@@ -54,7 +54,7 @@ interface IAddEditMappingModalProps {
 }
 
 const useMappingFormState = (
-  mappingsQuery: QueryResult<IKubeList<Mapping>>,
+  mappingsQuery: UseQueryResult<IKubeList<Mapping>>,
   mappingBeingEdited: Mapping | null
 ) =>
   useFormState({
@@ -121,10 +121,16 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form.values.sourceProvider, form.values.targetProvider]);
 
-  const [createMapping, createMappingResult] = useCreateMappingMutation(mappingType, onClose);
-  const [patchMapping, patchMappingResult] = usePatchMappingMutation(mappingType, onClose);
+  const createMappingMutationResult = useCreateMappingMutation(mappingType, onClose);
+  const { mutate: createMapping } = createMappingMutationResult;
+
+  const patchMappingMutationResult = usePatchMappingMutation(mappingType, onClose);
+  const { mutate: patchMapping } = patchMappingMutationResult;
+
   const mutateMapping = !mappingBeingEdited ? createMapping : patchMapping;
-  const mutationResult = !mappingBeingEdited ? createMappingResult : patchMappingResult;
+  const mutationResult = !mappingBeingEdited
+    ? createMappingMutationResult
+    : patchMappingMutationResult;
 
   const MAPPING_TYPE_OPTIONS = Object.values(MappingType).map((type) => ({
     toString: () => MappingType[type],

--- a/src/app/Mappings/components/MappingDetailView/helpers.ts
+++ b/src/app/Mappings/components/MappingDetailView/helpers.ts
@@ -2,7 +2,6 @@ import {
   IAnnotatedStorageClass,
   INetworkMappingItem,
   IOpenShiftNetwork,
-  IStorageClass,
   IStorageMappingItem,
   MappingItem,
   MappingTarget,

--- a/src/app/Mappings/components/MappingsActionsDropdown.tsx
+++ b/src/app/Mappings/components/MappingsActionsDropdown.tsx
@@ -24,10 +24,13 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
 }: IMappingsActionsDropdownProps) => {
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
-  const [deleteMapping, deleteMappingResult] = useDeleteMappingMutation(
-    mappingType,
-    toggleDeleteModal
-  );
+  // const [deleteMapping, deleteMappingResult] = useDeleteMappingMutation(
+  //   mappingType,
+  //   toggleDeleteModal
+  // );
+
+  const deleteMappingMutationResult = useDeleteMappingMutation(mappingType, toggleDeleteModal);
+  const { mutate: deleteMapping } = deleteMappingMutationResult;
   const clusterProvidersQuery = useClusterProvidersQuery();
   const areProvidersReady = React.useMemo(
     () => kebabIsOpen && areAssociatedProvidersReady(clusterProvidersQuery, mapping.spec.provider),
@@ -74,7 +77,7 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
               setKebabIsOpen(false);
               toggleDeleteModal();
             }}
-            isDisabled={deleteMappingResult.isLoading}
+            isDisabled={deleteMappingMutationResult.isLoading}
             key="delete"
           >
             Delete
@@ -86,7 +89,7 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
         isOpen={isDeleteModalOpen}
         toggleOpen={toggleDeleteModal}
         mutateFn={() => deleteMapping(mapping)}
-        mutateResult={deleteMappingResult}
+        mutateResult={deleteMappingMutationResult}
         title={`Delete ${mappingType.toLowerCase()} mapping`}
         confirmButtonText="Delete"
         body={

--- a/src/app/Mappings/components/MappingsActionsDropdown.tsx
+++ b/src/app/Mappings/components/MappingsActionsDropdown.tsx
@@ -25,8 +25,7 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
 
-  const deleteMappingMutationResult = useDeleteMappingMutation(mappingType, toggleDeleteModal);
-  const { mutate: deleteMapping } = deleteMappingMutationResult;
+  const deleteMappingMutation = useDeleteMappingMutation(mappingType, toggleDeleteModal);
   const clusterProvidersQuery = useClusterProvidersQuery();
   const areProvidersReady = React.useMemo(
     () => kebabIsOpen && areAssociatedProvidersReady(clusterProvidersQuery, mapping.spec.provider),
@@ -73,7 +72,7 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
               setKebabIsOpen(false);
               toggleDeleteModal();
             }}
-            isDisabled={deleteMappingMutationResult.isLoading}
+            isDisabled={deleteMappingMutation.isLoading}
             key="delete"
           >
             Delete
@@ -84,8 +83,8 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
       <ConfirmModal
         isOpen={isDeleteModalOpen}
         toggleOpen={toggleDeleteModal}
-        mutateFn={() => deleteMapping(mapping)}
-        mutateResult={deleteMappingMutationResult}
+        mutateFn={() => deleteMappingMutation.mutate(mapping)}
+        mutateResult={deleteMappingMutation}
         title={`Delete ${mappingType.toLowerCase()} mapping`}
         confirmButtonText="Delete"
         body={

--- a/src/app/Mappings/components/MappingsActionsDropdown.tsx
+++ b/src/app/Mappings/components/MappingsActionsDropdown.tsx
@@ -24,10 +24,6 @@ const MappingsActionsDropdown: React.FunctionComponent<IMappingsActionsDropdownP
 }: IMappingsActionsDropdownProps) => {
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
-  // const [deleteMapping, deleteMappingResult] = useDeleteMappingMutation(
-  //   mappingType,
-  //   toggleDeleteModal
-  // );
 
   const deleteMappingMutationResult = useDeleteMappingMutation(mappingType, toggleDeleteModal);
   const { mutate: deleteMapping } = deleteMappingMutationResult;

--- a/src/app/Mappings/components/helpers.ts
+++ b/src/app/Mappings/components/helpers.ts
@@ -14,7 +14,7 @@ import {
   SourceInventoryProvider,
 } from '@app/queries/types';
 import { MappingFormState } from './AddEditMappingModal';
-import { QueryResult, QueryStatus } from 'react-query';
+import { UseQueryResult } from 'react-query';
 import { IMappingResourcesResult } from '@app/queries';
 import { getBuilderItemsFromMapping } from './MappingBuilder/helpers';
 import { ProviderType } from '@app/common/constants';
@@ -74,7 +74,7 @@ export const useEditingMappingPrefillEffect = (
     sourceProvider: SourceInventoryProvider | null;
     targetProvider: IOpenShiftProvider | null;
   },
-  providersQuery: QueryResult<IProvidersByType>,
+  providersQuery: UseQueryResult<IProvidersByType>,
   mappingResourceQueries: IMappingResourcesResult
 ): { isDonePrefilling: boolean } => {
   const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
@@ -84,7 +84,7 @@ export const useEditingMappingPrefillEffect = (
       !isStartedPrefilling &&
       mappingBeingEdited &&
       providersQuery.isSuccess &&
-      mappingResourceQueries.status === QueryStatus.Success
+      mappingResourceQueries.status === 'success'
     ) {
       setIsStartedPrefilling(true);
       const { sourceProvider, targetProvider } = mappingBeingEditedProviders;

--- a/src/app/Plans/components/MigrateOrCutoverButton.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverButton.tsx
@@ -26,17 +26,10 @@ const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonPro
   const onMigrationStarted = (migration: IMigration) => {
     history.push(`/plans/${migration.spec.plan.name}`);
   };
-  const createMigrationMutationResult = useCreateMigrationMutation(onMigrationStarted);
-  const { mutate: createMigration } = createMigrationMutationResult;
+  const createMigrationMutation = useCreateMigrationMutation(onMigrationStarted);
+  const setCutoverMutation = useSetCutoverMutation();
 
-  const setCutoverMutationResult = useSetCutoverMutation();
-  const { mutate: setCutover } = setCutoverMutationResult;
-
-  if (
-    isBeingStarted ||
-    createMigrationMutationResult.isLoading ||
-    setCutoverMutationResult.isLoading
-  ) {
+  if (isBeingStarted || createMigrationMutation.isLoading || setCutoverMutation.isLoading) {
     return <Spinner size="md" className={spacing.mxLg} />;
   }
   return (
@@ -45,27 +38,26 @@ const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonPro
         variant="secondary"
         onClick={() => {
           if (buttonType === 'Start' || buttonType === 'Restart') {
-            createMigration(plan);
+            createMigrationMutation.mutate(plan);
           } else if (buttonType === 'Cutover') {
-            setCutover({ plan, cutover: new Date().toISOString() });
+            setCutoverMutation.mutate({ plan, cutover: new Date().toISOString() });
           }
         }}
       >
         {buttonType}
       </Button>
-      {(createMigrationMutationResult.isError || setCutoverMutationResult.isError) &&
-      errorContainerRef.current
+      {(createMigrationMutation.isError || setCutoverMutation.isError) && errorContainerRef.current
         ? createPortal(
             <>
               <ResolvedQuery
-                result={createMigrationMutationResult}
+                result={createMigrationMutation}
                 errorTitle="Error starting migration"
                 errorsInline={false}
                 spinnerMode={QuerySpinnerMode.None}
                 className={spacing.mbMd}
               />
               <ResolvedQuery
-                result={setCutoverMutationResult}
+                result={setCutoverMutation}
                 errorTitle="Error setting cutover time"
                 errorsInline={false}
                 spinnerMode={QuerySpinnerMode.None}

--- a/src/app/Plans/components/MigrateOrCutoverButton.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverButton.tsx
@@ -26,9 +26,17 @@ const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonPro
   const onMigrationStarted = (migration: IMigration) => {
     history.push(`/plans/${migration.spec.plan.name}`);
   };
-  const [createMigration, createMigrationResult] = useCreateMigrationMutation(onMigrationStarted);
-  const [setCutover, setCutoverResult] = useSetCutoverMutation();
-  if (isBeingStarted || createMigrationResult.isLoading || setCutoverResult.isLoading) {
+  const createMigrationMutationResult = useCreateMigrationMutation(onMigrationStarted);
+  const { mutate: createMigration } = createMigrationMutationResult;
+
+  const setCutoverMutationResult = useSetCutoverMutation();
+  const { mutate: setCutover } = setCutoverMutationResult;
+
+  if (
+    isBeingStarted ||
+    createMigrationMutationResult.isLoading ||
+    setCutoverMutationResult.isLoading
+  ) {
     return <Spinner size="md" className={spacing.mxLg} />;
   }
   return (
@@ -45,18 +53,19 @@ const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonPro
       >
         {buttonType}
       </Button>
-      {(createMigrationResult.isError || setCutoverResult.isError) && errorContainerRef.current
+      {(createMigrationMutationResult.isError || setCutoverMutationResult.isError) &&
+      errorContainerRef.current
         ? createPortal(
             <>
               <ResolvedQuery
-                result={createMigrationResult}
+                result={createMigrationMutationResult}
                 errorTitle="Error starting migration"
                 errorsInline={false}
                 spinnerMode={QuerySpinnerMode.None}
                 className={spacing.mbMd}
               />
               <ResolvedQuery
-                result={setCutoverResult}
+                result={setCutoverMutationResult}
                 errorTitle="Error setting cutover time"
                 errorsInline={false}
                 spinnerMode={QuerySpinnerMode.None}

--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -28,7 +28,9 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
   const [isDetailsModalOpen, toggleDetailsModal] = React.useReducer((isOpen) => !isOpen, false);
-  const [deletePlan, deletePlanResult] = useDeletePlanMutation(toggleDeleteModal);
+  // const [deletePlan, deletePlanResult] = useDeletePlanMutation(toggleDeleteModal);
+  const deletePlanMutationResult = useDeletePlanMutation(toggleDeleteModal);
+  const { mutate: deletePlan } = deletePlanMutationResult;
   const history = useHistory();
   const conditions = plan.status?.conditions || [];
   const clusterProvidersQuery = useClusterProvidersQuery();
@@ -69,19 +71,21 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
           <ConditionalTooltip
             key="Delete"
             isTooltipEnabled={
-              hasCondition(conditions, PlanStatusType.Executing) || deletePlanResult.isLoading
+              hasCondition(conditions, PlanStatusType.Executing) ||
+              deletePlanMutationResult.isLoading
             }
             content={
               hasCondition(conditions, PlanStatusType.Executing)
                 ? 'This plan cannot be deleted because it is running'
-                : deletePlanResult.isLoading
+                : deletePlanMutationResult.isLoading
                 ? 'This plan cannot be deleted because it is deleting'
                 : ''
             }
           >
             <DropdownItem
               isDisabled={
-                hasCondition(conditions, PlanStatusType.Executing) || deletePlanResult.isLoading
+                hasCondition(conditions, PlanStatusType.Executing) ||
+                deletePlanMutationResult.isLoading
               }
               onClick={() => {
                 setKebabIsOpen(false);
@@ -107,7 +111,7 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
         isOpen={isDeleteModalOpen}
         toggleOpen={toggleDeleteModal}
         mutateFn={() => deletePlan(plan)}
-        mutateResult={deletePlanResult}
+        mutateResult={deletePlanMutationResult}
         title="Delete migration plan"
         confirmButtonText="Delete"
         body={

--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -28,8 +28,7 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
   const [isDetailsModalOpen, toggleDetailsModal] = React.useReducer((isOpen) => !isOpen, false);
-  const deletePlanMutationResult = useDeletePlanMutation(toggleDeleteModal);
-  const { mutate: deletePlan } = deletePlanMutationResult;
+  const deletePlanMutation = useDeletePlanMutation(toggleDeleteModal);
   const history = useHistory();
   const conditions = plan.status?.conditions || [];
   const clusterProvidersQuery = useClusterProvidersQuery();
@@ -70,21 +69,19 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
           <ConditionalTooltip
             key="Delete"
             isTooltipEnabled={
-              hasCondition(conditions, PlanStatusType.Executing) ||
-              deletePlanMutationResult.isLoading
+              hasCondition(conditions, PlanStatusType.Executing) || deletePlanMutation.isLoading
             }
             content={
               hasCondition(conditions, PlanStatusType.Executing)
                 ? 'This plan cannot be deleted because it is running'
-                : deletePlanMutationResult.isLoading
+                : deletePlanMutation.isLoading
                 ? 'This plan cannot be deleted because it is deleting'
                 : ''
             }
           >
             <DropdownItem
               isDisabled={
-                hasCondition(conditions, PlanStatusType.Executing) ||
-                deletePlanMutationResult.isLoading
+                hasCondition(conditions, PlanStatusType.Executing) || deletePlanMutation.isLoading
               }
               onClick={() => {
                 setKebabIsOpen(false);
@@ -109,8 +106,8 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
       <ConfirmModal
         isOpen={isDeleteModalOpen}
         toggleOpen={toggleDeleteModal}
-        mutateFn={() => deletePlan(plan)}
-        mutateResult={deletePlanMutationResult}
+        mutateFn={() => deletePlanMutation.mutate(plan)}
+        mutateResult={deletePlanMutation}
         title="Delete migration plan"
         confirmButtonText="Delete"
         body={

--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -28,7 +28,6 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
   const [isDetailsModalOpen, toggleDetailsModal] = React.useReducer((isOpen) => !isOpen, false);
-  // const [deletePlan, deletePlanResult] = useDeletePlanMutation(toggleDeleteModal);
   const deletePlanMutationResult = useDeletePlanMutation(toggleDeleteModal);
   const { mutate: deletePlan } = deletePlanMutationResult;
   const history = useHistory();

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -221,12 +221,10 @@ const VMMigrationDetails: React.FunctionComponent = () => {
 
   const [isCancelModalOpen, toggleCancelModal] = React.useReducer((isOpen) => !isOpen, false);
 
-  const cancelVMsMutationResult = useCancelVMsMutation(plan || null, () => {
+  const cancelVMsMutation = useCancelVMsMutation(plan || null, () => {
     toggleCancelModal();
     setSelectedItems([]);
   });
-
-  const { mutate: cancelVMs } = cancelVMsMutationResult;
 
   const { toggleItemSelected: toggleVMExpanded, isItemSelected: isVMExpanded } =
     useSelectionState<IVMStatus>({
@@ -348,7 +346,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
                     toolbarItems={
                       <Button
                         variant="secondary"
-                        isDisabled={selectedItems.length === 0 || cancelVMsMutationResult.isLoading}
+                        isDisabled={selectedItems.length === 0 || cancelVMsMutation.isLoading}
                         onClick={toggleCancelModal}
                       >
                         Cancel
@@ -408,9 +406,9 @@ const VMMigrationDetails: React.FunctionComponent = () => {
         mutateFn={() => {
           const vmsToCancel = selectedItems.map((vmStatus) => findVMById(vmStatus.id, vmsQuery));
           if (vmsToCancel.some((vm) => !vm)) return;
-          cancelVMs(vmsToCancel as SourceVM[]);
+          cancelVMsMutation.mutate(vmsToCancel as SourceVM[]);
         }}
-        mutateResult={cancelVMsMutationResult}
+        mutateResult={cancelVMsMutation}
         title="Cancel migrations?"
         confirmButtonText="Yes, cancel"
         cancelButtonText="No, keep migrating"

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -220,10 +220,13 @@ const VMMigrationDetails: React.FunctionComponent = () => {
     isSelected ? setSelectedItems(cancelableVMs) : setSelectedItems([]);
 
   const [isCancelModalOpen, toggleCancelModal] = React.useReducer((isOpen) => !isOpen, false);
-  const [cancelVMs, cancelVMsResult] = useCancelVMsMutation(plan || null, () => {
+
+  const cancelVMsMutationResult = useCancelVMsMutation(plan || null, () => {
     toggleCancelModal();
     setSelectedItems([]);
   });
+
+  const { mutate: cancelVMs } = cancelVMsMutationResult;
 
   const { toggleItemSelected: toggleVMExpanded, isItemSelected: isVMExpanded } =
     useSelectionState<IVMStatus>({
@@ -345,7 +348,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
                     toolbarItems={
                       <Button
                         variant="secondary"
-                        isDisabled={selectedItems.length === 0 || cancelVMsResult.isLoading}
+                        isDisabled={selectedItems.length === 0 || cancelVMsMutationResult.isLoading}
                         onClick={toggleCancelModal}
                       >
                         Cancel
@@ -407,7 +410,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
           if (vmsToCancel.some((vm) => !vm)) return;
           cancelVMs(vmsToCancel as SourceVM[]);
         }}
-        mutateResult={cancelVMsResult}
+        mutateResult={cancelVMsMutationResult}
         title="Cancel migrations?"
         confirmButtonText="Yes, cancel"
         cancelButtonText="No, keep migrating"

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -38,7 +38,6 @@ import {
 import { isSameResource } from '@app/queries/helpers';
 
 import './MappingForm.css';
-import { QueryStatus } from 'react-query';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { isMappingValid } from '@app/Mappings/components/helpers';
 import ConditionalTooltip from '@app/common/components/ConditionalTooltip';
@@ -73,7 +72,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
 
   const hasInitialized = React.useRef(false);
   React.useEffect(() => {
-    if (!hasInitialized.current && mappingResourceQueries.status === QueryStatus.Success) {
+    if (!hasInitialized.current && mappingResourceQueries.status === 'success') {
       hasInitialized.current = true;
       if (form.values.builderItems.length > 0) {
         form.fields.builderItems.setValue(

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -215,26 +215,16 @@ const PlanWizard: React.FunctionComponent = () => {
   const patchPlanMutationResult = usePatchPlanMutation();
   const { mutate: patchPlan } = patchPlanMutationResult;
 
-  // const {
-  //   network: [createSharedNetworkMap, createSharedNetworkMapResult],
-  //   storage: [createSharedStorageMap, createSharedStorageMapResult],
-  // } = useCreateMappingMutations();
-
-  const createMappingMutationResult = useCreateMappingMutations();
-  const { mutate: createSharedNetworkMap } = createMappingMutationResult.network;
-  const { mutate: createSharedStorageMap } = createMappingMutationResult.storage;
-  let createSharedNetworkMapResult;
-  let createSharedStorageMapResult;
+  const { network: createSharedNetworkMapMutation, storage: createSharedStorageMapMutation } =
+    useCreateMappingMutations();
 
   const createSharedMappings = async () => {
     const { networkMapping, storageMapping } = generateMappings({ forms });
     if (networkMapping && forms.networkMapping.values.isSaveNewMapping) {
-      createSharedNetworkMapResult = createSharedNetworkMap(networkMapping);
-      // TODO: needs more testing
+      createSharedNetworkMapMutation.mutate(networkMapping);
     }
     if (storageMapping && forms.storageMapping.values.isSaveNewMapping) {
-      createSharedStorageMapResult = createSharedStorageMap(storageMapping);
-      // TODO: needs more testing
+      createSharedStorageMapMutation.mutate(storageMapping);
     }
   };
 
@@ -249,8 +239,8 @@ const PlanWizard: React.FunctionComponent = () => {
 
   const allMutationResults = [
     !editRouteMatch ? createPlanMutationResult : patchPlanMutationResult,
-    ...(forms.networkMapping.values.isSaveNewMapping ? [createSharedNetworkMapResult] : []),
-    ...(forms.storageMapping.values.isSaveNewMapping ? [createSharedStorageMapResult] : []),
+    ...(forms.networkMapping.values.isSaveNewMapping ? [createSharedNetworkMapMutation] : []),
+    ...(forms.storageMapping.values.isSaveNewMapping ? [createSharedStorageMapMutation] : []),
   ];
   const allMutationErrorTitles = [
     !editRouteMatch ? 'Error creating migration plan' : 'Error saving migration plan',

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -209,11 +209,8 @@ const PlanWizard: React.FunctionComponent = () => {
 
   const onClose = () => history.push('/plans');
 
-  const createPlanMutationResult = useCreatePlanMutation();
-  const { mutate: createPlan } = createPlanMutationResult;
-
-  const patchPlanMutationResult = usePatchPlanMutation();
-  const { mutate: patchPlan } = patchPlanMutationResult;
+  const createPlanMutation = useCreatePlanMutation();
+  const patchPlanMutation = usePatchPlanMutation();
 
   const { network: createSharedNetworkMapMutation, storage: createSharedStorageMapMutation } =
     useCreateMappingMutations();
@@ -230,15 +227,15 @@ const PlanWizard: React.FunctionComponent = () => {
 
   const onSave = () => {
     if (!planBeingEdited) {
-      createPlan(forms);
+      createPlanMutation.mutate(forms);
     } else {
-      patchPlan({ planBeingEdited, forms });
+      patchPlanMutation.mutate({ planBeingEdited, forms });
     }
     createSharedMappings();
   };
 
   const allMutationResults = [
-    !editRouteMatch ? createPlanMutationResult : patchPlanMutationResult,
+    !editRouteMatch ? createPlanMutation : patchPlanMutation,
     ...(forms.networkMapping.values.isSaveNewMapping ? [createSharedNetworkMapMutation] : []),
     ...(forms.storageMapping.values.isSaveNewMapping ? [createSharedStorageMapMutation] : []),
   ];

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -3,7 +3,7 @@ import { TextContent, Text, Form } from '@patternfly/react-core';
 
 import { PlanWizardFormState } from './PlanWizard';
 import { IPlan, SourceVM, Mapping } from '@app/queries/types';
-import { MutationResult } from 'react-query';
+import { UseMutationResult } from 'react-query';
 import { IKubeResponse, KubeClientError } from '@app/client/types';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { generateMappings, generatePlan } from './helpers';
@@ -14,8 +14,8 @@ import PlanDetails from '../PlanDetails';
 interface IReviewProps {
   forms: PlanWizardFormState;
   allMutationResults: (
-    | MutationResult<IKubeResponse<IPlan>, KubeClientError>
-    | MutationResult<IKubeResponse<Mapping>, KubeClientError>
+    | UseMutationResult<IKubeResponse<IPlan>, KubeClientError>
+    | UseMutationResult<IKubeResponse<Mapping>, KubeClientError>
   )[];
   allMutationErrorTitles: string[];
   planBeingEdited: IPlan | null;

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -2,21 +2,17 @@ import * as React from 'react';
 import { TextContent, Text, Form } from '@patternfly/react-core';
 
 import { PlanWizardFormState } from './PlanWizard';
-import { IPlan, SourceVM, Mapping } from '@app/queries/types';
-import { UseMutationResult } from 'react-query';
-import { IKubeResponse, KubeClientError } from '@app/client/types';
+import { IPlan, SourceVM } from '@app/queries/types';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { generateMappings, generatePlan } from './helpers';
 import { usePausedPollingEffect } from '@app/common/context';
 import { useNamespacesQuery } from '@app/queries';
 import PlanDetails from '../PlanDetails';
+import { UnknownResult } from '@app/common/types';
 
 interface IReviewProps {
   forms: PlanWizardFormState;
-  allMutationResults: (
-    | UseMutationResult<IKubeResponse<IPlan>, KubeClientError>
-    | UseMutationResult<IKubeResponse<Mapping>, KubeClientError>
-  )[];
+  allMutationResults: UnknownResult[];
   allMutationErrorTitles: string[];
   planBeingEdited: IPlan | null;
   selectedVMs: SourceVM[];

--- a/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -4,20 +4,23 @@ import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import '@testing-library/jest-dom';
 import { Router } from 'react-router-dom';
-
+import { QueryClientProvider, QueryClient } from 'react-query';
 import { NetworkContextProvider } from '@app/common/context';
 import PlanWizard from '../PlanWizard';
+const queryClient = new QueryClient();
 
 describe('<AddEditProviderModal />', () => {
   const history = createMemoryHistory();
 
   it('allows to cancel a plan wizard', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <PlanWizard />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <PlanWizard />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const cancelButton = await screen.findByRole('button', { name: /Cancel/ });
@@ -26,11 +29,13 @@ describe('<AddEditProviderModal />', () => {
 
   it('allows to create a plan', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <PlanWizard />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <PlanWizard />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const name = await screen.findByRole('textbox', { name: /plan name/i });
@@ -73,11 +78,13 @@ describe('<AddEditProviderModal />', () => {
     const history = createMemoryHistory();
     history.push('/plans/plantest-02/edit');
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <PlanWizard />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <PlanWizard />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     await waitFor(() => {

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -41,7 +41,7 @@ import {
   useHooksQuery,
   useSourceVMsQuery,
 } from '@app/queries';
-import { QueryResult, QueryStatus } from 'react-query';
+import { UseQueryResult, QueryStatus } from 'react-query';
 import { StatusType } from '@konveyor/lib-ui';
 import { PlanHookInstance } from './PlanAddEditHookModal';
 import { IKubeList } from '@app/client/types';
@@ -428,7 +428,7 @@ export const generatePlan = (
 
 export const getSelectedVMsFromIds = (
   vmIds: string[],
-  vmsQuery: QueryResult<SourceVM[]>
+  vmsQuery: UseQueryResult<SourceVM[]>
 ): SourceVM[] =>
   vmIds.flatMap((id) => {
     const matchingVM = vmsQuery.data?.find((vm) => vm.id === id);
@@ -437,7 +437,7 @@ export const getSelectedVMsFromIds = (
 
 export const getSelectedVMsFromPlan = (
   planBeingEdited: IPlan | null,
-  vmsQuery: QueryResult<SourceVM[]>
+  vmsQuery: UseQueryResult<SourceVM[]>
 ): SourceVM[] => {
   if (!planBeingEdited) return [];
   const vmIds = planBeingEdited.spec.vms.map(({ id }) => id);
@@ -448,7 +448,7 @@ interface IEditingPrefillResults {
   prefillQueryStatus: QueryStatus;
   prefillQueryError: unknown;
   isDonePrefilling: boolean;
-  prefillQueries: QueryResult<unknown>[];
+  prefillQueries: UseQueryResult<unknown>[];
   prefillErrorTitles: string[];
 }
 
@@ -510,7 +510,7 @@ export const useEditingPlanPrefillEffect = (
   const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
   const [isDonePrefilling, setIsDonePrefilling] = React.useState(!isEditMode);
   React.useEffect(() => {
-    if (!isStartedPrefilling && queryStatus === QueryStatus.Success && planBeingEdited) {
+    if (!isStartedPrefilling && queryStatus === 'success' && planBeingEdited) {
       setIsStartedPrefilling(true);
       const selectedVMs = getSelectedVMsFromPlan(planBeingEdited, vmsQuery);
       const selectedTreeNodes = findNodesMatchingSelectedVMs(
@@ -640,7 +640,7 @@ export const generateHook = (
 
 export const getPlanHookFormInstances = (
   plan: IPlan,
-  hooksQuery: QueryResult<IKubeList<IHook>>
+  hooksQuery: UseQueryResult<IKubeList<IHook>>
 ): PlanHookInstance[] => {
   if (plan.spec.vms.length === 0) return [];
   const planHookRefs = plan.spec.vms[0].hooks || [];

--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -4,7 +4,7 @@ import { hasCondition } from '@app/common/helpers';
 import { isSameResource } from '@app/queries/helpers';
 import { IPlan } from '@app/queries/types';
 import { IMigration } from '@app/queries/types/migrations.types';
-import { QueryResult } from 'react-query';
+import { UseQueryResult } from 'react-query';
 
 export const getPlanStatusTitle = (plan: IPlan): string => {
   const condition = plan.status?.conditions.find(
@@ -30,7 +30,7 @@ type WarmPlanState =
 export const getWarmPlanState = (
   plan: IPlan | null,
   migration: IMigration | null,
-  migrationsQuery: QueryResult<IKubeList<IMigration>>
+  migrationsQuery: UseQueryResult<IKubeList<IMigration>>
 ): WarmPlanState | null => {
   if (!plan || !plan.spec.warm) return null;
   if (!migration) return 'NotStarted';
@@ -92,7 +92,7 @@ export const canPlanBeStarted = (plan: IPlan): boolean => {
 export const isPlanBeingStarted = (
   plan: IPlan,
   latestMigrationInHistory: IMigration | null,
-  migrationsQuery: QueryResult<IKubeList<IMigration>>
+  migrationsQuery: UseQueryResult<IKubeList<IMigration>>
 ): boolean => {
   // True if we just don't have any status data yet
   if (

--- a/src/app/Providers/ProvidersPage.tsx
+++ b/src/app/Providers/ProvidersPage.tsx
@@ -27,7 +27,6 @@ import AddEditProviderModal from './components/AddEditProviderModal';
 import { IPlan, IProviderObject } from '@app/queries/types';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { getAggregateQueryStatus } from '@app/queries/helpers';
-import { QueryStatus } from 'react-query';
 import { useRouteMatch } from 'react-router';
 
 export const EditProviderContext = React.createContext({
@@ -63,7 +62,7 @@ const ProvidersPage: React.FunctionComponent = () => {
   const clusterProviders = clusterProvidersQuery.data?.items || [];
   const areProvidersEmpty = clusterProviders.length === 0;
 
-  const areTabsVisible = queryStatus !== QueryStatus.Loading && !areProvidersEmpty;
+  const areTabsVisible = queryStatus !== 'loading' && !areProvidersEmpty;
 
   const availableProviderTypes = Array.from(
     new Set(clusterProviders.map((provider) => provider.spec.type))

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -136,21 +136,20 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
       >)
     : null;
 
-  // const [createProvider, createProviderResult] = useCreateProviderMutation(providerType, onClose);
-  const createProviderMutationResult = useCreateProviderMutation(providerType, onClose);
-  const { mutate: createProvider } = createProviderMutationResult;
+  const createProviderMutation = useCreateProviderMutation(providerType, onClose);
 
-  const patchProviderMutationResult = usePatchProviderMutation(
+  const patchProviderMutation = usePatchProviderMutation(
     providerType,
     providerBeingEdited,
     onClose
   );
-  const { mutate: patchProvider } = patchProviderMutationResult;
 
-  const mutateProvider = !providerBeingEdited ? createProvider : patchProvider;
+  const mutateProvider = !providerBeingEdited
+    ? createProviderMutation.mutate
+    : patchProviderMutation.mutate;
   const mutateProviderResult = !providerBeingEdited
-    ? createProviderMutationResult
-    : patchProviderMutationResult;
+    ? createProviderMutation
+    : patchProviderMutation;
 
   return (
     <Modal

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -37,10 +37,8 @@ import {
 } from '@app/queries';
 
 import { IProviderObject } from '@app/queries/types';
-import { QueryResult } from 'react-query';
 import { HelpIcon } from '@patternfly/react-icons';
 import { QuerySpinnerMode, ResolvedQuery } from '@app/common/components/ResolvedQuery';
-import { IKubeList } from '@app/client/types';
 import { useEditProviderPrefillEffect } from './helpers';
 import LoadingEmptyState from '@app/common/components/LoadingEmptyState';
 import ValidatedPasswordInput from '@app/common/components/ValidatedPasswordInput';
@@ -56,7 +54,7 @@ const PROVIDER_TYPE_OPTIONS = PROVIDER_TYPES.map((type) => ({
 })) as OptionWithValue<ProviderType>[];
 
 const useAddProviderFormState = (
-  clusterProvidersQuery: QueryResult<IKubeList<IProviderObject>>,
+  clusterProvidersQuery: ReturnType<typeof useClusterProvidersQuery>,
   providerBeingEdited: IProviderObject | null
 ) => {
   const providerTypeField = useFormField<ProviderType | null>(
@@ -138,14 +136,26 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
       >)
     : null;
 
-  const [createProvider, createProviderResult] = useCreateProviderMutation(providerType, onClose);
-  const [patchProvider, patchProviderResult] = usePatchProviderMutation(
+  // const [createProvider, createProviderResult] = useCreateProviderMutation(providerType, onClose);
+  const createProviderMutationResult = useCreateProviderMutation(providerType, onClose);
+  const { mutate: createProvider } = createProviderMutationResult;
+
+  // const [patchProvider, patchProviderResult] = usePatchProviderMutation(
+  //   providerType,
+  //   providerBeingEdited,
+  //   onClose
+  // );
+  const patchProviderMutationResult = usePatchProviderMutation(
     providerType,
     providerBeingEdited,
     onClose
   );
+  const { mutate: patchProvider } = patchProviderMutationResult;
+
   const mutateProvider = !providerBeingEdited ? createProvider : patchProvider;
-  const mutateProviderResult = !providerBeingEdited ? createProviderResult : patchProviderResult;
+  const mutateProviderResult = !providerBeingEdited
+    ? createProviderMutationResult
+    : patchProviderMutationResult;
 
   return (
     <Modal

--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -140,11 +140,6 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
   const createProviderMutationResult = useCreateProviderMutation(providerType, onClose);
   const { mutate: createProvider } = createProviderMutationResult;
 
-  // const [patchProvider, patchProviderResult] = usePatchProviderMutation(
-  //   providerType,
-  //   providerBeingEdited,
-  //   onClose
-  // );
   const patchProviderMutationResult = usePatchProviderMutation(
     providerType,
     providerBeingEdited,

--- a/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import '@testing-library/jest-dom';
 import { Router } from 'react-router-dom';
+import { QueryClientProvider, QueryClient } from 'react-query';
+const queryClient = new QueryClient();
 
 import { NetworkContextProvider } from '@app/common/context';
 import AddEditProviderModal from '../AddEditProviderModal';
@@ -21,11 +23,13 @@ describe('<AddEditProviderModal />', () => {
 
   it('allows to cancel addition/edition of a provider', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <AddEditProviderModal {...props} providerBeingEdited={null} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <AddEditProviderModal {...props} providerBeingEdited={null} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const cancelButton = await screen.findByRole('button', { name: /Cancel/ });
@@ -36,11 +40,13 @@ describe('<AddEditProviderModal />', () => {
 
   it('allows adding a vsphere provider', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <AddEditProviderModal {...props} providerBeingEdited={null} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <AddEditProviderModal {...props} providerBeingEdited={null} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const typeButton = await screen.findByRole('button', { name: /select a provider type/i });
@@ -75,11 +81,13 @@ describe('<AddEditProviderModal />', () => {
 
   it('fails to add a vsphere provider with wrong values', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <AddEditProviderModal {...props} providerBeingEdited={null} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <AddEditProviderModal {...props} providerBeingEdited={null} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const typeButton = await screen.findByRole('button', { name: /select a provider type/i });
@@ -114,11 +122,13 @@ describe('<AddEditProviderModal />', () => {
 
   it('allows editing a vsphere provider', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <AddEditProviderModal {...props} providerBeingEdited={MOCK_CLUSTER_PROVIDERS[0]} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <AddEditProviderModal {...props} providerBeingEdited={MOCK_CLUSTER_PROVIDERS[0]} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const editButton = await screen.findByRole('dialog', { name: /Edit provider/ });
@@ -131,11 +141,13 @@ describe('<AddEditProviderModal />', () => {
 
   it('allows to add an openshift provider', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <AddEditProviderModal {...props} providerBeingEdited={null} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <AddEditProviderModal {...props} providerBeingEdited={null} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const typeButton = await screen.findByRole('button', { name: /select a provider type/i });
@@ -161,11 +173,13 @@ describe('<AddEditProviderModal />', () => {
 
   it('fails to add an openshift provider with wrong values', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <AddEditProviderModal {...props} providerBeingEdited={null} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <AddEditProviderModal {...props} providerBeingEdited={null} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const typeButton = await screen.findByRole('button', { name: /select a provider type/i });
@@ -191,11 +205,13 @@ describe('<AddEditProviderModal />', () => {
 
   it('allows editing an openshift provider', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <AddEditProviderModal {...props} providerBeingEdited={MOCK_CLUSTER_PROVIDERS[4]} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <AddEditProviderModal {...props} providerBeingEdited={MOCK_CLUSTER_PROVIDERS[4]} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const editButton = await screen.findByRole('dialog', { name: /Edit provider/ });

--- a/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
@@ -25,7 +25,7 @@ import { centerCellTransform } from '@app/utils/utils';
 
 import './OpenShiftProvidersTable.css';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { PlanStatusType, ProviderType } from '@app/common/constants';
+import { PlanStatusType } from '@app/common/constants';
 import { isSameResource } from '@app/queries/helpers';
 import OpenShiftNetworkList from './OpenShiftNetworkList';
 import SelectOpenShiftNetworkModal from '@app/common/components/SelectOpenShiftNetworkModal';
@@ -180,16 +180,17 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
     (isOpen) => !isOpen,
     false
   );
-  const [setMigrationNetwork, migrationNetworkMutationResult] = useOCPMigrationNetworkMutation(
-    () => {
-      toggleSelectNetworkModal();
-      setExpandedItem({
-        provider: selectedProvider as ICorrelatedProvider<IOpenShiftProvider>,
-        column: 'Networks',
-      });
-      setSelectedProvider(null);
-    }
-  );
+
+  const migrationNetworkMutationResult = useOCPMigrationNetworkMutation(() => {
+    toggleSelectNetworkModal();
+    setExpandedItem({
+      provider: selectedProvider as ICorrelatedProvider<IOpenShiftProvider>,
+      column: 'Networks',
+    });
+    setSelectedProvider(null);
+  });
+
+  const { mutate: setMigrationNetwork } = migrationNetworkMutationResult;
 
   const selectedNetworkName =
     (selectedProvider?.metadata.annotations &&

--- a/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
@@ -181,7 +181,7 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
     false
   );
 
-  const migrationNetworkMutationResult = useOCPMigrationNetworkMutation(() => {
+  const migrationNetworkMutation = useOCPMigrationNetworkMutation(() => {
     toggleSelectNetworkModal();
     setExpandedItem({
       provider: selectedProvider as ICorrelatedProvider<IOpenShiftProvider>,
@@ -189,8 +189,6 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
     });
     setSelectedProvider(null);
   });
-
-  const { mutate: setMigrationNetwork } = migrationNetworkMutationResult;
 
   const selectedNetworkName =
     (selectedProvider?.metadata.annotations &&
@@ -252,13 +250,16 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
           instructions="Select a default migration network for the provider. This network will be used for migrating data to all namespaces to which it is attached."
           onClose={() => {
             toggleSelectNetworkModal();
-            migrationNetworkMutationResult.reset();
+            migrationNetworkMutation.reset();
             setSelectedProvider(null);
           }}
           onSubmit={(network) =>
-            setMigrationNetwork({ provider: selectedProvider?.inventory || null, network })
+            migrationNetworkMutation.mutate({
+              provider: selectedProvider?.inventory || null,
+              network,
+            })
           }
-          mutationResult={migrationNetworkMutationResult}
+          mutationResult={migrationNetworkMutation}
         />
       ) : null}
     </>

--- a/src/app/Providers/components/ProvidersTable/OpenShift/__tests__/OpenShiftProvidersTable.test.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/__tests__/OpenShiftProvidersTable.test.tsx
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import '@testing-library/jest-dom';
 import { Router } from 'react-router-dom';
+import { QueryClientProvider, QueryClient } from 'react-query';
+const queryClient = new QueryClient();
 
 import { NetworkContextProvider } from '@app/common/context';
 import OpenShiftProvidersTable from '../OpenShiftProvidersTable';
@@ -25,11 +27,13 @@ describe('<OpenShiftProvidersTable />', () => {
 
   it('renders openshift table', () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <OpenShiftProvidersTable {...props} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <OpenShiftProvidersTable {...props} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     expect(
@@ -43,11 +47,13 @@ describe('<OpenShiftProvidersTable />', () => {
   // The expanding section doesn't render, is it the right button?
   it.skip('renders storage classes', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <OpenShiftProvidersTable {...props} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <OpenShiftProvidersTable {...props} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     const sharedClasses = screen.getAllByRole('button', { name: '0' });
@@ -60,11 +66,13 @@ describe('<OpenShiftProvidersTable />', () => {
 
   it('renders status condition', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <OpenShiftProvidersTable {...props} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <OpenShiftProvidersTable {...props} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     userEvent.click(screen.getByRole('button', { name: /Critical/ }));
@@ -76,11 +84,13 @@ describe('<OpenShiftProvidersTable />', () => {
 
   it('renders action menu', async () => {
     render(
-      <NetworkContextProvider>
-        <Router history={history}>
-          <OpenShiftProvidersTable {...props} />
-        </Router>
-      </NetworkContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <OpenShiftProvidersTable {...props} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
     );
 
     userEvent.click(screen.getAllByRole('button', { name: /Actions/ })[0]);

--- a/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
+++ b/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
@@ -21,9 +21,7 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
 
-  const deleteProviderMutationResult = useDeleteProviderMutation(providerType, toggleDeleteModal);
-
-  const { mutate: deleteProvider } = deleteProviderMutationResult;
+  const deleteProviderMutation = useDeleteProviderMutation(providerType, toggleDeleteModal);
 
   const { openEditProviderModal, plans } = React.useContext(EditProviderContext);
   const hasRunningMigration = !!plans
@@ -82,7 +80,7 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
                 setKebabIsOpen(false);
                 toggleDeleteModal();
               }}
-              isDisabled={deleteProviderMutationResult.isLoading || isEditDeleteDisabled}
+              isDisabled={deleteProviderMutation.isLoading || isEditDeleteDisabled}
             >
               Remove
             </DropdownItem>
@@ -93,8 +91,8 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
       <ConfirmModal
         isOpen={isDeleteModalOpen}
         toggleOpen={toggleDeleteModal}
-        mutateFn={() => deleteProvider(provider)}
-        mutateResult={deleteProviderMutationResult}
+        mutateFn={() => deleteProviderMutation.mutate(provider)}
+        mutateResult={deleteProviderMutation}
         title="Remove provider"
         confirmButtonText="Remove"
         body={

--- a/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
+++ b/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
@@ -20,10 +20,11 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
 }: IProviderActionsDropdownProps) => {
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
-  const [deleteProvider, deleteProviderResult] = useDeleteProviderMutation(
-    providerType,
-    toggleDeleteModal
-  );
+
+  const deleteProviderMutationResult = useDeleteProviderMutation(providerType, toggleDeleteModal);
+
+  const { mutate: deleteProvider } = deleteProviderMutationResult;
+
   const { openEditProviderModal, plans } = React.useContext(EditProviderContext);
   const hasRunningMigration = !!plans
     .filter((plan) => hasCondition(plan.status?.conditions || [], PlanStatusType.Executing))
@@ -81,7 +82,7 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
                 setKebabIsOpen(false);
                 toggleDeleteModal();
               }}
-              isDisabled={deleteProviderResult.isLoading || isEditDeleteDisabled}
+              isDisabled={deleteProviderMutationResult.isLoading || isEditDeleteDisabled}
             >
               Remove
             </DropdownItem>
@@ -93,7 +94,7 @@ const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownP
         isOpen={isDeleteModalOpen}
         toggleOpen={toggleDeleteModal}
         mutateFn={() => deleteProvider(provider)}
-        mutateResult={deleteProviderResult}
+        mutateResult={deleteProviderMutationResult}
         title="Remove provider"
         confirmButtonText="Remove"
         body={

--- a/src/app/Providers/components/ProvidersTable/Source/__tests__/SourceProvidersTable.test.tsx
+++ b/src/app/Providers/components/ProvidersTable/Source/__tests__/SourceProvidersTable.test.tsx
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import '@testing-library/jest-dom';
 import { Router } from 'react-router-dom';
+import { QueryClientProvider, QueryClient } from 'react-query';
+const queryClient = new QueryClient();
 
 import SourceProvidersTable from '../SourceProvidersTable';
 import {
@@ -24,9 +26,11 @@ describe('<SourceProvidersTable />', () => {
 
   it('renders vsphere table', () => {
     render(
-      <Router history={history}>
-        <SourceProvidersTable {...props} providerType="vsphere" />
-      </Router>
+      <QueryClientProvider client={queryClient}>
+        <Router history={history}>
+          <SourceProvidersTable {...props} providerType="vsphere" />
+        </Router>
+      </QueryClientProvider>
     );
 
     expect(screen.getByRole('grid', { name: /VMware providers table/ })).toBeInTheDocument();
@@ -49,9 +53,11 @@ describe('<SourceProvidersTable />', () => {
 
   it('renders Hosts links', () => {
     render(
-      <Router history={history}>
-        <SourceProvidersTable {...props} providerType="vsphere" />
-      </Router>
+      <QueryClientProvider client={queryClient}>
+        <Router history={history}>
+          <SourceProvidersTable {...props} providerType="vsphere" />
+        </Router>
+      </QueryClientProvider>
     );
 
     const links = screen.getAllByRole('link');
@@ -61,9 +67,11 @@ describe('<SourceProvidersTable />', () => {
 
   it('renders status condition', async () => {
     render(
-      <Router history={history}>
-        <SourceProvidersTable {...props} providerType="vsphere" />
-      </Router>
+      <QueryClientProvider client={queryClient}>
+        <Router history={history}>
+          <SourceProvidersTable {...props} providerType="vsphere" />
+        </Router>
+      </QueryClientProvider>
     );
 
     userEvent.click(screen.getByRole('button', { name: /Critical/ }));
@@ -75,9 +83,11 @@ describe('<SourceProvidersTable />', () => {
 
   it('renders action menu', async () => {
     render(
-      <Router history={history}>
-        <SourceProvidersTable {...props} providerType="vsphere" />
-      </Router>
+      <QueryClientProvider client={queryClient}>
+        <Router history={history}>
+          <SourceProvidersTable {...props} providerType="vsphere" />
+        </Router>
+      </QueryClientProvider>
     );
 
     userEvent.click(screen.getAllByRole('button', { name: /Actions/ })[0]);

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -57,12 +57,13 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
   commonNetworkAdapters,
   onClose,
 }: ISelectNetworkModalProps) => {
-  const [configureHosts, configureHostsResult] = useConfigureHostsMutation(
+  const configureHostMutationResult = useConfigureHostsMutation(
     provider,
     selectedHosts,
     hostConfigs,
     onClose
   );
+  const { mutate: configureHosts } = configureHostMutationResult;
 
   const form = useSelectNetworkFormState(selectedHosts);
   const { isDonePrefilling } = usePrefillHostConfigEffect(
@@ -93,7 +94,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
       footer={
         <Stack hasGutter>
           <ResolvedQuery
-            result={configureHostsResult}
+            result={configureHostMutationResult}
             errorTitle="Error configuring hosts"
             spinnerMode={QuerySpinnerMode.Inline}
           />
@@ -102,7 +103,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
               id="modal-confirm-button"
               key="confirm"
               variant="primary"
-              isDisabled={!form.isDirty || !form.isValid || configureHostsResult.isLoading}
+              isDisabled={!form.isDirty || !form.isValid || configureHostMutationResult.isLoading}
               onClick={() => {
                 if (form.isValid) {
                   configureHosts(form.values);
@@ -116,7 +117,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
               key="cancel"
               variant="link"
               onClick={onClose}
-              isDisabled={configureHostsResult.isLoading}
+              isDisabled={configureHostMutationResult.isLoading}
             >
               Cancel
             </Button>

--- a/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -57,13 +57,12 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
   commonNetworkAdapters,
   onClose,
 }: ISelectNetworkModalProps) => {
-  const configureHostMutationResult = useConfigureHostsMutation(
+  const configureHostMutation = useConfigureHostsMutation(
     provider,
     selectedHosts,
     hostConfigs,
     onClose
   );
-  const { mutate: configureHosts } = configureHostMutationResult;
 
   const form = useSelectNetworkFormState(selectedHosts);
   const { isDonePrefilling } = usePrefillHostConfigEffect(
@@ -94,7 +93,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
       footer={
         <Stack hasGutter>
           <ResolvedQuery
-            result={configureHostMutationResult}
+            result={configureHostMutation}
             errorTitle="Error configuring hosts"
             spinnerMode={QuerySpinnerMode.Inline}
           />
@@ -103,10 +102,10 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
               id="modal-confirm-button"
               key="confirm"
               variant="primary"
-              isDisabled={!form.isDirty || !form.isValid || configureHostMutationResult.isLoading}
+              isDisabled={!form.isDirty || !form.isValid || configureHostMutation.isLoading}
               onClick={() => {
                 if (form.isValid) {
-                  configureHosts(form.values);
+                  configureHostMutation.mutate(form.values);
                 }
               }}
             >
@@ -117,7 +116,7 @@ const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProps> = ({
               key="cancel"
               variant="link"
               onClick={onClose}
-              isDisabled={configureHostMutationResult.isLoading}
+              isDisabled={configureHostMutation.isLoading}
             >
               Cancel
             </Button>

--- a/src/app/common/components/ConfirmModal.tsx
+++ b/src/app/common/components/ConfirmModal.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Modal, Stack, Flex, Button } from '@patternfly/react-core';
-import { MutationResult } from 'react-query';
+import { UseMutationResult } from 'react-query';
 import { QuerySpinnerMode, ResolvedQuery } from './ResolvedQuery';
+import { IKubeResponse, KubeClientError } from '@app/client/types';
 
 // TODO lib-ui candidate
 
@@ -9,7 +10,7 @@ interface IConfirmModalProps {
   isOpen: boolean;
   toggleOpen: () => void;
   mutateFn: () => void;
-  mutateResult?: MutationResult<unknown>;
+  mutateResult?: UseMutationResult<IKubeResponse<unknown>, KubeClientError, any, unknown>;
   title: string;
   body: React.ReactNode;
   confirmButtonText: string;

--- a/src/app/common/components/ConfirmModal.tsx
+++ b/src/app/common/components/ConfirmModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Modal, Stack, Flex, Button } from '@patternfly/react-core';
 import { QuerySpinnerMode, ResolvedQuery } from './ResolvedQuery';
-import { MutationResultSubset } from '../types';
+import { UnknownMutationResult } from '../types';
 
 // TODO lib-ui candidate
 
@@ -9,7 +9,7 @@ interface IConfirmModalProps {
   isOpen: boolean;
   toggleOpen: () => void;
   mutateFn: () => void;
-  mutateResult?: MutationResultSubset;
+  mutateResult?: UnknownMutationResult;
   title: string;
   body: React.ReactNode;
   confirmButtonText: string;

--- a/src/app/common/components/ConfirmModal.tsx
+++ b/src/app/common/components/ConfirmModal.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Modal, Stack, Flex, Button } from '@patternfly/react-core';
-import { UseMutationResult } from 'react-query';
 import { QuerySpinnerMode, ResolvedQuery } from './ResolvedQuery';
-import { IKubeResponse, KubeClientError } from '@app/client/types';
+import { MutationResultSubset } from '../types';
 
 // TODO lib-ui candidate
 
@@ -10,7 +9,7 @@ interface IConfirmModalProps {
   isOpen: boolean;
   toggleOpen: () => void;
   mutateFn: () => void;
-  mutateResult?: UseMutationResult<IKubeResponse<unknown>, KubeClientError, any, unknown>;
+  mutateResult?: MutationResultSubset;
   title: string;
   body: React.ReactNode;
   confirmButtonText: string;

--- a/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
+++ b/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { MutationResult, QueryResult, QueryStatus } from 'react-query';
+import { UseMutationResult } from 'react-query';
+import { ResultSubset } from '@app/common/types';
 import {
   Spinner,
   Alert,
@@ -19,7 +20,7 @@ export enum QuerySpinnerMode {
 }
 
 export interface IResolvedQueriesProps {
-  results: (QueryResult<unknown> | MutationResult<unknown>)[];
+  results: ResultSubset[];
   errorTitles: string[];
   errorsInline?: boolean;
   spinnerMode?: QuerySpinnerMode;
@@ -57,9 +58,9 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
 
   return (
     <>
-      {status === QueryStatus.Loading || forceLoadingState ? (
+      {status === 'loading' || forceLoadingState ? (
         spinner
-      ) : status === QueryStatus.Error ? (
+      ) : status === 'error' ? (
         <div>
           {erroredResults.map((result, index) => (
             <Alert
@@ -73,7 +74,7 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
                 (result as { reset?: () => void }).reset ? (
                   <AlertActionCloseButton
                     aria-label="Dismiss error"
-                    onClose={(result as MutationResult<unknown>).reset}
+                    onClose={(result as UseMutationResult<unknown>).reset}
                   />
                 ) : null
               }

--- a/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
+++ b/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { UseMutationResult } from 'react-query';
-import { ResultSubset } from '@app/common/types';
+import { UnknownResult } from '@app/common/types';
 import {
   Spinner,
   Alert,
@@ -20,7 +20,7 @@ export enum QuerySpinnerMode {
 }
 
 export interface IResolvedQueriesProps {
-  results: ResultSubset[];
+  results: UnknownResult[];
   errorTitles: string[];
   errorsInline?: boolean;
   spinnerMode?: QuerySpinnerMode;

--- a/src/app/common/components/ResolvedQuery/ResolvedQuery.tsx
+++ b/src/app/common/components/ResolvedQuery/ResolvedQuery.tsx
@@ -1,10 +1,10 @@
+import { ResultSubset } from '@app/common/types';
 import * as React from 'react';
-import { QueryResult, MutationResult } from 'react-query';
 import { ResolvedQueries, IResolvedQueriesProps } from './ResolvedQueries';
 
 export interface IResolvedQueryProps
   extends Omit<IResolvedQueriesProps, 'results' | 'errorTitles'> {
-  result: QueryResult<unknown> | MutationResult<unknown>;
+  result: ResultSubset;
   errorTitle: string;
 }
 

--- a/src/app/common/components/ResolvedQuery/ResolvedQuery.tsx
+++ b/src/app/common/components/ResolvedQuery/ResolvedQuery.tsx
@@ -1,10 +1,10 @@
-import { ResultSubset } from '@app/common/types';
+import { UnknownResult } from '@app/common/types';
 import * as React from 'react';
 import { ResolvedQueries, IResolvedQueriesProps } from './ResolvedQueries';
 
 export interface IResolvedQueryProps
   extends Omit<IResolvedQueriesProps, 'results' | 'errorTitles'> {
-  result: ResultSubset;
+  result: UnknownResult;
   errorTitle: string;
 }
 

--- a/src/app/common/components/SelectOpenShiftNetworkModal.tsx
+++ b/src/app/common/components/SelectOpenShiftNetworkModal.tsx
@@ -19,8 +19,9 @@ import {
   IProviderObject,
   POD_NETWORK,
 } from '@app/queries/types';
+import { IProviderMigrationNetworkMutationVars } from '@app/queries/providers';
 
-import { MutationResult } from 'react-query';
+import { UseMutationResult } from 'react-query';
 import { IKubeResponse, KubeClientError } from '@app/client/types';
 import { QuerySpinnerMode, ResolvedQuery } from './ResolvedQuery';
 import { useOpenShiftNetworksQuery } from '@app/queries';
@@ -33,7 +34,13 @@ interface ISelectOpenShiftNetworkModalProps {
   instructions: string;
   onClose: () => void;
   onSubmit: (network: IOpenShiftNetwork | null) => void;
-  mutationResult?: MutationResult<IKubeResponse<IProviderObject>, KubeClientError>;
+  // mutationResult?: UseMutationResult<IKubeResponse<IProviderObject>, KubeClientError>;
+  mutationResult?: UseMutationResult<
+    IKubeResponse<IProviderObject>,
+    KubeClientError,
+    IProviderMigrationNetworkMutationVars,
+    unknown
+  >;
 }
 
 const useSelectNetworkFormState = (initialSelectedNetwork: string | null) =>

--- a/src/app/common/components/SelectOpenShiftNetworkModal.tsx
+++ b/src/app/common/components/SelectOpenShiftNetworkModal.tsx
@@ -34,7 +34,6 @@ interface ISelectOpenShiftNetworkModalProps {
   instructions: string;
   onClose: () => void;
   onSubmit: (network: IOpenShiftNetwork | null) => void;
-  // mutationResult?: UseMutationResult<IKubeResponse<IProviderObject>, KubeClientError>;
   mutationResult?: UseMutationResult<
     IKubeResponse<IProviderObject>,
     KubeClientError,

--- a/src/app/common/helpers.ts
+++ b/src/app/common/helpers.ts
@@ -11,7 +11,7 @@ import {
   IStep,
   IVMStatus,
 } from '@app/queries/types';
-import { QueryResult } from 'react-query';
+import { UseQueryResult } from 'react-query';
 import { IKubeList } from '@app/client/types';
 
 dayjs.extend(utc);
@@ -135,7 +135,7 @@ export const getMinutesUntil = (timestamp: Date | string): string => {
 };
 
 export const getAvailableProviderTypes = (
-  clusterProvidersQuery: QueryResult<IKubeList<IProviderObject>>
+  clusterProvidersQuery: UseQueryResult<IKubeList<IProviderObject>>
 ): ProviderType[] => {
   const clusterProviders = clusterProvidersQuery.data?.items || [];
   return Array.from(new Set(clusterProviders.map((provider) => provider.spec.type)))

--- a/src/app/common/types.ts
+++ b/src/app/common/types.ts
@@ -1,5 +1,5 @@
 import { BrandType } from '@app/global-flags';
-import { UseQueryResult } from 'react-query';
+import { UseMutationResult, UseQueryResult } from 'react-query';
 
 export interface IMetaVars {
   clusterApi: string;
@@ -32,4 +32,9 @@ export interface IEnvVars {
 export type ResultSubset = Pick<
   UseQueryResult<unknown>,
   'isError' | 'isLoading' | 'isIdle' | 'error'
+>;
+
+export type MutationResultSubset = Pick<
+  UseMutationResult<unknown>,
+  'isError' | 'isLoading' | 'isIdle' | 'error' | 'reset'
 >;

--- a/src/app/common/types.ts
+++ b/src/app/common/types.ts
@@ -1,4 +1,5 @@
 import { BrandType } from '@app/global-flags';
+import { UseQueryResult } from 'react-query';
 
 export interface IMetaVars {
   clusterApi: string;
@@ -27,3 +28,8 @@ export interface IEnvVars {
   FORKLIFT_VALIDATION_GIT_COMMIT: string;
   FORKLIFT_CLUSTER_VERSION: string;
 }
+
+export type ResultSubset = Pick<
+  UseQueryResult<unknown>,
+  'isError' | 'isLoading' | 'isIdle' | 'error'
+>;

--- a/src/app/common/types.ts
+++ b/src/app/common/types.ts
@@ -29,12 +29,12 @@ export interface IEnvVars {
   FORKLIFT_CLUSTER_VERSION: string;
 }
 
-export type ResultSubset = Pick<
+export type UnknownResult = Pick<
   UseQueryResult<unknown>,
   'isError' | 'isLoading' | 'isIdle' | 'error'
 >;
 
-export type MutationResultSubset = Pick<
+export type UnknownMutationResult = Pick<
   UseMutationResult<unknown>,
   'isError' | 'isLoading' | 'isIdle' | 'error' | 'reset'
 >;

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
 import { QueryClientProvider, QueryClient, QueryCache } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { AppLayout } from '@app/AppLayout/AppLayout';
 import { AppRoutes } from '@app/routes';
@@ -27,6 +28,7 @@ const App: React.FunctionComponent = () => (
         </NetworkContextProvider>
       </LocalStorageContextProvider>
     </PollingContextProvider>
+    {process.env.NODE_ENV !== 'test' ? <ReactQueryDevtools /> : null}
   </QueryClientProvider>
 );
 

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
-import { QueryCache, ReactQueryCacheProvider } from 'react-query';
-import { ReactQueryDevtools } from 'react-query-devtools';
+import { QueryClientProvider, QueryClient, QueryCache } from 'react-query';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { AppLayout } from '@app/AppLayout/AppLayout';
 import { AppRoutes } from '@app/routes';
@@ -13,9 +12,10 @@ import {
 } from '@app/common/context';
 
 const queryCache = new QueryCache();
+const queryClient = new QueryClient({ queryCache });
 
 const App: React.FunctionComponent = () => (
-  <ReactQueryCacheProvider queryCache={queryCache}>
+  <QueryClientProvider client={queryClient}>
     <PollingContextProvider>
       <LocalStorageContextProvider>
         <NetworkContextProvider>
@@ -27,8 +27,7 @@ const App: React.FunctionComponent = () => (
         </NetworkContextProvider>
       </LocalStorageContextProvider>
     </PollingContextProvider>
-    {process.env.NODE_ENV !== 'test' ? <ReactQueryDevtools /> : null}
-  </ReactQueryCacheProvider>
+  </QueryClientProvider>
 );
 
 export { App };

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -14,7 +14,7 @@ import { useHistory } from 'react-router-dom';
 import { useFetchContext } from './fetchHelpers';
 import { INameNamespaceRef, IProviderObject, ISrcDestRefs } from './types';
 import { InventoryTree } from './types/tree.types';
-import { ResultSubset } from '@app/common/types';
+import { UnknownResult } from '@app/common/types';
 
 // TODO what about usePaginatedQuery, useInfiniteQuery?
 
@@ -86,7 +86,7 @@ export const useMockableMutation = <
 export const getInventoryApiUrl = (relativePath: string): string =>
   `/inventory-api/${relativePath}`;
 
-export const getAggregateQueryStatus = (queryResults: ResultSubset[]): QueryStatus => {
+export const getAggregateQueryStatus = (queryResults: UnknownResult[]): QueryStatus => {
   if (queryResults.some((result) => result.isError)) return 'error';
   if (queryResults.some((result) => result.isLoading)) return 'loading';
   if (queryResults.every((result) => result.isIdle)) return 'idle';

--- a/src/app/queries/hooks.ts
+++ b/src/app/queries/hooks.ts
@@ -8,8 +8,7 @@ import { META } from '@app/common/constants';
 import { usePollingContext } from '@app/common/context';
 import {
   mockKubeList,
-  // useKubeResultsSortedByName,
-  // sortByName,
+  sortKubeListByName,
   useMockableQuery,
 } from './helpers';
 import { MOCK_HOOKS } from './mocks/hooks.mock';
@@ -25,12 +24,11 @@ export const useHooksQuery = (): UseQueryResult<IKubeList<IHook>> => {
       queryKey: 'hooks',
       queryFn: async () => (await client.list<IKubeList<IHook>>(hookResource)).data,
       refetchInterval: usePollingContext().refetchInterval,
-      // select: sortByName
+      select: sortKubeListByName
     },
     mockKubeList(MOCK_HOOKS, 'Hook')
   );
   return result;
-  // return useKubeResultsSortedByName(result);
 };
 
 export const playbookSchema = yup

--- a/src/app/queries/hooks.ts
+++ b/src/app/queries/hooks.ts
@@ -1,4 +1,4 @@
-import { QueryResult } from 'react-query';
+import { UseQueryResult } from 'react-query';
 import * as yup from 'yup';
 import yaml from 'js-yaml';
 
@@ -6,26 +6,31 @@ import { ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
 import { IKubeList } from '@app/client/types';
 import { META } from '@app/common/constants';
 import { usePollingContext } from '@app/common/context';
-import { mockKubeList, useKubeResultsSortedByName, useMockableQuery } from './helpers';
+import {
+  mockKubeList,
+  // useKubeResultsSortedByName,
+  // sortByName,
+  useMockableQuery,
+} from './helpers';
 import { MOCK_HOOKS } from './mocks/hooks.mock';
 import { IHook } from './types';
 import { useAuthorizedK8sClient } from './fetchHelpers';
 
 const hookResource = new ForkliftResource(ForkliftResourceKind.Hook, META.namespace);
 
-export const useHooksQuery = (): QueryResult<IKubeList<IHook>> => {
+export const useHooksQuery = (): UseQueryResult<IKubeList<IHook>> => {
   const client = useAuthorizedK8sClient();
   const result = useMockableQuery<IKubeList<IHook>>(
     {
       queryKey: 'hooks',
       queryFn: async () => (await client.list<IKubeList<IHook>>(hookResource)).data,
-      config: {
-        refetchInterval: usePollingContext().refetchInterval,
-      },
+      refetchInterval: usePollingContext().refetchInterval,
+      // select: sortByName
     },
     mockKubeList(MOCK_HOOKS, 'Hook')
   );
-  return useKubeResultsSortedByName(result);
+  return result;
+  // return useKubeResultsSortedByName(result);
 };
 
 export const playbookSchema = yup

--- a/src/app/queries/hooks.ts
+++ b/src/app/queries/hooks.ts
@@ -6,11 +6,7 @@ import { ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
 import { IKubeList } from '@app/client/types';
 import { META } from '@app/common/constants';
 import { usePollingContext } from '@app/common/context';
-import {
-  mockKubeList,
-  sortKubeListByName,
-  useMockableQuery,
-} from './helpers';
+import { mockKubeList, sortKubeListByName, useMockableQuery } from './helpers';
 import { MOCK_HOOKS } from './mocks/hooks.mock';
 import { IHook } from './types';
 import { useAuthorizedK8sClient } from './fetchHelpers';
@@ -24,7 +20,7 @@ export const useHooksQuery = (): UseQueryResult<IKubeList<IHook>> => {
       queryKey: 'hooks',
       queryFn: async () => (await client.list<IKubeList<IHook>>(hookResource)).data,
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortKubeListByName
+      select: sortKubeListByName,
     },
     mockKubeList(MOCK_HOOKS, 'Hook')
   );

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -47,7 +47,7 @@ export const useMappingsQuery = (mappingType: MappingType): UseQueryResult<IKube
       queryFn: async () =>
         (await client.list<IKubeList<Mapping>>(getMappingResource(mappingType).resource)).data,
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortKubeListByName
+      select: sortKubeListByName,
     },
     mappingType === MappingType.Network
       ? mockKubeList(MOCK_NETWORK_MAPPINGS, 'NetworkMapList')

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -1,4 +1,4 @@
-import { MutationResultPair, useQueryCache, QueryResult, QueryStatus } from 'react-query';
+import { UseMutationResult, useQueryClient, UseQueryResult, QueryStatus } from 'react-query';
 import * as yup from 'yup';
 import {
   IOpenShiftProvider,
@@ -14,7 +14,7 @@ import {
   getAggregateQueryStatus,
   getFirstQueryError,
   mockKubeList,
-  useKubeResultsSortedByName,
+  // useKubeResultsSortedByName,
   useMockableMutation,
   useMockableQuery,
 } from './helpers';
@@ -39,33 +39,35 @@ export const getMappingResource = (
   return { kind, resource };
 };
 
-export const useMappingsQuery = (mappingType: MappingType): QueryResult<IKubeList<Mapping>> => {
+export const useMappingsQuery = (mappingType: MappingType): UseQueryResult<IKubeList<Mapping>> => {
   const client = useAuthorizedK8sClient();
   const result = useMockableQuery<IKubeList<Mapping>>(
     {
       queryKey: ['mappings', mappingType],
       queryFn: async () =>
         (await client.list<IKubeList<Mapping>>(getMappingResource(mappingType).resource)).data,
-      config: { refetchInterval: usePollingContext().refetchInterval },
+      refetchInterval: usePollingContext().refetchInterval,
+      // select: sortByName
     },
     mappingType === MappingType.Network
       ? mockKubeList(MOCK_NETWORK_MAPPINGS, 'NetworkMapList')
       : mockKubeList(MOCK_STORAGE_MAPPINGS, 'StorageMapList')
   );
-  return useKubeResultsSortedByName(result);
+  return result;
+  // return useKubeResultsSortedByName(result);
 };
 
 export const useCreateMappingMutation = (
   mappingType: MappingType,
   onSuccess?: () => void
-): MutationResultPair<
+): UseMutationResult<
   IKubeResponse<Mapping>,
   KubeClientError,
   Mapping,
   unknown // TODO replace `unknown` for TSnapshot? not even sure what this is for
 > => {
   const client = useAuthorizedK8sClient();
-  const queryCache = useQueryCache();
+  const queryClient = useQueryClient();
   return useMockableMutation<IKubeResponse<Mapping>, KubeClientError, Mapping>(
     async (mapping) => {
       const { kind, resource } = getMappingResource(mappingType);
@@ -77,7 +79,7 @@ export const useCreateMappingMutation = (
     },
     {
       onSuccess: () => {
-        queryCache.invalidateQueries(['mappings', mappingType]);
+        queryClient.invalidateQueries(['mappings', mappingType]);
         onSuccess && onSuccess();
       },
     }
@@ -95,9 +97,9 @@ export const useCreateMappingMutations = (): {
 export const usePatchMappingMutation = (
   mappingType: MappingType,
   onSuccess?: () => void
-): MutationResultPair<IKubeResponse<Mapping>, KubeClientError, Mapping, unknown> => {
+): UseMutationResult<IKubeResponse<Mapping>, KubeClientError, Mapping, unknown> => {
   const client = useAuthorizedK8sClient();
-  const queryCache = useQueryCache();
+  const queryClient = useQueryClient();
   return useMockableMutation<IKubeResponse<Mapping>, KubeClientError, Mapping>(
     async (mapping: Mapping) => {
       const { resource } = getMappingResource(mappingType);
@@ -105,7 +107,7 @@ export const usePatchMappingMutation = (
     },
     {
       onSuccess: () => {
-        queryCache.invalidateQueries(['mappings', mappingType]);
+        queryClient.invalidateQueries(['mappings', mappingType]);
         onSuccess && onSuccess();
       },
     }
@@ -120,18 +122,15 @@ export const usePatchMappingMutations = (): {
   storage: usePatchMappingMutation(MappingType.Storage),
 });
 
-export const useDeleteMappingMutation = (
-  mappingType: MappingType,
-  onSuccess?: () => void
-): MutationResultPair<IKubeResponse<IKubeStatus>, KubeClientError, Mapping, unknown> => {
+export const useDeleteMappingMutation = (mappingType: MappingType, onSuccess?: () => void) => {
   const client = useAuthorizedK8sClient();
   const { resource } = getMappingResource(mappingType);
-  const queryCache = useQueryCache();
+  const queryClient = useQueryClient();
   return useMockableMutation<IKubeResponse<IKubeStatus>, KubeClientError, Mapping>(
     (mapping: Mapping) => client.delete(resource, (mapping.metadata as IMetaObjectMeta).name),
     {
       onSuccess: () => {
-        queryCache.invalidateQueries(['mappings', mappingType]);
+        queryClient.invalidateQueries(['mappings', mappingType]);
         onSuccess && onSuccess();
       },
     }
@@ -145,7 +144,7 @@ export interface IMappingResourcesResult {
   isError: boolean;
   status: QueryStatus;
   error: unknown; // TODO not sure how to handle error types yet
-  queries: QueryResult<unknown>[];
+  queries: UseQueryResult<unknown>[];
 }
 
 export interface ISpecificMappingResourcesResult extends IMappingResourcesResult {
@@ -194,8 +193,8 @@ export const useMappingResourceQueries = (
   return {
     availableSources,
     availableTargets,
-    isLoading: status === QueryStatus.Loading,
-    isError: status === QueryStatus.Error,
+    isLoading: status === 'loading',
+    isError: status === 'error',
     status,
     error,
     queries: queriesToWatch,
@@ -222,8 +221,8 @@ export const useResourceQueriesForMapping = (
   return {
     ...mappingResourceQueries,
     queries: allQueries,
-    isLoading: status === QueryStatus.Loading,
-    isError: status === QueryStatus.Error,
+    isLoading: status === 'loading',
+    isError: status === 'error',
     status,
     error,
     sourceProvider,
@@ -232,7 +231,7 @@ export const useResourceQueriesForMapping = (
 };
 
 export const getMappingNameSchema = (
-  mappingsQuery: QueryResult<IKubeList<Mapping>>,
+  mappingsQuery: UseQueryResult<IKubeList<Mapping>>,
   mappingBeingEdited: Mapping | null
 ): yup.StringSchema =>
   dnsLabelNameSchema.test('unique-name', 'A mapping with this name already exists', (value) => {

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -14,7 +14,7 @@ import {
   getAggregateQueryStatus,
   getFirstQueryError,
   mockKubeList,
-  // useKubeResultsSortedByName,
+  sortKubeListByName,
   useMockableMutation,
   useMockableQuery,
 } from './helpers';
@@ -47,14 +47,13 @@ export const useMappingsQuery = (mappingType: MappingType): UseQueryResult<IKube
       queryFn: async () =>
         (await client.list<IKubeList<Mapping>>(getMappingResource(mappingType).resource)).data,
       refetchInterval: usePollingContext().refetchInterval,
-      // select: sortByName
+      select: sortKubeListByName
     },
     mappingType === MappingType.Network
       ? mockKubeList(MOCK_NETWORK_MAPPINGS, 'NetworkMapList')
       : mockKubeList(MOCK_STORAGE_MAPPINGS, 'StorageMapList')
   );
   return result;
-  // return useKubeResultsSortedByName(result);
 };
 
 export const useCreateMappingMutation = (

--- a/src/app/queries/namespaces.ts
+++ b/src/app/queries/namespaces.ts
@@ -1,24 +1,20 @@
 import { usePollingContext } from '@app/common/context';
-import { QueryResult } from 'react-query';
-import { getInventoryApiUrl, useResultsSortedByName, useMockableQuery } from './helpers';
+import { getInventoryApiUrl, sortByName, useMockableQuery } from './helpers';
 import { IOpenShiftProvider } from './types';
 import { useAuthorizedFetch } from './fetchHelpers';
 import { IOpenShiftNamespace } from './types/namespaces.types';
 import { MOCK_OPENSHIFT_NAMESPACES } from './mocks/namespaces.mock';
 
-export const useNamespacesQuery = (
-  provider: IOpenShiftProvider | null
-): QueryResult<IOpenShiftNamespace[]> => {
+export const useNamespacesQuery = (provider: IOpenShiftProvider | null) => {
   const result = useMockableQuery<IOpenShiftNamespace[]>(
     {
       queryKey: ['namespaces', provider?.name],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}/namespaces`)),
-      config: {
-        enabled: !!provider,
-        refetchInterval: usePollingContext().refetchInterval,
-      },
+      enabled: !!provider,
+      refetchInterval: usePollingContext().refetchInterval,
+      select: sortByName,
     },
     MOCK_OPENSHIFT_NAMESPACES
   );
-  return useResultsSortedByName(result);
+  return result;
 };

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -33,7 +33,7 @@ export const usePlansQuery = (): UseQueryResult<IKubeList<IPlan>> => {
       queryKey: 'plans',
       queryFn: async () => (await client.list<IKubeList<IPlan>>(planResource)).data,
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortKubeListByName
+      select: sortKubeListByName,
     },
     mockKubeList(MOCK_PLANS, 'Plan')
   );

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -9,6 +9,7 @@ import {
   nameAndNamespace,
   useMockableMutation,
   useMockableQuery,
+  sortKubeListByName,
   isSameResource,
 } from './helpers';
 import { MOCK_PLANS } from './mocks/plans.mock';
@@ -32,12 +33,11 @@ export const usePlansQuery = (): UseQueryResult<IKubeList<IPlan>> => {
       queryKey: 'plans',
       queryFn: async () => (await client.list<IKubeList<IPlan>>(planResource)).data,
       refetchInterval: usePollingContext().refetchInterval,
-      // select: sortByName
+      select: sortKubeListByName
     },
     mockKubeList(MOCK_PLANS, 'Plan')
   );
   return result;
-  // return useKubeResultsSortedByName(result);
 };
 
 export const useCreatePlanMutation = (

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -3,12 +3,10 @@ import { checkIfResourceExists, ForkliftResource, ForkliftResourceKind } from '@
 import { IKubeList, IKubeResponse, IKubeStatus, KubeClientError } from '@app/client/types';
 import { dnsLabelNameSchema, META } from '@app/common/constants';
 import { usePollingContext } from '@app/common/context';
-import { MutationResultPair, QueryResult, useQueryCache } from 'react-query';
-
+import { UseMutationResult, UseQueryResult, useQueryClient } from 'react-query';
 import {
   mockKubeList,
   nameAndNamespace,
-  useKubeResultsSortedByName,
   useMockableMutation,
   useMockableQuery,
   isSameResource,
@@ -27,26 +25,26 @@ const networkMapResource = getMappingResource(MappingType.Network).resource;
 const storageMapResource = getMappingResource(MappingType.Storage).resource;
 const hookResource = new ForkliftResource(ForkliftResourceKind.Hook, META.namespace);
 
-export const usePlansQuery = (): QueryResult<IKubeList<IPlan>> => {
+export const usePlansQuery = (): UseQueryResult<IKubeList<IPlan>> => {
   const client = useAuthorizedK8sClient();
   const result = useMockableQuery<IKubeList<IPlan>>(
     {
       queryKey: 'plans',
       queryFn: async () => (await client.list<IKubeList<IPlan>>(planResource)).data,
-      config: {
-        refetchInterval: usePollingContext().refetchInterval,
-      },
+      refetchInterval: usePollingContext().refetchInterval,
+      // select: sortByName
     },
     mockKubeList(MOCK_PLANS, 'Plan')
   );
-  return useKubeResultsSortedByName(result);
+  return result;
+  // return useKubeResultsSortedByName(result);
 };
 
 export const useCreatePlanMutation = (
   onSuccess?: () => void
-): MutationResultPair<IKubeResponse<IPlan>, KubeClientError, PlanWizardFormState, unknown> => {
+): UseMutationResult<IKubeResponse<IPlan>, KubeClientError, PlanWizardFormState, unknown> => {
   const client = useAuthorizedK8sClient();
-  const queryCache = useQueryCache();
+  const queryClient = useQueryClient();
   const { pollFasterAfterMutation } = usePollingContext();
   return useMockableMutation<IKubeResponse<IPlan>, KubeClientError, PlanWizardFormState>(
     async (forms) => {
@@ -118,9 +116,9 @@ export const useCreatePlanMutation = (
     },
     {
       onSuccess: () => {
-        queryCache.invalidateQueries('plans');
-        queryCache.invalidateQueries('mappings');
-        queryCache.invalidateQueries('hooks');
+        queryClient.invalidateQueries('plans');
+        queryClient.invalidateQueries('mappings');
+        queryClient.invalidateQueries('hooks');
         pollFasterAfterMutation();
         onSuccess && onSuccess();
       },
@@ -135,9 +133,9 @@ interface IPatchPlanArgs {
 
 export const usePatchPlanMutation = (
   onSuccess?: () => void
-): MutationResultPair<IKubeResponse<IPlan>, KubeClientError, IPatchPlanArgs, unknown> => {
+): UseMutationResult<IKubeResponse<IPlan>, KubeClientError, IPatchPlanArgs, unknown> => {
   const client = useAuthorizedK8sClient();
-  const queryCache = useQueryCache();
+  const queryClient = useQueryClient();
   const { pollFasterAfterMutation } = usePollingContext();
   const hooks = useHooksQuery();
 
@@ -231,9 +229,9 @@ export const usePatchPlanMutation = (
     },
     {
       onSuccess: () => {
-        queryCache.invalidateQueries('plans');
-        queryCache.invalidateQueries('mappings');
-        queryCache.invalidateQueries('hooks');
+        queryClient.invalidateQueries('plans');
+        queryClient.invalidateQueries('hooks');
+        queryClient.invalidateQueries('mappings');
         pollFasterAfterMutation();
         onSuccess && onSuccess();
       },
@@ -243,15 +241,15 @@ export const usePatchPlanMutation = (
 
 export const useDeletePlanMutation = (
   onSuccess?: () => void
-): MutationResultPair<IKubeResponse<IKubeStatus>, KubeClientError, IPlan, unknown> => {
+): UseMutationResult<IKubeResponse<IKubeStatus>, KubeClientError, IPlan, unknown> => {
   const client = useAuthorizedK8sClient();
-  const queryCache = useQueryCache();
+  const queryClient = useQueryClient();
   return useMockableMutation<IKubeResponse<IKubeStatus>, KubeClientError, IPlan>(
     (plan: IPlan) => client.delete(planResource, plan.metadata.name),
     {
       onSuccess: () => {
-        queryCache.invalidateQueries('plans');
-        queryCache.invalidateQueries('mappings');
+        queryClient.invalidateQueries('plans');
+        queryClient.invalidateQueries('mappings');
         onSuccess && onSuccess();
       },
     }
@@ -259,7 +257,7 @@ export const useDeletePlanMutation = (
 };
 
 export const getPlanNameSchema = (
-  plansQuery: QueryResult<IKubeList<IPlan>>,
+  plansQuery: UseQueryResult<IKubeList<IPlan>>,
   planBeingEdited: IPlan | null
 ): yup.StringSchema =>
   dnsLabelNameSchema.test('unique-name', 'A plan with this name already exists', (value) => {

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -50,7 +50,7 @@ export const useClusterProvidersQuery = (): UseQueryResult<IKubeList<IProviderOb
   );
 };
 
-export const useInventoryProvidersQuery = (): UseQueryResult<IProvidersByType> => {
+export const useInventoryProvidersQuery = () => {
   const result = useMockableQuery<IProvidersByType>(
     {
       queryKey: 'inventory-providers',
@@ -61,7 +61,6 @@ export const useInventoryProvidersQuery = (): UseQueryResult<IProvidersByType> =
     MOCK_INVENTORY_PROVIDERS
   );
   return result;
-  // return useIndexedResultsSortedByName(result);
 };
 
 export const useCreateProviderMutation = (

--- a/src/app/queries/provisioners.ts
+++ b/src/app/queries/provisioners.ts
@@ -1,4 +1,3 @@
-import { QueryResult } from 'react-query';
 import { ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
 import { IKubeList } from '@app/client/types';
 import { META } from '@app/common/constants';
@@ -10,15 +9,13 @@ import { MOCK_PROVISIONERS } from './mocks/provisioners.mock';
 
 const provisionerResource = new ForkliftResource(ForkliftResourceKind.Provisioners, META.namespace);
 
-export const useProvisionersQuery = (): QueryResult<IKubeList<IProvisioner>> => {
+export const useProvisionersQuery = () => {
   const client = useAuthorizedK8sClient();
   return useMockableQuery<IKubeList<IProvisioner>>(
     {
       queryKey: 'provisioners',
       queryFn: async () => (await client.list<IKubeList<IProvisioner>>(provisionerResource)).data,
-      config: {
-        refetchInterval: usePollingContext().refetchInterval,
-      },
+      refetchInterval: usePollingContext().refetchInterval,
     },
     mockKubeList(MOCK_PROVISIONERS, 'Provisioner')
   );

--- a/src/app/queries/secrets.ts
+++ b/src/app/queries/secrets.ts
@@ -1,21 +1,19 @@
 import { secretResource } from '@app/client/helpers';
 import { usePollingContext } from '@app/common/context';
-import { QueryResult } from 'react-query';
+import { UseQueryResult } from 'react-query';
 import { useAuthorizedK8sClient } from './fetchHelpers';
 import { useMockableQuery } from './helpers';
 import { MOCK_SECRET } from './mocks/secrets.mock';
 import { ISecret } from './types';
 
-export const useSecretQuery = (secretName: string | null): QueryResult<ISecret> => {
+export const useSecretQuery = (secretName: string | null): UseQueryResult<ISecret> => {
   const client = useAuthorizedK8sClient();
   return useMockableQuery<ISecret>(
     {
       queryKey: ['secret', secretName],
       queryFn: async () => (await client.get<ISecret>(secretResource, secretName || '')).data,
-      config: {
-        refetchInterval: usePollingContext().refetchInterval,
-        enabled: !!secretName,
-      },
+      refetchInterval: usePollingContext().refetchInterval,
+      enabled: !!secretName,
     },
     MOCK_SECRET
   );

--- a/src/app/queries/tree.ts
+++ b/src/app/queries/tree.ts
@@ -1,6 +1,5 @@
-import * as React from 'react';
 import { usePollingContext } from '@app/common/context';
-import { QueryResult } from 'react-query';
+import { UseQueryResult } from 'react-query';
 import { getInventoryApiUrl, sortTreeItemsByName, useMockableQuery } from './helpers';
 import { MOCK_RHV_HOST_TREE, MOCK_VMWARE_HOST_TREE, MOCK_VMWARE_VM_TREE } from './mocks/tree.mock';
 import { SourceInventoryProvider } from './types';
@@ -10,7 +9,7 @@ import { useAuthorizedFetch } from './fetchHelpers';
 export const useInventoryTreeQuery = <T extends InventoryTree>(
   provider: SourceInventoryProvider | null,
   treeType: InventoryTreeType
-): QueryResult<T> => {
+): UseQueryResult<T> => {
   // VMware providers have both Host and VM trees, but RHV only has Host trees.
   const isValidQuery = provider?.type === 'vsphere' || treeType === InventoryTreeType.Host;
   const apiSlug = treeType === InventoryTreeType.Host ? '/tree/host' : '/tree/vm';
@@ -18,10 +17,9 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
     {
       queryKey: ['inventory-tree', provider?.name, treeType],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}${apiSlug}`)),
-      config: {
-        enabled: isValidQuery && !!provider,
-        refetchInterval: usePollingContext().refetchInterval,
-      },
+      enabled: isValidQuery && !!provider,
+      refetchInterval: usePollingContext().refetchInterval,
+      select: sortTreeItemsByName,
     },
     (treeType === InventoryTreeType.Host
       ? provider?.type === 'vsphere'
@@ -29,9 +27,5 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
         : MOCK_RHV_HOST_TREE
       : MOCK_VMWARE_VM_TREE) as T
   );
-  const sortedData = React.useMemo(() => sortTreeItemsByName(result.data), [result.data]);
-  return {
-    ...result,
-    data: sortedData,
-  };
+  return result;
 };


### PR DESCRIPTION
This PR upgrades `react-query` to v3. There really isn't a way to introduce this in pieces as far as I can tell, sorry for the big diff 😅 It seems like a massive change, and while it isn't small most of this is the same change in a bunch of places throughout the codebase. Should help close https://github.com/konveyor/forklift-ui/issues/567

@mturley major thx for helping me work through this!

### Highlights

- react query devtools is now part of the react-query pkg
- Rendering components inside the test suite now requires wrapping JSX in a stub `QueryClientProvider`
- QueryStatus enum was removed, just use string literals for states now (success, error, loading etc)
- `QueryResult` => `UseQueryResult`
- `MutationResult` => `UseMutationResult`
- `ReactQueryCacheProvider` => `QueryClientProvider`
- Can now utilize [`select`](https://react-query.tanstack.com/guides/migrating-to-react-query-3#query-data-selectors) config property to apply transforms to returned data, eliminating the need for complex sort helpers
- I started to pair back some of the function return type definitions where we used generics heavily. It was [recommended](https://tkdodo.eu/blog/react-query-and-type-script#type-inference) by maintainers of react-query since ts inferencing does the same job with less code
