### PR TITLE
Bug 1977657 - Concatenate Service Signing CA to global CA bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ COPY --from=builder /opt/app-root/src/dist/index.html.ejs /opt/app-root/src/view
 COPY --from=builder /opt/app-root/src/node_modules /opt/app-root/src/node_modules
 COPY --from=builder /opt/app-root/src/package.json /opt/app-root/src
 
+COPY --from=builder /opt/app-root/src/entrypoint.sh /usr/bin/entrypoint.sh
+
 ENV META_FILE="/etc/forklift-ui/meta.json"
 
-ENTRYPOINT ["npm", "run", "-d", "start"]
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Add service serving CA cert to the global CA bundle
+if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" ]; then
+    cat /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt >> /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+fi
+
+exec npm run -s start


### PR DESCRIPTION
In OpenShift 4.8, the `service-ca.crt` file contains only one CA certificate, the one for Service Serving Certificates, and this breaks the ability for NodeJS to verify Kubernetes API certificate. Previously, all the internal CA certificates were present in `service-ca.crt`. Now, they are only present in `ca.crt`.

This pull request creates an entrypoint script that concatenates the `service-ca.crt` to the `ca.crt` bundle, if it exists. A parallel pull request, https://github.com/konveyor/forklift-operator/pull/131, changes the `NODE_EXTRA_CA_CERTS` environment variable of the UI container to point to `ca.crt`, so that it uses the CA bundle with all the internal CAs and the Service Service CA.