### PR TITLE
fix(table): enter grid layout when there is not enough horizontal space

### DIFF
--- a/src/app/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
@@ -202,6 +202,7 @@ const SourceProvidersTable: React.FunctionComponent<ISourceProvidersTableProps> 
         </LevelItem>
       </Level>
       <Table
+        gridBreakPoint="grid-lg"
         aria-label={`${PROVIDER_TYPE_NAMES[providerType]} providers table`}
         variant="compact"
         cells={columns}


### PR DESCRIPTION
This PR sends the Red Hat Virtualization and VMware tables into grid layout up through large viewports (992px) to avoid table data from overflowing its container. The OpenShift Virtualization table remains as it was. Should help close https://github.com/konveyor/forklift-ui/issues/168

<img width="1027" alt="Screen Shot 2021-06-22 at 10 27 59 AM" src="https://user-images.githubusercontent.com/5942899/122944278-acc92680-d345-11eb-8b61-bb34339b4c9a.png">
