### PR TITLE
Bug 1985475: SelectVMsForm: Ensure the latest versions of already-selected VMs are used when re-rendering from new query data

### DIFF
--- a/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
@@ -33,7 +33,7 @@ const VMConcernsDescription: React.FunctionComponent<IVMConcernsDescriptionProps
   if (vm.revisionValidated < vm.revision) {
     return (
       <TextContent className={spacing.myMd}>
-        <Text component="p">Completing migration Analysis. This might take a few minutes.</Text>
+        <Text component="p">Completing migration analysis. This might take a few minutes.</Text>
       </TextContent>
     );
   } else {

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -266,12 +266,14 @@ export const getAvailableVMs = (
 ): SourceVM[] => {
   if (!indexedTree) return [];
   const treeVMNodes = getAllVMChildren(indexedTree, selectedTreeNodes, treeType);
-  const vmSelfLinks = treeVMNodes.flatMap(({ object }) => (object ? [object.selfLink] : []));
-  const matchingVMs = indexedVMs?.findVMsBySelfLinks(vmSelfLinks) || [];
-  return [
-    ...includeExtraVMs,
-    ...matchingVMs?.filter((vm) => !includeExtraVMs.some((extraVM) => vm.id === extraVM.id)),
+  const vmSelfLinks = [
+    ...includeExtraVMs.map((vm) => vm.selfLink),
+    ...treeVMNodes
+      .flatMap(({ object }) => (object ? [object.selfLink] : []))
+      .filter((selfLink) => !includeExtraVMs.some((extraVM) => selfLink === extraVM.selfLink)),
   ];
+  const matchingVMs = indexedVMs?.findVMsBySelfLinks(vmSelfLinks) || [];
+  return matchingVMs;
 };
 
 export interface IVMTreePathInfo {


### PR DESCRIPTION
When the SelectVMsForm is mounted, if there are already any selected VMs in form state (because either you are editing an existing plan, or you have moved back and forward again in the wizard), we include those VMs in the list even if they don't match the tree-based filter. This is done by capturing the copy of `selectedVMs` from when the component is first mounted in a ref and including them when calling `getAvailableVMs` (as opposed to always including the latest selected VMs, because that way if you deselect them they can suddenly disappear from the list... it's a whole thing).

The bug with this implementation is that when new VM data comes in via polling, we were not showing the latest data for these extra VMs being included this way since we were using the copy of them from the first mount. This PR fixes it by using selfLinks as the source of truth for which VMs to include, and always getting the latest VMs from the query data for all of the selfLinks.

I hate these two wizard steps.