### PR TITLE
[Backport] Filter VMs step: show badge with number of VMs provided by each tree node's selected descendants (#661)

### DIFF
--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -14,6 +14,8 @@ import {
   findMatchingNode,
   findMatchingNodeAndDescendants,
   findNodesMatchingSelectedVMs,
+  flattenInventoryTreeNodes,
+  getAvailableVMs,
   getSelectableNodes,
   getSelectedVMsFromPlan,
   isNodeFullyChecked,
@@ -84,6 +86,18 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
     isNodeSelectable,
   ]);
 
+  const getNodeBadgeContent = (node: InventoryTree, isRootNode: boolean) => {
+    const { treeType } = form.values;
+    const { isItemSelected, selectedItems } = treeSelection;
+    const selectedDescendants = flattenInventoryTreeNodes(node).filter(isItemSelected);
+    const numVMs = getAvailableVMs(selectedDescendants, vmsQuery.data || [], treeType).length;
+    const rootNodeSuffix = ` VM${numVMs !== 1 ? 's' : ''}`;
+    if (numVMs || isItemSelected(node) || (isRootNode && selectedItems.length > 0)) {
+      return `${numVMs}${isRootNode ? rootNodeSuffix : ''}`;
+    }
+    return null;
+  };
+
   return (
     <div className="plan-wizard-filter-vms-form">
       <TextContent>
@@ -121,10 +135,12 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
             searchText,
             treeSelection.isItemSelected,
             treeSelection.areAllSelected,
-            isNodeSelectable
+            isNodeSelectable,
+            getNodeBadgeContent
           )}
           defaultAllExpanded
           hasChecks
+          hasBadges
           onSearch={(event) => setSearchText(event.target.value)}
           onCheck={(_event, treeViewItem) => {
             if (treeViewItem.id === 'converted-root') {

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -126,10 +126,12 @@ const convertInventoryTreeNode = (
   node: InventoryTree,
   searchText: string,
   isNodeSelected: (node: InventoryTree) => boolean,
-  isNodeSelectable: (node: InventoryTree) => boolean
+  isNodeSelectable: (node: InventoryTree) => boolean,
+  getNodeBadgeContent: (node: InventoryTree, isRootNode: boolean) => React.ReactNode
 ): TreeViewDataItem => {
   const isFullyChecked = isNodeFullyChecked(node, isNodeSelected, isNodeSelectable);
   const isPartiallyChecked = isNodePartiallyChecked(node, isNodeSelected, isFullyChecked);
+  const badge = getNodeBadgeContent(node, false);
   return {
     name: node.object?.name || '',
     id: node.object?.selfLink,
@@ -137,7 +139,8 @@ const convertInventoryTreeNode = (
       node.children,
       searchText,
       isNodeSelected,
-      isNodeSelectable
+      isNodeSelectable,
+      getNodeBadgeContent
     ),
     checkProps: {
       'aria-label': `Select ${node.kind} ${node.object?.name || ''}`,
@@ -151,6 +154,8 @@ const convertInventoryTreeNode = (
       ) : node.kind === 'Folder' ? (
         <FolderIcon />
       ) : null,
+    customBadgeContent: badge,
+    hasBadge: !!badge,
   };
 };
 
@@ -159,14 +164,21 @@ const filterAndConvertInventoryTreeChildren = (
   children: InventoryTree[] | null,
   searchText: string,
   isNodeSelected: (node: InventoryTree) => boolean,
-  isNodeSelectable: (node: InventoryTree) => boolean
+  isNodeSelectable: (node: InventoryTree) => boolean,
+  getNodeBadgeContent: (node: InventoryTree, isRootNode: boolean) => React.ReactNode
 ): TreeViewDataItem[] | undefined => {
   const filteredChildren = ((children || []) as InventoryTree[]).filter((node) =>
     subtreeMatchesSearch(node, searchText)
   );
   if (filteredChildren.length > 0)
     return filteredChildren.map((node) =>
-      convertInventoryTreeNode(node, searchText, isNodeSelected, isNodeSelectable)
+      convertInventoryTreeNode(
+        node,
+        searchText,
+        isNodeSelected,
+        isNodeSelectable,
+        getNodeBadgeContent
+      )
     );
   return undefined;
 };
@@ -177,10 +189,12 @@ export const filterAndConvertInventoryTree = (
   searchText: string,
   isNodeSelected: (node: InventoryTree) => boolean,
   areAllSelected: boolean,
-  isNodeSelectable: (node: InventoryTree) => boolean
+  isNodeSelectable: (node: InventoryTree) => boolean,
+  getNodeBadgeContent: (node: InventoryTree, isRootNode: boolean) => React.ReactNode
 ): TreeViewDataItem[] => {
   if (!rootNode) return [];
   const isPartiallyChecked = isNodePartiallyChecked(rootNode, isNodeSelected, areAllSelected);
+  const badge = getNodeBadgeContent(rootNode, true);
   return [
     {
       name: 'All datacenters',
@@ -193,8 +207,11 @@ export const filterAndConvertInventoryTree = (
         rootNode.children,
         searchText,
         isNodeSelected,
-        isNodeSelectable
+        isNodeSelectable,
+        getNodeBadgeContent
       ),
+      customBadgeContent: badge,
+      hasBadge: !!badge,
     },
   ];
 };


### PR DESCRIPTION
Backports #661 

* Add badges to each tree node to indicate how many VMs it has as immediate children

* Show number of VMs originating from selected descendants

* Remove unused imports

* Put 'VM / VMs' suffix on the badge of the root node

* Fix code smell (nested template literal and nested ternary)