### PR TITLE
fix(plans): conditionally display select network link in plans wiz

### DIFF
--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -45,6 +45,11 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   const clusterProvidersQuery = useClusterProvidersQuery();
   const namespacesQuery = useNamespacesQuery(form.values.targetProvider);
 
+  const targetNsFoundInQueriesNs = () =>
+    namespacesQuery.data?.reduce((acc, namespace) => {
+      return acc ? true : form.values.targetNamespace === namespace.name;
+    }, false);
+
   const [isNamespaceSelectOpen, setIsNamespaceSelectOpen] = React.useState(false);
   usePausedPollingEffect(isNamespaceSelectOpen);
 
@@ -143,6 +148,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
             spinnerMode={QuerySpinnerMode.Inline}
           >
             <Select
+              isInputValuePersisted
               placeholderText="Select a namespace"
               isOpen={isNamespaceSelectOpen}
               onToggle={(isOpen) => {
@@ -188,14 +194,16 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
                 </Popover>
               </Text>
             </TextContent>
-            <Button
-              variant="link"
-              isInline
-              onClick={toggleSelectNetworkModal}
-              className={spacing.mtXs}
-            >
-              Select a different network
-            </Button>
+            {targetNsFoundInQueriesNs() && (
+              <Button
+                variant="link"
+                isInline
+                onClick={toggleSelectNetworkModal}
+                className={spacing.mtXs}
+              >
+                Select a different network
+              </Button>
+            )}
           </div>
         ) : null}
       </Form>

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -44,11 +44,9 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   const inventoryProvidersQuery = useInventoryProvidersQuery();
   const clusterProvidersQuery = useClusterProvidersQuery();
   const namespacesQuery = useNamespacesQuery(form.values.targetProvider);
-
-  const targetNsFoundInQueriesNs = () =>
-    namespacesQuery.data?.reduce((acc, namespace) => {
-      return acc ? true : form.values.targetNamespace === namespace.name;
-    }, false);
+  const targetNsFoundInQueriesNs = !!namespacesQuery.data?.find(
+    (namespace) => form.values.targetNamespace === namespace.name
+  );
 
   const [isNamespaceSelectOpen, setIsNamespaceSelectOpen] = React.useState(false);
   usePausedPollingEffect(isNamespaceSelectOpen);
@@ -194,7 +192,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
                 </Popover>
               </Text>
             </TextContent>
-            {targetNsFoundInQueriesNs() && (
+            {targetNsFoundInQueriesNs && (
               <Button
                 variant="link"
                 isInline


### PR DESCRIPTION
This PR hides the "Select a different network" link if the specified namespace isn't found in the available namespaces of the first (general) step of the plans wizard. It also ensures values persist when removing focus from the target namespace field. Should help close https://github.com/konveyor/forklift-ui/issues/463

<img width="400" alt="Screen Shot 2021-06-22 at 2 39 32 PM" src="https://user-images.githubusercontent.com/5942899/122982249-a13b2700-d368-11eb-828f-2995b9bb4219.png">

<img width="400" alt="Screen Shot 2021-06-22 at 2 39 48 PM" src="https://user-images.githubusercontent.com/5942899/122982250-a13b2700-d368-11eb-9c46-318885ad5d16.png">
