### PR TITLE
[Backport] Bug 1985475: SelectVMsForm: Ensure the latest versions of already-selected VMs are used when re-rendering from new query data

### DIFF
--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -89,13 +89,14 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   const [availableVMs, setAvailableVMs] = React.useState<SourceVM[] | null>(null);
   React.useEffect(() => {
     if (vmsQuery.data) {
-      const filteredVMs = getAvailableVMs(selectedTreeNodes, vmsQuery.data || [], treeType);
-      setAvailableVMs([
-        ...selectedVMsOnMount.current,
-        ...filteredVMs.filter(
-          (vm) => !selectedVMsOnMount.current.some((selectedVM) => vm.id === selectedVM.id)
-        ),
-      ]);
+      setAvailableVMs(
+        getAvailableVMs(
+          selectedTreeNodes,
+          vmsQuery.data || [],
+          treeType,
+          selectedVMsOnMount.current
+        )
+      );
     }
   }, [vmsQuery.data, selectedTreeNodes, treeType]);
 

--- a/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
@@ -33,7 +33,7 @@ const VMConcernsDescription: React.FunctionComponent<IVMConcernsDescriptionProps
   if (vm.revisionValidated < vm.revision) {
     return (
       <TextContent className={spacing.myMd}>
-        <Text component="p">Completing migration Analysis. This might take a few minutes.</Text>
+        <Text component="p">Completing migration analysis. This might take a few minutes.</Text>
       </TextContent>
     );
   } else {

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -258,13 +258,18 @@ export const getAllVMChildren = (
 export const getAvailableVMs = (
   selectedTreeNodes: InventoryTree[],
   allVMs: SourceVM[],
-  treeType: InventoryTreeType
+  treeType: InventoryTreeType,
+  includeExtraVMs: SourceVM[] = []
 ): SourceVM[] => {
-  const treeVMs = getAllVMChildren(selectedTreeNodes, treeType)
-    .map((node) => node.object)
-    .filter((object) => !!object) as ICommonTreeObject[];
-  const vmSelfLinks = treeVMs.map((object) => object.selfLink);
-  return allVMs.filter((vm) => vmSelfLinks.includes(vm.selfLink));
+  const treeVMNodes = getAllVMChildren(selectedTreeNodes, treeType);
+  const extraVMSelfLinks = includeExtraVMs.map((vm) => vm.selfLink);
+  const treeVMSelfLinks = treeVMNodes
+    .flatMap(({ object }) => (object ? [object.selfLink] : []))
+    .filter((selfLink) => !includeExtraVMs.some((extraVM) => selfLink === extraVM.selfLink));
+  return [
+    ...allVMs.filter((vm) => extraVMSelfLinks.includes(vm.selfLink)),
+    ...allVMs.filter((vm) => treeVMSelfLinks.includes(vm.selfLink)),
+  ];
 };
 
 // Given a tree and a vm, get a flattened breadcrumb of nodes from the root to the VM.


### PR DESCRIPTION
Backports #719.

Note: due to conflicts #675 (this code was totally reworked), this is a totally different (but similar) branch-specific implementation of the fix.