### PR TITLE
Bug 1978411: Plan details: fix bug where list of VM names would only show the first name repeated

### DIFF
--- a/src/app/Plans/components/PlanDetails.tsx
+++ b/src/app/Plans/components/PlanDetails.tsx
@@ -60,8 +60,6 @@ const PlanDetails: React.FunctionComponent<IPlanDetailsProps> = ({
 
   const hookStepPostfix = plan.spec.warm ? 'cutover' : 'migration';
 
-  const getVMName = (id: string) => vms.find((vm) => (vm.id = id))?.name;
-
   return (
     <DescriptionList isHorizontal>
       <DescriptionListGroup>
@@ -133,8 +131,8 @@ const PlanDetails: React.FunctionComponent<IPlanDetailsProps> = ({
             headerContent={<div>Selected VMs</div>}
             bodyContent={
               <List id="details-selected-vms-list">
-                {plan.spec.vms.map((vm, idx) => (
-                  <li key={idx}>{getVMName(vm.id)}</li>
+                {vms.map((vm, idx) => (
+                  <li key={idx}>{vm.name}</li>
                 ))}
               </List>
             }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1978411

This fixes a bug I overlooked in #650 since I only tested it on a plan with one VM.

In this expression:
```ts
vms.find((vm) => (vm.id = id))
```
the intention was to use an equality check (`===`) instead of an assignment (`=`), but as written this `find` condition will always return true, so it will always just find the first VM in the list. This was causing the popover of VM names to just use the first VM's name for all of them:

![Screen Shot 2021-07-01 at 2 02 16 PM](https://user-images.githubusercontent.com/811963/124171158-31b6ed00-da76-11eb-86c7-56658792b0ae.png)

I realized that instead of switching that to a `===`, the `vms` prop we already have is only the selected/included VMs anyway so we can just directly loop over those to show the names instead of having a `getVMName` helper at all.

With this fix:

![Screen Shot 2021-07-01 at 2 12 37 PM](https://user-images.githubusercontent.com/811963/124171324-688d0300-da76-11eb-8d5b-48fd23b0fb9c.png)

cc @gildub 