### PR TITLE
[Backport] Use history.replace() instead of history.push() when redirecting on first load of /providers route (#684)

### DIFF
--- a/src/app/Providers/ProvidersPage.tsx
+++ b/src/app/Providers/ProvidersPage.tsx
@@ -77,7 +77,7 @@ const ProvidersPage: React.FunctionComponent = () => {
       (!activeProviderType && availableProviderTypes.length > 0) ||
       (activeProviderType && !availableProviderTypes.includes(activeProviderType))
     )
-      history.push(`/providers/${availableProviderTypes[0]}`);
+      history.replace(`/providers/${availableProviderTypes[0]}`);
   }, [activeProviderType, availableProviderTypes, history]);
 
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);


### PR DESCRIPTION
Backports #684 (https://bugzilla.redhat.com/show_bug.cgi?id=1978785)