### PR TITLE
Filter VMs step: show badge with number of VMs provided by each tree node's selected descendants

### DIFF
--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -91,8 +91,9 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
     const { isItemSelected, selectedItems } = treeSelection;
     const selectedDescendants = flattenInventoryTreeNodes(node).filter(isItemSelected);
     const numVMs = getAvailableVMs(selectedDescendants, vmsQuery.data || [], treeType).length;
+    const rootNodeSuffix = ` VM${numVMs !== 1 ? 's' : ''}`;
     if (numVMs || isItemSelected(node) || (isRootNode && selectedItems.length > 0)) {
-      return `${numVMs}${isRootNode ? ` VM${numVMs !== 1 ? 's' : ''}` : ''}`;
+      return `${numVMs}${isRootNode ? rootNodeSuffix : ''}`;
     }
     return null;
   };

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -14,6 +14,7 @@ import {
   findMatchingNode,
   findMatchingNodeAndDescendants,
   findNodesMatchingSelectedVMs,
+  flattenInventoryTreeNodes,
   getAvailableVMs,
   getSelectableNodes,
   getSelectedVMsFromPlan,
@@ -88,8 +89,15 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
   ]);
 
   const getNodeBadgeContent = (node: InventoryTree) => {
-    if (!isNodeSelectable(node)) return null;
-    return getAvailableVMs([node], vmsQuery.data || [], form.values.treeType).length || null;
+    const selectedDescendants = flattenInventoryTreeNodes(node).filter(
+      treeSelection.isItemSelected
+    );
+    const numVMs =
+      getAvailableVMs(selectedDescendants, vmsQuery.data || [], form.values.treeType).length ||
+      null;
+    if (numVMs) return numVMs;
+    if (treeSelection.isItemSelected(node)) return '0';
+    return null;
   };
 
   return (

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -14,8 +14,11 @@ import {
   findMatchingNode,
   findMatchingNodeAndDescendants,
   findNodesMatchingSelectedVMs,
+  getAvailableVMs,
   getSelectableNodes,
   getSelectedVMsFromPlan,
+  isIncludedLeafNode,
+  isIncludedNode,
   isNodeFullyChecked,
   useIsNodeSelectableCallback,
 } from './helpers';
@@ -84,6 +87,11 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
     isNodeSelectable,
   ]);
 
+  const getNodeBadgeContent = (node: InventoryTree) => {
+    if (!isNodeSelectable(node)) return null;
+    return getAvailableVMs([node], vmsQuery.data || [], form.values.treeType).length || null;
+  };
+
   return (
     <div className="plan-wizard-filter-vms-form">
       <TextContent>
@@ -121,10 +129,12 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
             searchText,
             treeSelection.isItemSelected,
             treeSelection.areAllSelected,
-            isNodeSelectable
+            isNodeSelectable,
+            getNodeBadgeContent
           )}
           defaultAllExpanded
           hasChecks
+          hasBadges
           onSearch={(event) => setSearchText(event.target.value)}
           onCheck={(_event, treeViewItem) => {
             if (treeViewItem.id === 'converted-root') {

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -86,15 +86,14 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
     isNodeSelectable,
   ]);
 
-  const getNodeBadgeContent = (node: InventoryTree) => {
-    const selectedDescendants = flattenInventoryTreeNodes(node).filter(
-      treeSelection.isItemSelected
-    );
-    const numVMs =
-      getAvailableVMs(selectedDescendants, vmsQuery.data || [], form.values.treeType).length ||
-      null;
-    if (numVMs) return numVMs;
-    if (treeSelection.isItemSelected(node)) return '0';
+  const getNodeBadgeContent = (node: InventoryTree, isRootNode: boolean) => {
+    const { treeType } = form.values;
+    const { isItemSelected, selectedItems } = treeSelection;
+    const selectedDescendants = flattenInventoryTreeNodes(node).filter(isItemSelected);
+    const numVMs = getAvailableVMs(selectedDescendants, vmsQuery.data || [], treeType).length;
+    if (numVMs || isItemSelected(node) || (isRootNode && selectedItems.length > 0)) {
+      return `${numVMs}${isRootNode ? ` VM${numVMs !== 1 ? 's' : ''}` : ''}`;
+    }
     return null;
   };
 

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -18,8 +18,6 @@ import {
   getAvailableVMs,
   getSelectableNodes,
   getSelectedVMsFromPlan,
-  isIncludedLeafNode,
-  isIncludedNode,
   isNodeFullyChecked,
   useIsNodeSelectableCallback,
 } from './helpers';

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -126,10 +126,12 @@ const convertInventoryTreeNode = (
   node: InventoryTree,
   searchText: string,
   isNodeSelected: (node: InventoryTree) => boolean,
-  isNodeSelectable: (node: InventoryTree) => boolean
+  isNodeSelectable: (node: InventoryTree) => boolean,
+  getNodeBadgeContent: (node: InventoryTree) => React.ReactNode
 ): TreeViewDataItem => {
   const isFullyChecked = isNodeFullyChecked(node, isNodeSelected, isNodeSelectable);
   const isPartiallyChecked = isNodePartiallyChecked(node, isNodeSelected, isFullyChecked);
+  const badge = getNodeBadgeContent(node);
   return {
     name: node.object?.name || '',
     id: node.object?.selfLink,
@@ -137,7 +139,8 @@ const convertInventoryTreeNode = (
       node.children,
       searchText,
       isNodeSelected,
-      isNodeSelectable
+      isNodeSelectable,
+      getNodeBadgeContent
     ),
     checkProps: {
       'aria-label': `Select ${node.kind} ${node.object?.name || ''}`,
@@ -151,6 +154,8 @@ const convertInventoryTreeNode = (
       ) : node.kind === 'Folder' ? (
         <FolderIcon />
       ) : null,
+    customBadgeContent: badge,
+    hasBadge: !!badge,
   };
 };
 
@@ -159,14 +164,21 @@ const filterAndConvertInventoryTreeChildren = (
   children: InventoryTree[] | null,
   searchText: string,
   isNodeSelected: (node: InventoryTree) => boolean,
-  isNodeSelectable: (node: InventoryTree) => boolean
+  isNodeSelectable: (node: InventoryTree) => boolean,
+  getNodeBadgeContent: (node: InventoryTree) => React.ReactNode
 ): TreeViewDataItem[] | undefined => {
   const filteredChildren = ((children || []) as InventoryTree[]).filter((node) =>
     subtreeMatchesSearch(node, searchText)
   );
   if (filteredChildren.length > 0)
     return filteredChildren.map((node) =>
-      convertInventoryTreeNode(node, searchText, isNodeSelected, isNodeSelectable)
+      convertInventoryTreeNode(
+        node,
+        searchText,
+        isNodeSelected,
+        isNodeSelectable,
+        getNodeBadgeContent
+      )
     );
   return undefined;
 };
@@ -177,10 +189,12 @@ export const filterAndConvertInventoryTree = (
   searchText: string,
   isNodeSelected: (node: InventoryTree) => boolean,
   areAllSelected: boolean,
-  isNodeSelectable: (node: InventoryTree) => boolean
+  isNodeSelectable: (node: InventoryTree) => boolean,
+  getNodeBadgeContent: (node: InventoryTree) => React.ReactNode
 ): TreeViewDataItem[] => {
   if (!rootNode) return [];
   const isPartiallyChecked = isNodePartiallyChecked(rootNode, isNodeSelected, areAllSelected);
+  const badge = getNodeBadgeContent(rootNode);
   return [
     {
       name: 'All datacenters',
@@ -193,8 +207,11 @@ export const filterAndConvertInventoryTree = (
         rootNode.children,
         searchText,
         isNodeSelected,
-        isNodeSelectable
+        isNodeSelectable,
+        getNodeBadgeContent
       ),
+      customBadgeContent: badge,
+      hasBadge: !!badge,
     },
   ];
 };

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -127,11 +127,11 @@ const convertInventoryTreeNode = (
   searchText: string,
   isNodeSelected: (node: InventoryTree) => boolean,
   isNodeSelectable: (node: InventoryTree) => boolean,
-  getNodeBadgeContent: (node: InventoryTree) => React.ReactNode
+  getNodeBadgeContent: (node: InventoryTree, isRootNode: boolean) => React.ReactNode
 ): TreeViewDataItem => {
   const isFullyChecked = isNodeFullyChecked(node, isNodeSelected, isNodeSelectable);
   const isPartiallyChecked = isNodePartiallyChecked(node, isNodeSelected, isFullyChecked);
-  const badge = getNodeBadgeContent(node);
+  const badge = getNodeBadgeContent(node, false);
   return {
     name: node.object?.name || '',
     id: node.object?.selfLink,
@@ -165,7 +165,7 @@ const filterAndConvertInventoryTreeChildren = (
   searchText: string,
   isNodeSelected: (node: InventoryTree) => boolean,
   isNodeSelectable: (node: InventoryTree) => boolean,
-  getNodeBadgeContent: (node: InventoryTree) => React.ReactNode
+  getNodeBadgeContent: (node: InventoryTree, isRootNode: boolean) => React.ReactNode
 ): TreeViewDataItem[] | undefined => {
   const filteredChildren = ((children || []) as InventoryTree[]).filter((node) =>
     subtreeMatchesSearch(node, searchText)
@@ -190,11 +190,11 @@ export const filterAndConvertInventoryTree = (
   isNodeSelected: (node: InventoryTree) => boolean,
   areAllSelected: boolean,
   isNodeSelectable: (node: InventoryTree) => boolean,
-  getNodeBadgeContent: (node: InventoryTree) => React.ReactNode
+  getNodeBadgeContent: (node: InventoryTree, isRootNode: boolean) => React.ReactNode
 ): TreeViewDataItem[] => {
   if (!rootNode) return [];
   const isPartiallyChecked = isNodePartiallyChecked(rootNode, isNodeSelected, areAllSelected);
-  const badge = getNodeBadgeContent(rootNode);
+  const badge = getNodeBadgeContent(rootNode, true);
   return [
     {
       name: 'All datacenters',


### PR DESCRIPTION
Resolves #658.

@vconzola I'm curious about your feedback here. With the mock data we have it's easiest to test this with the folder view. Note that the V2V-DC datacenter has 2 direct VM children that are not in any folders, and all other VMs are under a leaf node folder.

Based on [your comment](https://github.com/konveyor/forklift-ui/pull/653#pullrequestreview-686754691) I think this is what you were asking for? Any tree node that is selected or has selected descendants (showing checked or indeterminate) will have a number next to it with the total number of VMs coming from the selections under that node. If a node isn't selected it won't have a badge (so we don't have "0"s all over the tree), but if it is selected and provides no VMs it gets a "0" badge to be extra clear. (not sure how often this will come up in real data anyway, we just have empty stuff in our mock data).

It feels a little weird, but maybe is fine? I wonder if we should add "VMs" as a suffix on the number to be more clear what those numbers mean?

Also, I was initially messing around with a slightly different approach where instead of showing anything about descendants, each node just lists the number of VMs that will be included by selecting that node (and not its children). So the numbers will not change based on selections, they just describe where the VMs are in the tree. You can see that older preview here: https://forklift-tree-counts-v1-preview.surge.sh/ (edit: tore this down)

For both of these previews, the easiest way to get to the tree quickly is by editing plantest-02 and clicking Filter VMs in the wizard nav. As mentioned above it's more apparent in the Folders tab.