### PR TITLE
Add a prompt component for route blocking

### DIFF
--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -11,11 +11,11 @@ import {
   WizardStep,
   WizardStepFunctionType,
 } from '@patternfly/react-core';
-import { Link, Prompt, Redirect, useHistory, useRouteMatch } from 'react-router-dom';
+import { Link, Redirect, useHistory, useRouteMatch } from 'react-router-dom';
 import { UseQueryResult } from 'react-query';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useFormField, useFormState } from '@konveyor/lib-ui';
-
+import { RouteGuard } from '@app/common/components/RouteGuard';
 import WizardStepContainer from './WizardStepContainer';
 import GeneralForm from './GeneralForm';
 import FilterVMsForm from './FilterVMsForm';
@@ -410,9 +410,10 @@ const PlanWizard: React.FunctionComponent = () => {
         <Redirect to="/plans" />
       ) : (
         <>
-          <Prompt
+          <RouteGuard
             when={forms.isSomeFormDirty && mutationStatus === 'idle'}
-            message="Leave this page? All unsaved changes will be lost."
+            title="Leave this page?"
+            message="All unsaved changes will be lost."
           />
           <PageSection
             title={`${!planBeingEdited ? 'Create' : 'Edit'} Migration Plan`}

--- a/src/app/common/components/RouteGuard.tsx
+++ b/src/app/common/components/RouteGuard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useHistory } from 'react-router';
 import ConfirmModal from '@app/common/components/ConfirmModal';
-import { RouteGuardOptions } from '@app/common/constants';
+import { unBlockRoute } from '@app/common/constants';
 interface IRouteGuard {
   when: boolean;
   title: string;
@@ -20,25 +20,24 @@ const RouteGuard: React.FunctionComponent<IRouteGuard> = ({
   const history = useHistory();
   const [showRouteGuard, setShowRouteGuard] = React.useState(when);
   const [currentPath, setCurrentPath] = React.useState('');
-  const unBlock = () => RouteGuardOptions.permit;
 
   React.useEffect(() => {
     if (when) {
       history.block((prompt) => {
         setCurrentPath(prompt.pathname);
         setShowRouteGuard(true);
-        return RouteGuardOptions.prevent;
+        return false;
       });
     } else {
-      history.block(unBlock());
+      history.block(unBlockRoute);
     }
     return () => {
-      history.block(unBlock());
+      history.block(unBlockRoute);
     };
   }, [history, when]);
 
   const handleOk = React.useCallback(() => {
-    history.block(unBlock());
+    history.block(unBlockRoute);
     history.push(currentPath);
   }, [currentPath, history]);
 

--- a/src/app/common/components/RouteGuard.tsx
+++ b/src/app/common/components/RouteGuard.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { useHistory } from 'react-router';
+import ConfirmModal from '@app/common/components/ConfirmModal';
+import { RouteGuardOptions } from '@app/common/constants';
+interface IRouteGuard {
+  when: boolean;
+  title: string;
+  message: string | JSX.Element;
+  okText?: string;
+  cancelText?: string;
+}
+
+const RouteGuard: React.FunctionComponent<IRouteGuard> = ({
+  when,
+  title,
+  message,
+  okText = 'OK',
+  cancelText = 'Cancel',
+}) => {
+  const history = useHistory();
+  const [showRouteGuard, setShowRouteGuard] = React.useState(when);
+  const [currentPath, setCurrentPath] = React.useState('');
+  const unBlock = () => RouteGuardOptions.permit;
+
+  React.useEffect(() => {
+    if (when) {
+      history.block((prompt) => {
+        setCurrentPath(prompt.pathname);
+        setShowRouteGuard(true);
+        return RouteGuardOptions.prevent;
+      });
+    } else {
+      history.block(unBlock());
+    }
+    return () => {
+      history.block(unBlock());
+    };
+  }, [history, when]);
+
+  const handleOk = React.useCallback(() => {
+    history.block(unBlock());
+    history.push(currentPath);
+  }, [currentPath, history]);
+
+  const handleCancel = React.useCallback(() => setShowRouteGuard(false), []);
+
+  return (
+    <ConfirmModal
+      title={title}
+      isOpen={showRouteGuard}
+      toggleOpen={handleCancel}
+      mutateFn={handleOk}
+      cancelButtonText={cancelText}
+      confirmButtonText={okText}
+      body={message}
+    />
+  );
+};
+
+export { RouteGuard };

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -140,7 +140,5 @@ export const usernameSchema = yup
     excludeEmptyString: true,
   });
 
-export enum RouteGuardOptions {
-  permit = 'permit',
-  prevent = 'prevent',
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export const unBlockRoute = () => {};

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -139,3 +139,8 @@ export const usernameSchema = yup
     message: ({ label }) => `${label} must not contain spaces`,
     excludeEmptyString: true,
   });
+
+export enum RouteGuardOptions {
+  permit = 'permit',
+  prevent = 'prevent',
+}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -11,6 +11,7 @@ import {
   LocalStorageContextProvider,
   NetworkContextProvider,
 } from '@app/common/context';
+import { RouteGuardOptions } from '@app/common/constants';
 
 const queryCache = new QueryCache();
 const queryClient = new QueryClient({ queryCache });
@@ -20,7 +21,11 @@ const App: React.FunctionComponent = () => (
     <PollingContextProvider>
       <LocalStorageContextProvider>
         <NetworkContextProvider>
-          <Router>
+          <Router
+            getUserConfirmation={(message: string, callback: (ok: boolean) => void) => {
+              callback(message === RouteGuardOptions.permit);
+            }}
+          >
             <AppLayout>
               <AppRoutes />
             </AppLayout>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -11,7 +11,7 @@ import {
   LocalStorageContextProvider,
   NetworkContextProvider,
 } from '@app/common/context';
-import { RouteGuardOptions } from '@app/common/constants';
+import { unBlockRoute } from '@app/common/constants';
 
 const queryCache = new QueryCache();
 const queryClient = new QueryClient({ queryCache });
@@ -21,19 +21,7 @@ const App: React.FunctionComponent = () => (
     <PollingContextProvider>
       <LocalStorageContextProvider>
         <NetworkContextProvider>
-          <Router
-            getUserConfirmation={(message: string, callback: (ok: boolean) => void) => {
-              const isAllowed = message === RouteGuardOptions.permit || message === '';
-              if (
-                message !== RouteGuardOptions.prevent &&
-                message !== RouteGuardOptions.permit &&
-                message !== ''
-              ) {
-                confirm(message) ? callback(true) : callback(false);
-              }
-              callback(isAllowed);
-            }}
-          >
+          <Router getUserConfirmation={unBlockRoute}>
             <AppLayout>
               <AppRoutes />
             </AppLayout>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -23,12 +23,12 @@ const App: React.FunctionComponent = () => (
         <NetworkContextProvider>
           <Router
             getUserConfirmation={(message: string, callback: (ok: boolean) => void) => {
-              const isAllowed = (message === RouteGuardOptions.permit) || message === '';
+              const isAllowed = message === RouteGuardOptions.permit || message === '';
               if (
                 message !== RouteGuardOptions.prevent &&
                 message !== RouteGuardOptions.permit &&
                 message !== ''
-                ) {
+              ) {
                 confirm(message) ? callback(true) : callback(false);
               }
               callback(isAllowed);

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -23,7 +23,15 @@ const App: React.FunctionComponent = () => (
         <NetworkContextProvider>
           <Router
             getUserConfirmation={(message: string, callback: (ok: boolean) => void) => {
-              callback(message === RouteGuardOptions.permit);
+              const isAllowed = (message === RouteGuardOptions.permit) || message === '';
+              if (
+                message !== RouteGuardOptions.prevent &&
+                message !== RouteGuardOptions.permit &&
+                message !== ''
+                ) {
+                confirm(message) ? callback(true) : callback(false);
+              }
+              callback(isAllowed);
             }}
           >
             <AppLayout>


### PR DESCRIPTION
This PR replaces our usage of react-router-dom's `Prompt` component with a custom one that recycles our existing `ConfirmModal`. Should help close https://github.com/konveyor/forklift-ui/issues/701

<img src="https://user-images.githubusercontent.com/5942899/125328688-972a9980-e312-11eb-94c0-2a0a89ac6f2a.png" alt="screenshot" width="500" />