### PR TITLE
Use nodejs-14-minimal as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN npm install && npm run build
 
 # Runner image
-FROM registry.access.redhat.com/ubi8/nodejs-14
+FROM registry.access.redhat.com/ubi8/nodejs-14-minimal
 
 LABEL name="konveyor/forklift-ui" \
       description="Konveyor for Virtualization - User Interface" \


### PR DESCRIPTION
The `ubi8/nodejs-14-minimal` container image only weighs 253 MB, against 659 MB for the `ubi8/nodejs-14` image. With this pull request, we reduce the total size of the `forklift-ui` container image, hence reduce download time and save space on the nodes where the container runs.

I have built the image and tested it in a live cluster. No error, after a few tests.