### PR TITLE
[Backport] Aligned tests with changes in MTV 2.1, fixed VMWare provider, mappings and plan creation (#691)

### DIFF
--- a/qe-tests/cypress.json
+++ b/qe-tests/cypress.json
@@ -1,4 +1,4 @@
 {
-  "viewportWidth": 1280,
-  "viewportHeight": 800
+  "viewportWidth": 1920,
+  "viewportHeight": 1080
 }

--- a/qe-tests/cypress/integration/models/mapping.ts
+++ b/qe-tests/cypress/integration/models/mapping.ts
@@ -55,11 +55,12 @@ export class Mapping {
     openSidebarMenu();
 
     // Expanding sidebar mapping menu
-    cy.get(buttonNavLink).then(($mappings) => {
-      if ($mappings.attr('aria-expanded') == 'false') {
-        clickByText(buttonNavLink, mappings);
-      }
-    });
+    // cy.get(buttonNavLink).then(($mappings) => {
+    //   if ($mappings.attr('aria-expanded') == 'false') {
+    //     clickByText(buttonNavLink, mappings);
+    //   }
+    // });
+    clickByText(buttonNavLink, mappings);
   }
 
   protected createMappingPeer(mappingPeer: MappingPeer[]): void {

--- a/qe-tests/cypress/integration/models/mappingNetwork.ts
+++ b/qe-tests/cypress/integration/models/mappingNetwork.ts
@@ -1,14 +1,14 @@
 import { Mapping } from './mapping';
 import { clickByText } from '../../utils/utils';
 import { network } from '../types/constants';
-import { menuNavLink } from '../views/mapping.view';
+import { menuTabLink } from '../views/mapping.view';
 import { MappingData } from '../types/types';
 
 export class MappingNetwork extends Mapping {
   protected openMenu(): void {
     super.openMenu();
     //Clicking on Network menu item
-    clickByText(menuNavLink, network);
+    clickByText(menuTabLink, network);
   }
 
   create(mappingData: MappingData): void {

--- a/qe-tests/cypress/integration/models/mappingStorage.ts
+++ b/qe-tests/cypress/integration/models/mappingStorage.ts
@@ -1,7 +1,7 @@
 import { Mapping } from './mapping';
 import { clickByText } from '../../utils/utils';
 import { storage } from '../types/constants';
-import { menuNavLink } from '../views/mapping.view';
+import { menuTabLink } from '../views/mapping.view';
 import { MappingData } from '../types/types';
 
 export class MappingStorage extends Mapping {
@@ -9,7 +9,7 @@ export class MappingStorage extends Mapping {
     super.openMenu();
 
     //Clicking on Network menu item
-    clickByText(menuNavLink, storage);
+    clickByText(menuTabLink, storage);
   }
 
   create(mappingData: MappingData): void {
@@ -17,7 +17,7 @@ export class MappingStorage extends Mapping {
     this.openMenu();
 
     //Clicking on Network menu item
-    clickByText(menuNavLink, storage);
+    clickByText(menuTabLink, storage);
 
     //Creating new mapping instance
     this.createDialog(mappingData);

--- a/qe-tests/cypress/integration/models/plan.ts
+++ b/qe-tests/cypress/integration/models/plan.ts
@@ -80,15 +80,15 @@ export class Plan {
   }
 
   protected filterVm(planData: PlanData): void {
-    const { vmwareSourceFqdn } = planData;
-    const selector = `[aria-label="Select Host ${vmwareSourceFqdn}"]`;
+    const { sourceClusterName } = planData;
+    const selector = `[aria-label="Select Cluster ${sourceClusterName}"]`;
     click(selector);
     next();
   }
 
   protected selectVm(planData: PlanData): void {
     const { vmwareSourceVmList } = planData;
-    const selector = 'button.pf-c-button.pf-m-control';
+    const selector = `[aria-label="search button for search input"]`;
     vmwareSourceVmList.forEach((name) => {
       inputText(searchInput, name);
       click(selector);
@@ -132,6 +132,10 @@ export class Plan {
     if (useExistingStorageMapping) {
       selectFromDroplist(mappingDropdown, name);
     }
+    next();
+  }
+
+  protected hooksStep(): void {
     next();
   }
 
@@ -224,6 +228,7 @@ export class Plan {
     this.networkMappingStep(planData);
     this.storageMappingStep(planData);
     this.selectMigrationTypeStep(planData);
+    this.hooksStep();
     this.finalReviewStep(planData);
   }
 

--- a/qe-tests/cypress/integration/tests/ocpvirt/ocpVirtConfig.ts
+++ b/qe-tests/cypress/integration/tests/ocpvirt/ocpVirtConfig.ts
@@ -57,7 +57,7 @@ export const planData: PlanData = {
   sProvider: providerData.name,
   tProvider: 'host',
   namespace: 'default',
-  vmwareSourceFqdn: 'smicro-5037-08.cfme.lab.eng.rdu2.redhat.com',
+  sourceClusterName: 'smicro-5037-08.cfme.lab.eng.rdu2.redhat.com',
   vmwareSourceVmList: ['v2v-rhel7-igor'],
   useExistingNetworkMapping: true,
   useExistingStorageMapping: true,

--- a/qe-tests/cypress/integration/tests/vmware/bostonConfig.ts
+++ b/qe-tests/cypress/integration/tests/vmware/bostonConfig.ts
@@ -63,7 +63,7 @@ export const planData: PlanData = {
   sProvider: providerData.name,
   tProvider: 'host',
   namespace: 'default',
-  vmwareSourceFqdn: 'smicro-5037-08.cfme.lab.eng.rdu2.redhat.com',
+  sourceClusterName: 'smicro-5037-08.cfme.lab.eng.rdu2.redhat.com',
   vmwareSourceVmList: ['v2v-rhel7-igor'],
   useExistingNetworkMapping: true,
   useExistingStorageMapping: true,

--- a/qe-tests/cypress/integration/tests/vmware/config_forexternal_cluster.ts
+++ b/qe-tests/cypress/integration/tests/vmware/config_forexternal_cluster.ts
@@ -71,7 +71,7 @@ export const planData: PlanData = {
   sProvider: sourceVmwareData.name,
   tProvider: 'mgn05',
   namespace: 'default',
-  vmwareSourceFqdn: 'smicro-5037-08.cfme.lab.eng.rdu2.redhat.com',
+  sourceClusterName: 'smicro-5037-08.cfme.lab.eng.rdu2.redhat.com',
   vmwareSourceVmList: ['v2v-rhel7-igor'],
   useExistingNetworkMapping: true,
   useExistingStorageMapping: true,

--- a/qe-tests/cypress/integration/tests/vmware/config_internal_mapping.ts
+++ b/qe-tests/cypress/integration/tests/vmware/config_internal_mapping.ts
@@ -63,7 +63,7 @@ export const planData: PlanData = {
   sProvider: providerData.name,
   tProvider: 'host',
   namespace: 'default',
-  vmwareSourceFqdn: 'smicro-5037-08.cfme.lab.eng.rdu2.redhat.com',
+  sourceClusterName: 'smicro-5037-08.cfme.lab.eng.rdu2.redhat.com',
   vmwareSourceVmList: ['v2v-rhel7-igor'],
   useExistingNetworkMapping: false,
   useExistingStorageMapping: false,

--- a/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts
+++ b/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts
@@ -40,7 +40,7 @@ export const networkMappingPeer: MappingPeer[] = [
 export const storageMappingPeer: MappingPeer[] = [
   {
     sProvider: 'env-esxi67-ims-h02_localdisk',
-    dProvider: storageType.cephRbd,
+    dProvider: storageType.nfs,
   },
 ];
 
@@ -63,7 +63,7 @@ export const planData: PlanData = {
   sProvider: providerData.name,
   tProvider: 'host',
   namespace: 'default',
-  vmwareSourceFqdn: 'smicro-5037-08.cfme.lab.eng.rdu2.redhat.com',
+  sourceClusterName: 'Cluster',
   vmwareSourceVmList: ['v2v-rhel7-igor'],
   useExistingNetworkMapping: true,
   useExistingStorageMapping: true,

--- a/qe-tests/cypress/integration/types/types.ts
+++ b/qe-tests/cypress/integration/types/types.ts
@@ -40,7 +40,7 @@ export type PlanData = {
   sProvider: string;
   tProvider: string;
   namespace: string;
-  vmwareSourceFqdn: string;
+  sourceClusterName: string;
   vmwareSourceVmList: string[];
   useExistingNetworkMapping: boolean;
   useExistingStorageMapping: boolean;

--- a/qe-tests/cypress/integration/views/mapping.view.ts
+++ b/qe-tests/cypress/integration/views/mapping.view.ts
@@ -1,9 +1,9 @@
 export const mappingName = '#mapping-name';
 // export const inputClass = 'input.pf-c-form-control.pf-c-select__toggle-typeahead'
 export const inputAttr = 'aria-label';
-export const buttonNavLink = 'button.pf-c-nav__link';
+export const buttonNavLink = 'a.pf-c-nav__link';
 export const buttonModal = '.pf-c-modal-box button.pf-c-button.pf-m-primary';
-export const menuNavLink = 'a.pf-c-nav__link';
+export const menuTabLink = 'span.pf-c-tabs__item-text';
 export enum dataLabel {
   name = '[data-label=Name]',
   sourceProvider = '[data-label="Source provider"]',

--- a/qe-tests/cypress/integration/views/plan.view.ts
+++ b/qe-tests/cypress/integration/views/plan.view.ts
@@ -1,7 +1,7 @@
 export const planNameInput = '#plan-name';
 export const planDescriptionInput = '#plan-description';
-export const selectSourceProviderMenu = '#provider-select-vsphere-toggle';
-export const selectDestProviderMenu = '#provider-select-openshift-toggle';
+export const selectSourceProviderMenu = '#provider-select-source-toggle';
+export const selectDestProviderMenu = '#provider-select-target-toggle';
 export const selectTargetNamespace = 'input.pf-c-form-control.pf-c-select__toggle-typeahead';
 export const allDcCheckbox =
   '#converted-root > div > button > span.pf-c-tree-view__node-check > input[type=checkbox]';
@@ -9,10 +9,10 @@ export const searchInput = '#name-input';
 export const mappingDropdown = 'button.pf-c-select__toggle';
 export const targetNetwork = '[aria-label="Select target..."]';
 export const kebab = '.pf-c-dropdown__toggle.pf-m-plain';
-export const reviewName = '#review-plan-name';
-export const reviewSourceProvider = '#review-source-provider';
-export const reviewTargetProvider = '#review-target-provider';
-export const reviewTargetNamespace = '#review-target-namespace';
+export const reviewName = '#details-plan-name';
+export const reviewSourceProvider = '#details-source-provider';
+export const reviewTargetProvider = '#details-target-provider';
+export const reviewTargetNamespace = '#details-target-namespace';
 export enum dataLabel {
   name = '[data-label=Name]',
   sourceProvider = '[data-label="Source provider"]',

--- a/qe-tests/cypress/integration/views/providerVmware.view.ts
+++ b/qe-tests/cypress/integration/views/providerVmware.view.ts
@@ -1,8 +1,8 @@
-export const instanceName = '#vmware-name';
-export const instanceHostname = '#vmware-hostname';
-export const instanceUsername = '#vmware-username';
-export const instancePassword = '#vmware-password';
-export const instanceFingerprint = '#vmware-fingerprint';
+export const instanceName = '#name';
+export const instanceHostname = '#hostname';
+export const instanceUsername = '#username';
+export const instancePassword = '#password';
+export const instanceFingerprint = '#fingerprint';
 export const addButtonModal =
   '#pf-modal-part-0 > footer > div > div > button.pf-c-button.pf-m-primary';
 export const vmwareMenu = '.pf-c-tabs__link';

--- a/qe-tests/package.json
+++ b/qe-tests/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "cypress": "^7.1.0"
+  }
+}


### PR DESCRIPTION
Backports #691 

@ibragins let's open backport PRs for all 2.1 related tests to the `release-v2.1.0` branch from here on out so we don't have to do something like https://github.com/konveyor/forklift-ui/pull/695 again later. Here is a backport for the only outstanding one so far.