### PR TITLE
Bug 1977657 - Put CA bundle in a writable folder

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,8 @@
 
 # Add service serving CA cert to the global CA bundle
 if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" ]; then
-    cat /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt >> /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt /opt/app-root/src/ca.crt
+    cat /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt >> /opt-app-root/src/ca.crt
 fi
 
 exec npm run -s start


### PR DESCRIPTION
It happens that `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` is not writable. This pull request creates a new CA bundle file in /opt/app-root/src, which is the user home directory, to be sure it's a writable place.