### PR TITLE
fix(providers): update form field labels for better readability

### DIFF
--- a/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -36,6 +36,45 @@ describe('<AddEditProviderModal />', () => {
     expect(cancelButton).toBeEnabled();
   });
 
+  // oVirt Provider
+
+  it('allows adding a oVirt provider', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <NetworkContextProvider>
+          <Router history={history}>
+            <AddEditProviderModal {...props} providerBeingEdited={null} />
+          </Router>
+        </NetworkContextProvider>
+      </QueryClientProvider>
+    );
+
+    const typeButton = await screen.findByRole('button', { name: /select a provider type/i });
+    userEvent.click(typeButton);
+    const oVirtButton = await screen.findByRole('option', { name: /ovirt/i, hidden: true });
+    userEvent.click(oVirtButton);
+    const caCertField = screen.getByLabelText(/^File upload/);
+    await waitFor(() => {
+      const name = screen.getByRole('textbox', { name: /Name/ });
+      const hostname = screen.getByRole('textbox', {
+        name: /oVirt Engine host name or IP address/i,
+      });
+      const username = screen.getByRole('textbox', { name: /oVirt Engine user name/i });
+      const password = screen.getByLabelText(/^oVirt Engine password/);
+
+      userEvent.type(name, 'providername');
+      userEvent.type(hostname, 'host.example.com');
+      userEvent.type(username, 'username');
+      userEvent.type(password, 'password');
+      userEvent.type(caCertField, '-----BEGIN CERTIFICATE-----abc-----END CERTIFICATE-----');
+    });
+
+    const addButton = await screen.findByRole('dialog', { name: /Add provider/ });
+    expect(addButton).toBeEnabled();
+    const cancelButton = await screen.findByRole('button', { name: /Cancel/ });
+    expect(cancelButton).toBeEnabled();
+  });
+
   // Vsphere Provider
 
   it('allows adding a vsphere provider', async () => {
@@ -56,11 +95,13 @@ describe('<AddEditProviderModal />', () => {
 
     await waitFor(() => {
       const name = screen.getByRole('textbox', { name: /Name/ });
-      const hostname = screen.getByRole('textbox', { name: /hostname or ip address/i });
-      const username = screen.getByRole('textbox', { name: /username/i });
-      const password = screen.getByLabelText(/^Password/);
+      const hostname = screen.getByRole('textbox', {
+        name: /vCenter host name or IP address/i,
+      });
+      const username = screen.getByRole('textbox', { name: /vCenter user name/i });
+      const password = screen.getByLabelText(/^vCenter password/);
       const certFingerprint = screen.getByRole('textbox', {
-        name: /sha-1 fingerprint/i,
+        name: /vCenter sha-1 fingerprint/i,
       });
 
       userEvent.type(name, 'providername');
@@ -97,11 +138,13 @@ describe('<AddEditProviderModal />', () => {
 
     await waitFor(() => {
       const name = screen.getByRole('textbox', { name: /Name/ });
-      const hostname = screen.getByRole('textbox', { name: /hostname or ip address/i });
-      const username = screen.getByRole('textbox', { name: /username/i });
-      const password = screen.getByLabelText(/^Password/);
+      const hostname = screen.getByRole('textbox', {
+        name: /vCenter host name or IP address/i,
+      });
+      const username = screen.getByRole('textbox', { name: /vCenter user name/i });
+      const password = screen.getByLabelText(/^vCenter password/);
       const certFingerprint = screen.getByRole('textbox', {
-        name: /sha-1 fingerprint/i,
+        name: /vCenter sha-1 fingerprint/i,
       });
 
       userEvent.type(name, 'providername');

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -106,7 +106,6 @@ const subdomainRegex = /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[
 
 export const hostnameSchema = yup
   .string()
-  .label('Hostname or IP address')
   .max(253)
   .required()
   .test(
@@ -132,7 +131,6 @@ export const fingerprintSchema = yup
 export const usernameSchema = yup
   .string()
   .max(320)
-  .label('Username')
   .matches(/^\S*$/, {
     message: ({ label }) => `${label} must not contain spaces`,
     excludeEmptyString: true,


### PR DESCRIPTION
This PR updates the form field labels for the add provider modal. For VMware I used the "vCenter" prefix, and for RHV/oVirt I used the respective prefix for those as well. I also changed the helper text for Name/username fields based on some language from the docs, should be a little clearer for users who may be unfamiliar with what some of these properties do.

<img width="400" alt="Screen Shot 2021-07-06 at 12 32 08 PM" src="https://user-images.githubusercontent.com/5942899/124636191-44566b00-de56-11eb-99dd-065d0392f10c.png">

<img width="400" alt="Screen Shot 2021-07-06 at 12 32 15 PM" src="https://user-images.githubusercontent.com/5942899/124636192-44566b00-de56-11eb-99a4-1db027cf3a83.png">




should help close https://github.com/konveyor/forklift-ui/issues/655