### PR TITLE
Fix redirect loop when rendering /handle-login route with an error param and no user param

### DIFF
--- a/src/app/common/LoginHandlerComponent.tsx
+++ b/src/app/common/LoginHandlerComponent.tsx
@@ -1,6 +1,15 @@
+import { Alert, AlertActionLink } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import React, { useEffect } from 'react';
 import { useLocation, Redirect, useHistory } from 'react-router-dom';
 import { useNetworkContext } from './context/NetworkContext';
+
+interface ILoginError {
+  message?: string;
+  type?: string;
+  errno?: string;
+  code?: string;
+}
 
 const LoginHandlerComponent: React.FunctionComponent = () => {
   const { saveLoginToken } = useNetworkContext();
@@ -9,7 +18,7 @@ const LoginHandlerComponent: React.FunctionComponent = () => {
   const userStr = searchParams.get('user');
   const errorStr = searchParams.get('error');
   let user: string | null;
-  let loginError: string | null;
+  let loginError: ILoginError | null;
   try {
     user = userStr && JSON.parse(userStr);
     loginError = errorStr && JSON.parse(errorStr);
@@ -26,7 +35,23 @@ const LoginHandlerComponent: React.FunctionComponent = () => {
     }
   }, [loginError, user, history, saveLoginToken]);
 
-  return user ? null : <Redirect to="/" />;
+  if (user) return null;
+  if (loginError) {
+    return (
+      <Alert
+        variant="danger"
+        title="Error logging in"
+        className={spacing.mLg}
+        actionLinks={
+          <AlertActionLink onClick={() => history.replace('/')}>Try again</AlertActionLink>
+        }
+      >
+        {loginError.message}
+      </Alert>
+    );
+  }
+
+  return <Redirect to="/" />;
 };
 
 export default LoginHandlerComponent;

--- a/src/app/common/context/NetworkContext.tsx
+++ b/src/app/common/context/NetworkContext.tsx
@@ -30,14 +30,14 @@ export const NetworkContextProvider: React.FunctionComponent<INetworkContextProv
 
   const saveLoginToken = (user: string | null, history: History) => {
     setCurrentUser(JSON.stringify(user));
-    history.push('/');
+    history.replace('/');
   };
 
   const checkExpiry = (error: Response | AxiosError<unknown>, history: History) => {
     const status = (error as Response).status || (error as AxiosError<unknown>).response?.status;
     if (status === 401) {
       setCurrentUser('');
-      history.push('/');
+      history.replace('/');
     }
   };
 


### PR DESCRIPTION
Also renders login errors in an Alert on the page instead of just in the console.

To test this, you can simulate a login error by navigating to:
```
/handle-login?error=%7B%22message%22%3A%22request+to+https%3A%2F%2Fkubernetes.default.svc.cluster.local%2F.well-known%2Foauth-authorization-server+failed%2C+reason%3A+self+signed+certificate+in+certificate+chain%22%2C%22type%22%3A%22system%22%2C%22errno%22%3A%22SELF_SIGNED_CERT_IN_CHAIN%22%2C%22code%22%3A%22SELF_SIGNED_CERT_IN_CHAIN%22%7D
```

This would previously trigger a redirect to `/` which would attempt to perform the login again, ending up on this route again and causing a loop.