### PR TITLE
[Backport] Consistently use correct provider names based on upstream/downstream branding (oVirt/RHV and KubeVirt/OCPv) (#669)

### DIFF
--- a/src/app/Mappings/components/CreateMappingButton.tsx
+++ b/src/app/Mappings/components/CreateMappingButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Button, ButtonProps } from '@patternfly/react-core';
 import ConditionalTooltip from '@app/common/components/ConditionalTooltip';
 import { useHasSufficientProvidersQuery } from '@app/queries';
+import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 interface ICreateMappingButtonProps {
   onClick: () => void;
@@ -20,7 +21,7 @@ const CreateMappingButton: React.FunctionComponent<ICreateMappingButtonProps> = 
   return (
     <ConditionalTooltip
       isTooltipEnabled={!hasSufficientProviders}
-      content="You must add at least one VMware or Red Hat Virtualization provider and one OpenShift Virtualization provider in order to create a mapping."
+      content={`You must add at least one ${PROVIDER_TYPE_NAMES.vsphere} or ${PROVIDER_TYPE_NAMES.ovirt} provider and one ${PROVIDER_TYPE_NAMES.openshift} provider in order to create a mapping.`}
     >
       <Button
         {...props}

--- a/src/app/Plans/PlansPage.tsx
+++ b/src/app/Plans/PlansPage.tsx
@@ -20,6 +20,7 @@ import {
 import PlansTable from './components/PlansTable';
 import CreatePlanButton from './components/CreatePlanButton';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
+import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 const PlansPage: React.FunctionComponent = () => {
   const sufficientProvidersQuery = useHasSufficientProvidersQuery();
@@ -53,7 +54,8 @@ const PlansPage: React.FunctionComponent = () => {
                     No migration plans
                   </Title>
                   <EmptyStateBody>
-                    Create a migration plan to select VMs to migrate to OpenShift Virtualization.
+                    Create a migration plan to select VMs to migrate to{' '}
+                    {PROVIDER_TYPE_NAMES.openshift}.
                   </EmptyStateBody>
                   <CreatePlanButton />
                 </EmptyState>

--- a/src/app/Plans/components/CreatePlanButton.tsx
+++ b/src/app/Plans/components/CreatePlanButton.tsx
@@ -3,6 +3,7 @@ import { Button, ButtonProps } from '@patternfly/react-core';
 import ConditionalTooltip from '@app/common/components/ConditionalTooltip';
 import { useHasSufficientProvidersQuery } from '@app/queries';
 import { useHistory } from 'react-router-dom';
+import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 interface ICreatePlanButtonProps {
   variant?: ButtonProps['variant'];
@@ -17,7 +18,7 @@ const CreatePlanButton: React.FunctionComponent<ICreatePlanButtonProps> = ({
   return (
     <ConditionalTooltip
       isTooltipEnabled={!hasSufficientProviders}
-      content="You must add at least one VMware or Red Hat Virtualization provider and one OpenShift Virtualization provider in order to create a migration plan."
+      content={`You must add at least one ${PROVIDER_TYPE_NAMES.vsphere} or ${PROVIDER_TYPE_NAMES.ovirt} provider and one ${PROVIDER_TYPE_NAMES.openshift} provider in order to create a migration plan.`}
     >
       <Button
         isSmall

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -31,6 +31,7 @@ import SelectOpenShiftNetworkModal from '@app/common/components/SelectOpenShiftN
 import { HelpIcon } from '@patternfly/react-icons';
 import { usePausedPollingEffect } from '@app/common/context';
 import { isSameResource } from '@app/queries/helpers';
+import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
@@ -180,7 +181,9 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
               <Text component="p">
                 The migration transfer network for this migration plan is:{' '}
                 <strong>{form.values.migrationNetwork || POD_NETWORK.name}</strong>.
-                <Popover bodyContent="The default migration network defined for the OpenShift Virtualization provider is used if it exists in the target namespace. Otherwise, the pod network is used. You can select a different network for this migration plan.">
+                <Popover
+                  bodyContent={`The default migration network defined for the ${PROVIDER_TYPE_NAMES.openshift} provider is used if it exists in the target namespace. Otherwise, the pod network is used. You can select a different network for this migration plan.`}
+                >
                   <Button
                     variant="plain"
                     aria-label="More info for migration transfer network field"

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -49,6 +49,7 @@ import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import VMConcernsIcon from './VMConcernsIcon';
 import VMConcernsDescription from './VMConcernsDescription';
 import { LONG_LOADING_MESSAGE } from '@app/queries/constants';
+import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 interface ISelectVMsFormProps {
   form: PlanWizardFormState['selectVMs'];
@@ -341,7 +342,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
           </Split>
           {filteredItems.length > 0 ? (
             <Table
-              aria-label="VMware VMs table"
+              aria-label={`${PROVIDER_TYPE_NAMES[sourceProvider?.type || 'vsphere']} VMs table`}
               variant={TableVariant.compact}
               cells={columns}
               rows={rows}

--- a/src/app/Plans/components/Wizard/TypeForm.tsx
+++ b/src/app/Plans/components/Wizard/TypeForm.tsx
@@ -5,6 +5,7 @@ import { PlanWizardFormState } from './PlanWizard';
 import { warmCriticalConcerns, someVMHasConcern } from './helpers';
 import { SourceInventoryProvider, SourceVM } from '@app/queries/types';
 import { StatusIcon } from '@konveyor/lib-ui';
+import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 interface ITypeFormProps {
   form: PlanWizardFormState['type'];
@@ -55,7 +56,7 @@ const TypeForm: React.FunctionComponent<ITypeFormProps> = ({
               <div className={`${spacing.mtMd} ${spacing.mlXs}`}>
                 <StatusIcon
                   status="Info"
-                  label="Warm migration is not currently supported for Red Hat Virtualization providers."
+                  label={`Warm migration is not currently supported for ${PROVIDER_TYPE_NAMES.ovirt} providers.`}
                 />
               </div>
             ) : isAnalysingVms ? (

--- a/src/app/Providers/HostsPage.tsx
+++ b/src/app/Providers/HostsPage.tsx
@@ -19,6 +19,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useHostsQuery, useInventoryProvidersQuery } from '@app/queries';
 import { IVMwareProvider } from '@app/queries/types';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
+import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 export interface IHostsMatchParams {
   url: string;
@@ -47,7 +48,7 @@ export const HostsPage: React.FunctionComponent = () => {
             <Breadcrumb>
               <BreadcrumbItem>Providers</BreadcrumbItem>
               <BreadcrumbItem>
-                <Link to={`/providers/vsphere`}>VMware</Link>
+                <Link to={`/providers/vsphere`}>{PROVIDER_TYPE_NAMES.vsphere}</Link>
               </BreadcrumbItem>
               <BreadcrumbItem>{match?.params.providerName}</BreadcrumbItem>
               <BreadcrumbItem isActive>Hosts</BreadcrumbItem>

--- a/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -152,7 +152,7 @@ describe('<AddEditProviderModal />', () => {
 
     const typeButton = await screen.findByRole('button', { name: /select a provider type/i });
     userEvent.click(typeButton);
-    const openshiftButton = await screen.findByRole('option', { name: /openshift/i, hidden: true });
+    const openshiftButton = await screen.findByRole('option', { name: /kubevirt/i, hidden: true });
     userEvent.click(openshiftButton);
 
     await waitFor(() => {
@@ -184,7 +184,7 @@ describe('<AddEditProviderModal />', () => {
 
     const typeButton = await screen.findByRole('button', { name: /select a provider type/i });
     userEvent.click(typeButton);
-    const openshiftButton = await screen.findByRole('option', { name: /openshift/i, hidden: true });
+    const openshiftButton = await screen.findByRole('option', { name: /kubevirt/i, hidden: true });
     userEvent.click(openshiftButton);
 
     await waitFor(() => {

--- a/src/app/Providers/components/CloudAnalyticsInfoAlert.tsx
+++ b/src/app/Providers/components/CloudAnalyticsInfoAlert.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Alert, AlertActionCloseButton, Text } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useLocalStorageContext, LocalStorageKey } from '@app/common/context/LocalStorageContext';
-import { CLOUD_MA_LINK } from '@app/common/constants';
+import { CLOUD_MA_LINK, PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 const CloudAnalyticsInfoAlert: React.FunctionComponent = () => {
   const [isAlertHidden, setIsAlertHidden] = useLocalStorageContext(
@@ -17,10 +17,11 @@ const CloudAnalyticsInfoAlert: React.FunctionComponent = () => {
 
   const alertMessage = (
     <Text>
-      You can analyze your VMware provider data with Migration Analytics. Migration Analytics
-      generates a complete inventory of your VMware environment and VM recommendations for
-      migration. Select your VMware providers and download the data file. Then log in to {link},
-      select Migration Analytics, and create a Migration Analytics report.
+      You can analyze your {PROVIDER_TYPE_NAMES.vsphere} provider data with Migration Analytics.
+      Migration Analytics generates a complete inventory of your {PROVIDER_TYPE_NAMES.vsphere}{' '}
+      environment and VM recommendations for migration. Select your {PROVIDER_TYPE_NAMES.vsphere}{' '}
+      providers and download the data file. Then log in to {link}, select Migration Analytics, and
+      create a Migration Analytics report.
     </Text>
   );
 

--- a/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
@@ -25,7 +25,7 @@ import { centerCellTransform } from '@app/utils/utils';
 
 import './OpenShiftProvidersTable.css';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { PlanStatusType } from '@app/common/constants';
+import { PlanStatusType, PROVIDER_TYPE_NAMES } from '@app/common/constants';
 import { isSameResource } from '@app/queries/helpers';
 import OpenShiftNetworkList from './OpenShiftNetworkList';
 import SelectOpenShiftNetworkModal from '@app/common/components/SelectOpenShiftNetworkModal';
@@ -213,7 +213,7 @@ const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableP
       </Level>
       <Table
         variant="compact"
-        aria-label="OpenShift Virtualization providers table"
+        aria-label={`${PROVIDER_TYPE_NAMES.openshift} providers table`}
         cells={columns}
         rows={rows}
         sortBy={sortBy}

--- a/src/app/Providers/components/ProvidersTable/OpenShift/__tests__/OpenShiftProvidersTable.test.tsx
+++ b/src/app/Providers/components/ProvidersTable/OpenShift/__tests__/OpenShiftProvidersTable.test.tsx
@@ -36,9 +36,7 @@ describe('<OpenShiftProvidersTable />', () => {
       </QueryClientProvider>
     );
 
-    expect(
-      screen.getByRole('grid', { name: /OpenShift Virtualization providers table/ })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('grid', { name: /KubeVirt providers table/ })).toBeInTheDocument();
     expect(screen.getByRole('cell', { name: /ocpv-1/ })).toBeInTheDocument();
     expect(screen.getByRole('cell', { name: /ocpv-2/ })).toBeInTheDocument();
     expect(screen.getByRole('cell', { name: /ocpv-3/ })).toBeInTheDocument();

--- a/src/app/Welcome/WelcomePage.tsx
+++ b/src/app/Welcome/WelcomePage.tsx
@@ -18,7 +18,7 @@ import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignmen
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import logoMA from './logoMA.svg';
 import { useLocalStorageContext, LocalStorageKey } from '@app/common/context/LocalStorageContext';
-import { APP_TITLE } from '@app/common/constants';
+import { APP_TITLE, PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 const WelcomePage: React.FunctionComponent = () => {
   const [isPageHidden, setIsPageHidden] = useLocalStorageContext(
@@ -44,7 +44,7 @@ const WelcomePage: React.FunctionComponent = () => {
           <FlexItem>
             <TextContent>
               <Text component="p">
-                Migrating workloads to OpenShift Virtualization is a multi-step process.
+                Migrating workloads to {PROVIDER_TYPE_NAMES.openshift} is a multi-step process.
               </Text>
               <List component="ol">
                 <ListItem>Add source and target providers for the migration.</ListItem>

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -2,8 +2,10 @@ import * as yup from 'yup';
 
 import { IEnvVars, IMetaVars } from './types';
 
+export const ENV: IEnvVars = window['_env'] || {};
+
 export const APP_TITLE =
-  process.env['BRAND_TYPE'] === 'RedHat' ? 'Migration Toolkit for Virtualization' : 'Forklift';
+  ENV.BRAND_TYPE === 'RedHat' ? 'Migration Toolkit for Virtualization' : 'Forklift';
 
 export const CLUSTER_API_VERSION = 'forklift.konveyor.io/v1beta1';
 
@@ -24,8 +26,8 @@ export const TARGET_PROVIDER_TYPES: ProviderType[] = ['openshift'];
 
 export const PROVIDER_TYPE_NAMES: Record<ProviderType, string> = {
   vsphere: 'VMware',
-  ovirt: 'Red Hat Virtualization',
-  openshift: 'OpenShift Virtualization',
+  ovirt: ENV.BRAND_TYPE === 'RedHat' ? 'Red Hat Virtualization' : 'oVirt',
+  openshift: ENV.BRAND_TYPE === 'RedHat' ? 'OpenShift Virtualization' : 'KubeVirt',
 };
 
 export enum StatusCategoryType {
@@ -77,8 +79,6 @@ export const META: IMetaVars =
         inventoryApi: '/mock/api',
         inventoryPayloadApi: '/mock/api',
       };
-
-export const ENV: IEnvVars = window['_env'] || {};
 
 export const dnsLabelNameSchema = yup
   .string()


### PR DESCRIPTION
Backports #669