### PR TITLE
RouteGuard: fix console warning, block tab from being closed or reloaded

### DIFF
--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -141,4 +141,4 @@ export const usernameSchema = yup
   });
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-export const unBlockRoute = () => {};
+export const noop = () => {};

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -11,7 +11,7 @@ import {
   LocalStorageContextProvider,
   NetworkContextProvider,
 } from '@app/common/context';
-import { unBlockRoute } from '@app/common/constants';
+import { noop } from '@app/common/constants';
 
 const queryCache = new QueryCache();
 const queryClient = new QueryClient({ queryCache });
@@ -21,7 +21,7 @@ const App: React.FunctionComponent = () => (
     <PollingContextProvider>
       <LocalStorageContextProvider>
         <NetworkContextProvider>
-          <Router getUserConfirmation={unBlockRoute}>
+          <Router getUserConfirmation={noop}>
             <AppLayout>
               <AppRoutes />
             </AppLayout>


### PR DESCRIPTION
Resolves #714.

* The `Warning: A history supports only one prompt at a time` message was coming up because `history.block` was being called more than once without properly unblocking it. Looking at [the docs for `history.block`](https://github.com/ReactTraining/history/blob/master/docs/blocking-transitions.md), it seems the correct way to unblock the route is to call the callback that gets returned from the initial call to `block` rather than calling `block` again with a noop function. The first commit in this PR accomplishes this by storing that returned callback in a ref and calling it where necessary via the ref.
* In order to block the tab from being reloaded or closed while we have our route guard in place, we need to use the `beforeunload` event. Unfortunately there is no way to prevent the unload without showing the native confirmation dialog provided by the browser, so we can't show our custom ConfirmModal in these corner cases. The second commit in this PR implements this event handler.

There was also an `} else { unblock(); }` case in the useEffect that we didn't need. useEffects call their cleanup function every time before running the effect again, so each time it runs the route will already be unblocked. So if `when` is false when the effect runs again it is sufficient to just not call `history.block`. The only places where we need to unblock are in that useEffect cleanup function and the `handleOk` function.

cc @seanforyou23 