### PR TITLE
Bug 1980587: Update plans table status filter logic to account for various plan states

### DIFF
--- a/src/app/Plans/components/PlanDetailsModal.tsx
+++ b/src/app/Plans/components/PlanDetailsModal.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import {
   IHook,
   IMetaObjectMeta,
-  InventoryProvider,
   IPlan,
   MappingType,
   SourceInventoryProvider,

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -46,14 +46,15 @@ export type ColdPlanState = Exclude<
 >;
 
 export type PlanState =
-  | 'NotStarted' // Just created, no action taken yet
+  | 'NotStarted-Ready' // Just created, no action taken yet
+  | 'NotStarted-NotReady' // Not ready for migration, likely a critical condition was encountered
   | 'Starting' // User clicked start button, Migration CR exists but no status data exists yet
   | 'Copying' // Warm-specific. "Running incremental copies" in the UI, the first stage of a warm migration
-  | 'FailedCopying' // Warm-specific. Plan was canceled during copying
+  | 'FailedCopying' // Warm-specific. Plan failed during copying
+  | 'CanceledCopying' // Warm-specific. Plan was canceled during copying
   | 'StartingCutover' // Warm-specific. User has clicked the cutover button but the first pipeline step doesn't have a start time yet
   | 'PipelineRunning' // The migration pipeline is running.
   | 'Canceled'
-  | 'CanceledCopying'
   | 'Finished-Succeeded' // Has a completed timestamp
   | 'Finished-Failed'
   | 'Finished-Incomplete';


### PR DESCRIPTION
The options in the plans table status filter dropdown were out of date, so this PR brings those options back in alignment with the states known for a plan (driven by the same logic that drives the plan status column in the table). Other than fixing the existing filter logic, another thing this does is introduce a few new statuses the user can filter by. Previously it was just Failed, Ready, Running, and Succeeded. Now we have addition options of Not Ready, Canceled, and Finished Incomplete. @vconzola are these new states ok/provide value? Let me know if we need to tweak it further.

<img width="700" alt="Screen Shot 2021-07-14 at 3 40 52 PM" src="https://user-images.githubusercontent.com/5942899/125684234-addd4315-dbf9-4978-b965-d7475a0cec8b.png">

drive status filter options from same state log as a plan state
distinguish between not started because of issues vs simply not having tried to start yet
should help close https://github.com/konveyor/forklift-ui/issues/703