### PR TITLE
feat(table): allow for expanding/collapsing all rows in VM selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3076,12 +3076,6 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4316,15 +4310,16 @@
       }
     },
     "css-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-      "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^3.2.1",
-        "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
+        "css-what": "^5.0.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.6.0",
+        "nth-check": "^2.0.0"
       }
     },
     "css-tree": {
@@ -4337,9 +4332,9 @@
       }
     },
     "css-what": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
       "dev": true
     },
     "css.escape": {
@@ -4984,9 +4979,9 @@
       "dev": true
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "dev": true,
       "requires": {
         "ip": "^1.1.0",
@@ -5027,21 +5022,14 @@
       }
     },
     "dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-          "dev": true
-        }
       }
     },
     "dom-walk": {
@@ -5051,9 +5039,9 @@
       "dev": true
     },
     "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
       "dev": true
     },
     "domexception": {
@@ -5074,22 +5062,23 @@
       }
     },
     "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "dot-case": {
@@ -6981,25 +6970,15 @@
       }
     },
     "htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
-        }
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
       }
     },
     "http-cache-semantics": {
@@ -7233,9 +7212,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "internal-ip": {
@@ -10607,9 +10586,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
       "version": "4.17.21",
@@ -11308,9 +11287,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "npm-run-path": {
@@ -11331,12 +11310,12 @@
       }
     },
     "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "^1.0.0"
       }
     },
     "nwsapi": {
@@ -12775,16 +12754,16 @@
       "dev": true
     },
     "renderkid": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.5.tgz",
-      "integrity": "sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+      "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
       "dev": true,
       "requires": {
-        "css-select": "^2.0.2",
-        "dom-converter": "^0.2",
-        "htmlparser2": "^3.10.1",
-        "lodash": "^4.17.20",
-        "strip-ansi": "^3.0.0"
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -15984,12 +15963,20 @@
           }
         },
         "ws": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
+          },
+          "dependencies": {
+            "async-limiter": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+              "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+              "dev": true
+            }
           }
         },
         "y18n": {

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 import {
   Flex,
   FlexItem,
-  Split,
-  SplitItem,
   Pagination,
   Progress,
   ProgressMeasureLocation,
   ProgressVariant,
   Text,
+  ToolbarItem,
 } from '@patternfly/react-core';
 import {
   Table,
@@ -359,23 +358,24 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
 
   return (
     <>
-      <Split>
-        <SplitItem isFilled>
-          <FilterToolbar<IPlan>
-            filterCategories={filterCategories}
-            filterValues={filterValues}
-            setFilterValues={setFilterValues}
-            toolbarItems={<CreatePlanButton variant="secondary" />}
-          />
-        </SplitItem>
-        <SplitItem>
+      <FilterToolbar<IPlan>
+        filterCategories={filterCategories}
+        filterValues={filterValues}
+        setFilterValues={setFilterValues}
+        endToolbarItems={
+          <ToolbarItem>
+            <CreatePlanButton variant="secondary" />
+          </ToolbarItem>
+        }
+        pagination={
           <Pagination
             className={spacing.mtMd}
             {...paginationProps}
             widgetId="plans-table-pagination-top"
           />
-        </SplitItem>
-      </Split>
+        }
+      />
+
       {filteredItems.length > 0 ? (
         <Table
           aria-label="Migration Plans table"

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -8,8 +8,7 @@ import {
   Pagination,
   PageSection,
   Title,
-  Split,
-  SplitItem,
+  ToolbarItem,
   Button,
   List,
   ListItem,
@@ -337,31 +336,29 @@ const VMMigrationDetails: React.FunctionComponent = () => {
         >
           <Card>
             <CardBody>
-              <Split>
-                <SplitItem isFilled>
-                  <FilterToolbar<IVMStatus>
-                    filterCategories={filterCategories}
-                    filterValues={filterValues}
-                    setFilterValues={setFilterValues}
-                    toolbarItems={
-                      <Button
-                        variant="secondary"
-                        isDisabled={selectedItems.length === 0 || cancelVMsMutation.isLoading}
-                        onClick={toggleCancelModal}
-                      >
-                        Cancel
-                      </Button>
-                    }
-                  />
-                </SplitItem>
-                <SplitItem>
+              <FilterToolbar<IVMStatus>
+                filterCategories={filterCategories}
+                filterValues={filterValues}
+                setFilterValues={setFilterValues}
+                endToolbarItems={
+                  <ToolbarItem>
+                    <Button
+                      variant="secondary"
+                      isDisabled={selectedItems.length === 0 || cancelVMsMutation.isLoading}
+                      onClick={toggleCancelModal}
+                    >
+                      Cancel
+                    </Button>
+                  </ToolbarItem>
+                }
+                pagination={
                   <Pagination
                     className={spacing.mtMd}
                     {...paginationProps}
                     widgetId="migration-vms-table-pagination-top"
                   />
-                </SplitItem>
-              </Split>
+                }
+              />
               {filteredItems.length > 0 ? (
                 <Table
                   className="migration-details-table"
@@ -380,7 +377,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
                       toggleItemSelected(rowData.meta.vmStatus, isSelected);
                     }
                   }}
-                  canSelectAll={cancelableVMs.length > 0}
+                  canSelectAll={false}
                 >
                   <TableHeader />
                   <TableBody />

--- a/src/app/Plans/components/Wizard/SelectVMsForm.css
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.css
@@ -1,0 +1,3 @@
+.pf-c-toolbar__content.pf-m-hidden {
+  display: none;
+}

--- a/src/app/common/components/FilterToolbar/FilterToolbar.tsx
+++ b/src/app/common/components/FilterToolbar/FilterToolbar.tsx
@@ -50,14 +50,18 @@ export interface IFilterToolbarProps<T> {
   filterCategories: FilterCategory<T>[];
   filterValues: IFilterValues;
   setFilterValues: (values: IFilterValues) => void;
-  toolbarItems?: JSX.Element;
+  beginToolbarItems?: JSX.Element;
+  endToolbarItems?: JSX.Element;
+  pagination?: JSX.Element;
 }
 
 export const FilterToolbar = <T,>({
   filterCategories,
   filterValues,
   setFilterValues,
-  toolbarItems,
+  beginToolbarItems,
+  endToolbarItems,
+  pagination,
 }: React.PropsWithChildren<IFilterToolbarProps<T>>): JSX.Element | null => {
   const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = React.useState(false);
   const [currentCategoryKey, setCurrentCategoryKey] = React.useState(filterCategories[0].key);
@@ -75,8 +79,10 @@ export const FilterToolbar = <T,>({
   );
 
   return (
-    <Toolbar id="pv-table-filter-toolbar" clearAllFilters={() => setFilterValues({})}>
+    <Toolbar clearAllFilters={() => setFilterValues({})}>
       <ToolbarContent>
+        {beginToolbarItems && <ToolbarGroup>{beginToolbarItems}</ToolbarGroup>}
+
         <ToolbarToggleGroup variant="filter-group" toggleIcon={<FilterIcon />} breakpoint="2xl">
           <ToolbarItem>
             <Dropdown
@@ -105,11 +111,9 @@ export const FilterToolbar = <T,>({
           ))}
         </ToolbarToggleGroup>
 
-        {toolbarItems && (
-          <ToolbarGroup>
-            <ToolbarItem>{toolbarItems}</ToolbarItem>
-          </ToolbarGroup>
-        )}
+        {endToolbarItems && <ToolbarGroup>{endToolbarItems}</ToolbarGroup>}
+
+        {pagination && <ToolbarItem variant="pagination">{pagination}</ToolbarItem>}
       </ToolbarContent>
     </Toolbar>
   );

--- a/src/app/common/hooks/usePaginationState.ts
+++ b/src/app/common/hooks/usePaginationState.ts
@@ -8,16 +8,16 @@ export type PaginationStateProps = Pick<
   'itemCount' | 'perPage' | 'page' | 'onSetPage' | 'onPerPageSelect'
 >;
 
-export interface IPaginationStateHook {
-  currentPageItems: any[];
+export interface IPaginationStateHook<T> {
+  currentPageItems: T[];
   setPageNumber: (pageNumber: number) => void;
   paginationProps: PaginationStateProps;
 }
 
-export const usePaginationState = (
-  items: any[],
+export const usePaginationState = <T>(
+  items: T[],
   initialItemsPerPage: number
-): IPaginationStateHook => {
+): IPaginationStateHook<T> => {
   const [pageNumber, setPageNumber] = React.useState(1);
   const [itemsPerPage, setItemsPerPage] = React.useState(initialItemsPerPage);
 


### PR DESCRIPTION
This PR adds an "expand/collapse" all rows toggle to the select VMs table. It also moves the select all rows function to a bulk select component and refactors the FilterToolbar layout. Should help close https://github.com/konveyor/forklift-ui/issues/36

<img width="1022" alt="Screen Shot 2021-06-24 at 4 22 54 PM" src="https://user-images.githubusercontent.com/5942899/123328064-1f363400-d509-11eb-8cef-d09ae6cd8aaa.png">
