### PR TITLE
[Backport] Simplify and optimize Filter/Select VMs code: pre-index tree and VM data only once per new data, drive everything from the pre-indexed data (#675)

### DIFF
--- a/src/app/Plans/components/PlanDetailsModal.tsx
+++ b/src/app/Plans/components/PlanDetailsModal.tsx
@@ -29,32 +29,33 @@ const PlanDetailsModal: React.FunctionComponent<IPlanDetailsModalProps> = ({
 }: IPlanDetailsModalProps) => {
   usePausedPollingEffect();
 
-  const networkMappings = useMappingsQuery(MappingType.Network);
+  const networkMappingsQuery = useMappingsQuery(MappingType.Network);
   const networkMapping =
-    networkMappings.data?.items.find((mapping) =>
+    networkMappingsQuery.data?.items.find((mapping) =>
       isSameResource(mapping.metadata as IMetaObjectMeta, plan.spec.map.network)
     ) || null;
 
-  const storageMappings = useMappingsQuery(MappingType.Storage);
+  const storageMappingsQuery = useMappingsQuery(MappingType.Storage);
   const storageMapping =
-    storageMappings.data?.items.find((mapping) =>
+    storageMappingsQuery.data?.items.find((mapping) =>
       isSameResource(mapping.metadata as IMetaObjectMeta, plan.spec.map.storage)
     ) || null;
 
-  const providers = useInventoryProvidersQuery();
-  const allProviders = providers.data
-    ? (SOURCE_PROVIDER_TYPES.flatMap((key) => providers.data[key]) as SourceInventoryProvider[])
+  const providersQuery = useInventoryProvidersQuery();
+  const allProviders = providersQuery.data
+    ? (SOURCE_PROVIDER_TYPES.flatMap(
+        (key) => providersQuery.data[key]
+      ) as SourceInventoryProvider[])
     : [];
   const provider =
     allProviders.find((provider) => isSameResource(provider, plan.spec.provider.source)) || null;
 
-  const vms = useSourceVMsQuery(provider);
-  const selectedVMs =
-    vms.data?.filter((vm) => plan.spec.vms.find((planVM) => planVM.id === vm.id)) || [];
+  const vmsQuery = useSourceVMsQuery(provider);
+  const selectedVMs = vmsQuery.data?.findVMsByIds(plan.spec.vms.map(({ id }) => id)) || [];
 
-  const hooks = useHooksQuery();
+  const hooksQuery = useHooksQuery();
   const selectedHooks =
-    hooks.data?.items.filter((hook) =>
+    hooksQuery.data?.items.filter((hook) =>
       plan.spec.vms.find((vm) =>
         vm.hooks?.find(
           (VMHook) =>
@@ -80,10 +81,10 @@ const PlanDetailsModal: React.FunctionComponent<IPlanDetailsModalProps> = ({
   return (
     <ResolvedQueries
       results={[
-        networkMappings,
-        storageMappings,
-        providers,
-        vms,
+        networkMappingsQuery,
+        storageMappingsQuery,
+        providersQuery,
+        vmsQuery,
         ...networkMappingResources.queries,
         ...storageMappingResources.queries,
       ]}

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -41,7 +41,7 @@ import PipelineSummary, { getPipelineSummaryTitle } from '@app/common/components
 
 import { FilterCategory, FilterToolbar, FilterType } from '@app/common/components/FilterToolbar';
 import TableEmptyState from '@app/common/components/TableEmptyState';
-import { SourceVM, IVMStatus } from '@app/queries/types';
+import { IVMStatus } from '@app/queries/types';
 import {
   findLatestMigration,
   useCancelVMsMutation,
@@ -50,7 +50,6 @@ import {
   useInventoryProvidersQuery,
   findProvidersByRefs,
   useSourceVMsQuery,
-  findVMById,
 } from '@app/queries';
 import { formatTimestamp, hasCondition } from '@app/common/helpers';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
@@ -99,6 +98,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
   const { sourceProvider } = findProvidersByRefs(plan?.spec.provider || null, providersQuery);
 
   const vmsQuery = useSourceVMsQuery(sourceProvider);
+  const getVMName = (vmStatus: IVMStatus) => vmsQuery.data?.vmsById[vmStatus.id]?.name || '';
 
   const migrationsQuery = useMigrationsQuery();
   const latestMigration = findLatestMigration(plan || null, migrationsQuery.data?.items || null);
@@ -113,7 +113,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
   const getSortValues = (vmStatus: IVMStatus) => {
     return [
       '', // Expand/collapse control column
-      findVMById(vmStatus.id, vmsQuery)?.name || '',
+      getVMName(vmStatus),
       ...(!isShowingPrecopyView
         ? [
             vmStatus.started || '',
@@ -131,9 +131,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
       title: 'Name',
       type: FilterType.search,
       placeholderText: 'Filter by name ...',
-      getItemValue: (item) => {
-        return findVMById(item.id, vmsQuery)?.name || '';
-      },
+      getItemValue: getVMName,
     },
     ...(!isShowingPrecopyView
       ? [
@@ -280,7 +278,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
       disableSelection: !cancelableVMs.find((vm) => vm === vmStatus),
       isOpen: planStarted ? isExpanded : undefined,
       cells: [
-        findVMById(vmStatus.id, vmsQuery)?.name || '',
+        getVMName(vmStatus),
         ...(!isShowingPrecopyView
           ? [
               formatTimestamp(vmStatus.started),
@@ -401,9 +399,8 @@ const VMMigrationDetails: React.FunctionComponent = () => {
         isOpen={isCancelModalOpen}
         toggleOpen={toggleCancelModal}
         mutateFn={() => {
-          const vmsToCancel = selectedItems.map((vmStatus) => findVMById(vmStatus.id, vmsQuery));
-          if (vmsToCancel.some((vm) => !vm)) return;
-          cancelVMsMutation.mutate(vmsToCancel as SourceVM[]);
+          const vmsToCancel = vmsQuery.data?.findVMsByIds(selectedItems.map(({ id }) => id)) || [];
+          cancelVMsMutation.mutate(vmsToCancel);
         }}
         mutateResult={cancelVMsMutation}
         title="Cancel migrations?"
@@ -414,9 +411,9 @@ const VMMigrationDetails: React.FunctionComponent = () => {
             Migration of the following VMs will be stopped, and any partially created resources on
             the target provider will be deleted.
             <List className={spacing.mtSm}>
-              {selectedItems.map((vm) => (
-                <ListItem key={vm.id}>
-                  <strong>{findVMById(vm.id, vmsQuery)?.name || ''}</strong>
+              {selectedItems.map((vmStatus) => (
+                <ListItem key={vmStatus.id}>
+                  <strong>{getVMName(vmStatus)}</strong>
                 </ListItem>
               ))}
             </List>

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -19,7 +19,6 @@ import { IPlan, POD_NETWORK, InventoryTreeType } from '@app/queries/types';
 import {
   useClusterProvidersQuery,
   useInventoryProvidersQuery,
-  useSourceVMsQuery,
   useInventoryTreeQuery,
   useOpenShiftNetworksQuery,
   useNamespacesQuery,
@@ -99,7 +98,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   };
 
   // Cache these queries as soon as a source provider is selected so they are ready in later wizard steps
-  useSourceVMsQuery(form.values.sourceProvider);
   useInventoryTreeQuery(form.values.sourceProvider, InventoryTreeType.Cluster);
   useInventoryTreeQuery(form.values.sourceProvider, InventoryTreeType.VM);
 

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -38,7 +38,7 @@ import {
   IMappingBuilderItem,
   mappingBuilderItemsSchema,
 } from '@app/Mappings/components/MappingBuilder';
-import { generateMappings, getSelectedVMsFromIds, useEditingPlanPrefillEffect } from './helpers';
+import { generateMappings, useEditingPlanPrefillEffect } from './helpers';
 import {
   getMappingNameSchema,
   useMappingsQuery,
@@ -251,7 +251,7 @@ const PlanWizard: React.FunctionComponent = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mutationStatus]);
 
-  const selectedVMs = getSelectedVMsFromIds(forms.selectVMs.values.selectedVMIds, vmsQuery);
+  const selectedVMs = vmsQuery.data?.findVMsByIds(forms.selectVMs.values.selectedVMIds) || [];
 
   const steps: WizardStep[] = [
     {

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -45,12 +45,10 @@ import {
   getAvailableVMs,
   getMostSevereVMConcern,
   getVMConcernStatusLabel,
-  getVMTreePathInfoByVM,
-  IVMTreePathInfo,
-  IVMTreePathInfoByVM,
+  getVMTreePathInfo,
   vmMatchesConcernFilter,
 } from './helpers';
-import { useInventoryTreeQuery, useSourceVMsQuery } from '@app/queries';
+import { IndexedTree, useInventoryTreeQuery, useSourceVMsQuery } from '@app/queries';
 import TableEmptyState from '@app/common/components/TableEmptyState';
 import { FilterToolbar, FilterType, FilterCategory } from '@app/common/components/FilterToolbar';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
@@ -84,41 +82,25 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   );
   const vmsQuery = useSourceVMsQuery(sourceProvider);
 
+  const indexedTree: IndexedTree | undefined =
+    treeType === InventoryTreeType.Cluster ? hostTreeQuery.data : vmTreeQuery.data;
+
   // Even if some of the already-selected VMs don't match the filter, include them in the list.
   const selectedVMsOnMount = React.useRef(selectedVMs);
-  const [availableVMs, setAvailableVMs] = React.useState<SourceVM[] | null>(null);
-  React.useEffect(() => {
-    if (vmsQuery.data) {
-      const filteredVMs = getAvailableVMs(selectedTreeNodes, vmsQuery.data || [], treeType);
-      setAvailableVMs([
-        ...selectedVMsOnMount.current,
-        ...filteredVMs.filter(
-          (vm) => !selectedVMsOnMount.current.some((selectedVM) => vm.id === selectedVM.id)
-        ),
-      ]);
-    }
-  }, [vmsQuery.data, selectedTreeNodes, treeType]);
+  const availableVMs = React.useMemo(
+    () =>
+      getAvailableVMs(
+        indexedTree,
+        selectedTreeNodes,
+        vmsQuery.data,
+        treeType,
+        selectedVMsOnMount.current
+      ),
+    [indexedTree, selectedTreeNodes, vmsQuery.data, treeType]
+  );
 
-  const [treePathInfoByVM, setTreePathInfoByVM] = React.useState<IVMTreePathInfoByVM | null>(null);
-  React.useEffect(() => {
-    if (
-      (availableVMs || []).length > 0 &&
-      hostTreeQuery.data &&
-      (sourceProvider?.type === 'ovirt' || vmTreeQuery.data) // Only VMware has a VM tree
-    ) {
-      setTreePathInfoByVM(
-        getVMTreePathInfoByVM(
-          availableVMs?.map((vm) => vm.selfLink) || [],
-          hostTreeQuery.data,
-          vmTreeQuery.data || null
-        )
-      );
-    }
-  }, [availableVMs, hostTreeQuery.data, sourceProvider?.type, vmTreeQuery.data]);
-  const getVMTreeInfo = (vm: SourceVM): IVMTreePathInfo => {
-    if (treePathInfoByVM) return treePathInfoByVM[vm.selfLink];
-    return { datacenter: null, cluster: null, host: null, folders: null, folderPathStr: null };
-  };
+  const getVMInfo = (vm: SourceVM) =>
+    getVMTreePathInfo(vm.selfLink, hostTreeQuery.data, vmTreeQuery.data);
 
   const filterCategories: FilterCategory<SourceVM>[] = [
     {
@@ -161,7 +143,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
       type: FilterType.search,
       placeholderText: 'Filter by datacenter ...',
       getItemValue: (item) => {
-        const { datacenter } = getVMTreeInfo(item);
+        const { datacenter } = getVMInfo(item);
         return datacenter ? datacenter.name : '';
       },
     },
@@ -171,7 +153,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
       type: FilterType.search,
       placeholderText: 'Filter by cluster ...',
       getItemValue: (item) => {
-        const { cluster } = getVMTreeInfo(item);
+        const { cluster } = getVMInfo(item);
         return cluster ? cluster.name : '';
       },
     },
@@ -181,7 +163,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
       type: FilterType.search,
       placeholderText: 'Filter by hostname...',
       getItemValue: (item) => {
-        const { host } = getVMTreeInfo(item);
+        const { host } = getVMInfo(item);
         return host ? host.name : '';
       },
     },
@@ -193,7 +175,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
             type: FilterType.search,
             placeholderText: 'Filter by folder path ...',
             getItemValue: (item: SourceVM) => {
-              const { folderPathStr } = getVMTreeInfo(item);
+              const { folderPathStr } = getVMInfo(item);
               return folderPathStr ? folderPathStr : '';
             },
           },
@@ -207,7 +189,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   );
 
   const getSortValues = (vm: SourceVM) => {
-    const { datacenter, cluster, host, folderPathStr } = getVMTreeInfo(vm);
+    const { datacenter, cluster, host, folderPathStr } = getVMInfo(vm);
     return [
       '', // Expand control column
       '', // Checkbox column
@@ -279,7 +261,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
 
   currentPageItems.forEach((vm: SourceVM) => {
     const isExpanded = isVMExpanded(vm);
-    const { datacenter, cluster, host, folderPathStr } = getVMTreeInfo(vm);
+    const { datacenter, cluster, host, folderPathStr } = getVMInfo(vm);
 
     rows.push({
       meta: { vm },

--- a/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -115,6 +115,7 @@ describe('<AddEditProviderModal />', () => {
     userEvent.click(nextButton);
 
     expect(screen.getByRole('heading', { name: /Select VMs/ })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText('VMware VMs table')).toBeInTheDocument());
     expect(screen.getByRole('checkbox', { name: /Select row 0/ })).toBeChecked();
     expect(nextButton).toBeEnabled();
     userEvent.click(nextButton);

--- a/src/app/queries/__tests__/tree.test.ts
+++ b/src/app/queries/__tests__/tree.test.ts
@@ -1,0 +1,195 @@
+import { indexTree } from '..';
+import { MOCK_VMWARE_HOST_TREE } from '../mocks/tree.mock';
+import { InventoryTree } from '../types';
+
+describe('indexTree', () => {
+  const indexedTree = indexTree(MOCK_VMWARE_HOST_TREE);
+
+  // Quick helpers to walk the tree by child indexes for easier testing.
+  // Even though this has some complexity, results matching the real algorithms are sufficient for a meaningful test.
+  const walkSubtree = (
+    subtree: InventoryTree | null,
+    indexes: number[],
+    pathSoFar: InventoryTree[]
+  ): InventoryTree[] => {
+    if (!subtree) return pathSoFar;
+    if (indexes.length === 0) return [...pathSoFar, subtree];
+    return walkSubtree(
+      (subtree.children && subtree.children[indexes[0]]) || null,
+      indexes.slice(1),
+      [...pathSoFar, subtree]
+    );
+  };
+  const walk = (indexes: number[]): InventoryTree[] => walkSubtree(indexedTree.tree, indexes, []);
+  const find = (indexes: number[]): InventoryTree => {
+    const path = walk(indexes);
+    return path[path.length - 1];
+  };
+
+  it('sorts a tree properly', () => {
+    const v2vDC = indexedTree.tree.children?.find((node) => node.object?.name === 'V2V-DC');
+    expect(
+      v2vDC?.children?.findIndex((node) => node.object?.name === 'V2V_Cluster') || 0
+    ).toBeGreaterThan(
+      v2vDC?.children?.findIndex((node) => node.object?.name === 'Fake_Cluster') || 0
+    );
+  });
+
+  it('flattens nodes properly', () => {
+    const allNodeNames = indexedTree.flattenedNodes.map((node) => node.object?.name || null);
+    expect(allNodeNames).toEqual([
+      'Fake_DC',
+      'V2V-DC',
+      'Fake_Cluster',
+      'V2V_Cluster',
+      'jortel',
+      'esx13.v2v.bos.redhat.com',
+      'fdupont%2ftest',
+      'fdupont-test-migration',
+      'fdupont-test-migration-centos',
+      'pemcg-discovery01',
+      'pemcg-iscsi-target',
+      'vm-template-test',
+    ]);
+  });
+
+  it('finds all VM selfLinks', () => {
+    expect(indexedTree.vmSelfLinks).toEqual([
+      '/providers/vsphere/test/vms/vm-2844',
+      '/providers/vsphere/test/vms/vm-1630',
+      '/providers/vsphere/test/vms/vm-1008',
+      '/providers/vsphere/test/vms/vm-2685',
+      '/providers/vsphere/test/vms/vm-431',
+      '/providers/vsphere/test/vms/vm-template-test',
+    ]);
+  });
+
+  it('indexes all tree ancestors by selfLink', () => {
+    expect(indexedTree.ancestorsBySelfLink).toEqual({
+      '/providers/vsphere/test4/datacenters/datacenter-2760': walk([0]),
+      '/providers/vsphere/test4/datacenters/datacenter-21': walk([1]),
+      '/providers/vsphere/test4/clusters/domain-c2758': walk([1, 0]),
+      '/providers/vsphere/test4/clusters/domain-c26': walk([1, 1]),
+      '/providers/vsphere/test4/folders/group-h2800': walk([1, 2]),
+      '/providers/vsphere/test4/hosts/host-29': walk([1, 1, 0]),
+      '/providers/vsphere/test/vms/vm-2844': walk([1, 1, 0, 0]),
+      '/providers/vsphere/test/vms/vm-1630': walk([1, 1, 0, 1]),
+      '/providers/vsphere/test/vms/vm-1008': walk([1, 1, 0, 2]),
+      '/providers/vsphere/test/vms/vm-2685': walk([1, 1, 0, 3]),
+      '/providers/vsphere/test/vms/vm-431': walk([1, 1, 0, 4]),
+      '/providers/vsphere/test/vms/vm-template-test': walk([1, 1, 0, 5]),
+    });
+  });
+
+  it('indexes all descendants by selfLink', () => {
+    expect(indexedTree.descendantsBySelfLink).toEqual({
+      '/providers/vsphere/test4/datacenters/datacenter-2760': [],
+      '/providers/vsphere/test4/datacenters/datacenter-21': [
+        find([1, 0]),
+        find([1, 1]),
+        find([1, 2]),
+        find([1, 1, 0]),
+        find([1, 1, 0, 0]),
+        find([1, 1, 0, 1]),
+        find([1, 1, 0, 2]),
+        find([1, 1, 0, 3]),
+        find([1, 1, 0, 4]),
+        find([1, 1, 0, 5]),
+      ],
+      '/providers/vsphere/test4/clusters/domain-c2758': [],
+      '/providers/vsphere/test4/clusters/domain-c26': [
+        find([1, 1, 0]),
+        find([1, 1, 0, 0]),
+        find([1, 1, 0, 1]),
+        find([1, 1, 0, 2]),
+        find([1, 1, 0, 3]),
+        find([1, 1, 0, 4]),
+        find([1, 1, 0, 5]),
+      ],
+      '/providers/vsphere/test4/folders/group-h2800': [],
+      '/providers/vsphere/test4/hosts/host-29': [
+        find([1, 1, 0, 0]),
+        find([1, 1, 0, 1]),
+        find([1, 1, 0, 2]),
+        find([1, 1, 0, 3]),
+        find([1, 1, 0, 4]),
+        find([1, 1, 0, 5]),
+      ],
+      '/providers/vsphere/test/vms/vm-2844': [],
+      '/providers/vsphere/test/vms/vm-1630': [],
+      '/providers/vsphere/test/vms/vm-1008': [],
+      '/providers/vsphere/test/vms/vm-2685': [],
+      '/providers/vsphere/test/vms/vm-431': [],
+      '/providers/vsphere/test/vms/vm-template-test': [],
+    });
+  });
+
+  it('indexes VM descendants by selfLink', () => {
+    expect(indexedTree.vmDescendantsBySelfLink).toEqual({
+      '/providers/vsphere/test4/datacenters/datacenter-2760': [],
+      '/providers/vsphere/test4/datacenters/datacenter-21': [
+        find([1, 1, 0, 0]),
+        find([1, 1, 0, 1]),
+        find([1, 1, 0, 2]),
+        find([1, 1, 0, 3]),
+        find([1, 1, 0, 4]),
+        find([1, 1, 0, 5]),
+      ],
+      '/providers/vsphere/test4/clusters/domain-c2758': [],
+      '/providers/vsphere/test4/clusters/domain-c26': [
+        find([1, 1, 0, 0]),
+        find([1, 1, 0, 1]),
+        find([1, 1, 0, 2]),
+        find([1, 1, 0, 3]),
+        find([1, 1, 0, 4]),
+        find([1, 1, 0, 5]),
+      ],
+      '/providers/vsphere/test4/folders/group-h2800': [],
+      '/providers/vsphere/test4/hosts/host-29': [
+        find([1, 1, 0, 0]),
+        find([1, 1, 0, 1]),
+        find([1, 1, 0, 2]),
+        find([1, 1, 0, 3]),
+        find([1, 1, 0, 4]),
+        find([1, 1, 0, 5]),
+      ],
+      '/providers/vsphere/test/vms/vm-2844': [],
+      '/providers/vsphere/test/vms/vm-1630': [],
+      '/providers/vsphere/test/vms/vm-1008': [],
+      '/providers/vsphere/test/vms/vm-2685': [],
+      '/providers/vsphere/test/vms/vm-431': [],
+      '/providers/vsphere/test/vms/vm-template-test': [],
+    });
+  });
+
+  it('properly gets descendants both including and not including the given node', () => {
+    const dc21 = find([1]);
+    const descendantsOfDC21 = [
+      find([1, 0]),
+      find([1, 1]),
+      find([1, 2]),
+      find([1, 1, 0]),
+      find([1, 1, 0, 0]),
+      find([1, 1, 0, 1]),
+      find([1, 1, 0, 2]),
+      find([1, 1, 0, 3]),
+      find([1, 1, 0, 4]),
+      find([1, 1, 0, 5]),
+    ];
+
+    expect(indexedTree.getDescendants(dc21)).toEqual([dc21, ...descendantsOfDC21]); // Defaults to true
+    expect(indexedTree.getDescendants(dc21, true)).toEqual([dc21, ...descendantsOfDC21]);
+    expect(indexedTree.getDescendants(dc21, false)).toEqual(descendantsOfDC21);
+  });
+
+  it('gets descendants of the root node even though it has no object/selfLink', () => {
+    const descendantsIncludingRoot = indexedTree.getDescendants(MOCK_VMWARE_HOST_TREE, true);
+    const descendantsNotIncludingRoot = indexedTree.getDescendants(MOCK_VMWARE_HOST_TREE, false);
+    expect(descendantsIncludingRoot.map((node) => node.object?.name)).toEqual(
+      [MOCK_VMWARE_HOST_TREE, ...indexedTree.flattenedNodes].map((node) => node.object?.name)
+    );
+    expect(descendantsNotIncludingRoot.map((node) => node.object?.name)).toEqual(
+      indexedTree.flattenedNodes.map((node) => node.object?.name)
+    );
+  });
+});

--- a/src/app/queries/__tests__/vms.test.ts
+++ b/src/app/queries/__tests__/vms.test.ts
@@ -1,0 +1,52 @@
+import { indexVMs } from '..';
+import { MOCK_VMWARE_VMS } from '../mocks/vms.mock';
+
+describe('indexVMs', () => {
+  const indexedVMs = indexVMs(MOCK_VMWARE_VMS);
+
+  it('sorts VMs by name and filters out templates', () => {
+    expect(indexedVMs.vms.map((vm) => vm.name)).toEqual([
+      'fdupont-test',
+      'fdupont-test-migration',
+      'fdupont-test-migration-centos',
+      'pemcg-discovery01',
+      'pemcg-iscsi-target',
+    ]);
+  });
+
+  it('indexes VMs by id', () => {
+    const { vmsById } = indexedVMs;
+    expect(vmsById['vm-1630']?.name).toEqual('fdupont-test-migration');
+    expect(vmsById['vm-2844']?.name).toEqual('fdupont-test');
+    expect(vmsById['vm-1008']?.name).toEqual('fdupont-test-migration-centos');
+    expect(vmsById['vm-2685']?.name).toEqual('pemcg-discovery01');
+    expect(vmsById['vm-431']?.name).toEqual('pemcg-iscsi-target');
+  });
+
+  it('indexes VMs by selfLink', () => {
+    const { vmsBySelfLink } = indexedVMs;
+    expect(vmsBySelfLink['/providers/vsphere/test/vms/vm-1630']?.name).toEqual(
+      'fdupont-test-migration'
+    );
+    expect(vmsBySelfLink['/providers/vsphere/test/vms/vm-2844']?.name).toEqual('fdupont-test');
+    expect(vmsBySelfLink['/providers/vsphere/test/vms/vm-1008']?.name).toEqual(
+      'fdupont-test-migration-centos'
+    );
+    expect(vmsBySelfLink['/providers/vsphere/test/vms/vm-2685']?.name).toEqual('pemcg-discovery01');
+    expect(vmsBySelfLink['/providers/vsphere/test/vms/vm-431']?.name).toEqual('pemcg-iscsi-target');
+  });
+
+  it('finds multiple VMs by ids correctly, ignoring invalid ids', () => {
+    const foundVMs = indexedVMs.findVMsByIds(['vm-2844', 'vm-something-invalid', 'vm-1630']);
+    expect(foundVMs.map((vm) => vm.name)).toEqual(['fdupont-test', 'fdupont-test-migration']);
+  });
+
+  it('finds multiple VMs by selfLinks correctly, ignoring invalid selfLinks', () => {
+    const foundVMs = indexedVMs.findVMsBySelfLinks([
+      '/providers/vsphere/test/vms/vm-2844',
+      '/some/invalid/url',
+      '/providers/vsphere/test/vms/vm-1630',
+    ]);
+    expect(foundVMs.map((vm) => vm.name)).toEqual(['fdupont-test', 'fdupont-test-migration']);
+  });
+});

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -13,7 +13,6 @@ import {
 import { useHistory } from 'react-router-dom';
 import { useFetchContext } from './fetchHelpers';
 import { INameNamespaceRef, IProviderObject, ISrcDestRefs } from './types';
-import { InventoryTree } from './types/tree.types';
 import { UnknownResult } from '@app/common/types';
 
 // TODO what about usePaginatedQuery, useInfiniteQuery?
@@ -134,17 +133,6 @@ export const sortIndexedDataByName = <TItem extends { name: string }, TIndexed>(
 export const sortKubeListByName = <T>(result: IKubeList<T>) => ({
   ...result,
   items: sortByName(result.items || []),
-});
-
-export const sortTreeItemsByName = <T extends InventoryTree>(tree: T): T => ({
-  ...tree,
-  children:
-    tree.children &&
-    (tree.children as T[]).map(sortTreeItemsByName).sort((a?: T, b?: T) => {
-      if (!a || !a.object) return -1;
-      if (!b || !b.object) return 1;
-      return a.object.name < b.object.name ? -1 : 1;
-    }),
 });
 
 export const nameAndNamespace = (

--- a/src/app/queries/tree.ts
+++ b/src/app/queries/tree.ts
@@ -1,15 +1,83 @@
 import { usePollingContext } from '@app/common/context';
 import { UseQueryResult } from 'react-query';
-import { getInventoryApiUrl, sortTreeItemsByName, useMockableQuery } from './helpers';
+import { getInventoryApiUrl, useMockableQuery } from './helpers';
 import { MOCK_RHV_HOST_TREE, MOCK_VMWARE_HOST_TREE, MOCK_VMWARE_VM_TREE } from './mocks/tree.mock';
 import { SourceInventoryProvider } from './types';
 import { InventoryTree, InventoryTreeType } from './types/tree.types';
 import { useAuthorizedFetch } from './fetchHelpers';
 
+const sortTreeItemsByName = <T extends InventoryTree>(tree: T): T => ({
+  ...tree,
+  children:
+    tree.children &&
+    (tree.children as T[]).map(sortTreeItemsByName).sort((a?: T, b?: T) => {
+      if (!a || !a.object) return -1;
+      if (!b || !b.object) return 1;
+      return a.object.name < b.object.name ? -1 : 1;
+    }),
+});
+
+export interface IndexedTree<T extends InventoryTree = InventoryTree> {
+  tree: T;
+  flattenedNodes: T[];
+  vmSelfLinks: string[];
+  ancestorsBySelfLink: Record<string, T[] | undefined>; // Flattened list of nodes leading to each node
+  descendantsBySelfLink: Record<string, T[] | undefined>; // Flattened list of nodes under each node
+  vmDescendantsBySelfLink: Record<string, T[] | undefined>; // Flattened list of only VM nodes under each node
+  getDescendants: (node: InventoryTree, includeSelf?: boolean) => InventoryTree[];
+}
+
+export const indexTree = <T extends InventoryTree>(tree: T): IndexedTree<T> => {
+  const sortedTree = sortTreeItemsByName(tree);
+  const vmSelfLinks: string[] = [];
+  const ancestorsBySelfLink: Record<string, T[] | undefined> = {};
+  const descendantsBySelfLink: Record<string, T[] | undefined> = {};
+  const vmDescendantsBySelfLink: Record<string, T[] | undefined> = {};
+  const walk = (node: T, ancestors: T[] = []): T[] => {
+    if (node.object) {
+      if (node.kind === 'VM') vmSelfLinks.push(node.object.selfLink);
+      ancestorsBySelfLink[node.object.selfLink] = [...ancestors, node];
+      descendantsBySelfLink[node.object.selfLink] = [];
+      vmDescendantsBySelfLink[node.object.selfLink] = [];
+    }
+    if (node.children) {
+      const children = node.children as T[];
+      const flattenedDescendants = [
+        ...children,
+        ...children.flatMap((childNode) => walk(childNode, [...ancestors, node])),
+      ];
+      if (node.object) {
+        descendantsBySelfLink[node.object.selfLink] = flattenedDescendants;
+        vmDescendantsBySelfLink[node.object.selfLink] = flattenedDescendants.filter(
+          (n) => n.kind === 'VM'
+        );
+      }
+      return flattenedDescendants;
+    }
+    return [];
+  };
+  const getDescendants = (node: InventoryTree, includeSelf = true) => {
+    // The root node is likely the only node with no `object`, so this will probably never recurse more than once.
+    const descendants = node.object
+      ? descendantsBySelfLink[node.object.selfLink || ''] || []
+      : node.children?.flatMap((child: InventoryTree) => getDescendants(child, true)) || [];
+    return includeSelf ? [node, ...descendants] : descendants;
+  };
+  return {
+    tree: sortedTree,
+    flattenedNodes: walk(sortedTree),
+    vmSelfLinks,
+    ancestorsBySelfLink,
+    descendantsBySelfLink,
+    vmDescendantsBySelfLink,
+    getDescendants,
+  };
+};
+
 export const useInventoryTreeQuery = <T extends InventoryTree>(
   provider: SourceInventoryProvider | null,
   treeType: InventoryTreeType
-): UseQueryResult<T> => {
+): UseQueryResult<IndexedTree<T>> => {
   // VMware providers have both Host and VM trees, but RHV only has Host trees.
   const isValidQuery = provider?.type === 'vsphere' || treeType === InventoryTreeType.Cluster;
   const apiSlug =
@@ -18,13 +86,13 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
         ? '/tree/host' // TODO in the future, this vsphere tree will also be at /tree/cluster
         : '/tree/cluster'
       : '/tree/vm';
-  const result = useMockableQuery<T>(
+  return useMockableQuery<T, unknown, IndexedTree<T>>(
     {
       queryKey: ['inventory-tree', provider?.name, treeType],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}${apiSlug}`)),
       enabled: isValidQuery && !!provider,
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortTreeItemsByName,
+      select: indexTree,
     },
     (treeType === InventoryTreeType.Cluster
       ? provider?.type === 'vsphere'
@@ -32,5 +100,4 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
         : MOCK_RHV_HOST_TREE
       : MOCK_VMWARE_VM_TREE) as T
   );
-  return result;
 };

--- a/src/app/queries/types/tree.types.ts
+++ b/src/app/queries/types/tree.types.ts
@@ -15,6 +15,7 @@ interface ICommonTree {
   children: ICommonTree[] | null;
 }
 
+// TODO we should rename this to IClusterHostTree and use the cluster naming everywhere
 export interface IInventoryHostTree extends ICommonTree {
   kind: '' | 'Datacenter' | 'DataCenter' | 'Cluster' | 'Folder' | 'Host' | 'VM';
   children: IInventoryHostTree[] | null;

--- a/src/app/queries/vms.ts
+++ b/src/app/queries/vms.ts
@@ -6,27 +6,50 @@ import { MOCK_RHV_VMS, MOCK_VMWARE_VMS } from './mocks/vms.mock';
 import { SourceInventoryProvider } from './types';
 import { SourceVM, IVMwareVM } from './types/vms.types';
 
+type SourceVMsRecord = Record<string, SourceVM | undefined>;
+
+export interface IndexedSourceVMs {
+  vms: SourceVM[];
+  vmsById: SourceVMsRecord;
+  vmsBySelfLink: SourceVMsRecord;
+  findVMsByIds: (ids: string[]) => SourceVM[];
+  findVMsBySelfLinks: (selfLinks: string[]) => SourceVM[];
+}
+
+const findVMsInRecord = (record: SourceVMsRecord, keys: string[]) =>
+  keys.flatMap((key) => (record[key] ? [record[key]] : [])) as SourceVM[];
+
+export const indexVMs = (vms: SourceVM[]): IndexedSourceVMs => {
+  const sortedVMs = sortByName(vms.filter((vm) => !(vm as IVMwareVM).isTemplate));
+  const vmsById: SourceVMsRecord = {};
+  const vmsBySelfLink: SourceVMsRecord = {};
+  sortedVMs.forEach((vm) => {
+    vmsById[vm.id] = vm;
+    vmsBySelfLink[vm.selfLink] = vm;
+  });
+  return {
+    vms: sortedVMs,
+    vmsById,
+    vmsBySelfLink,
+    findVMsByIds: (ids) => findVMsInRecord(vmsById, ids),
+    findVMsBySelfLinks: (selfLinks) => findVMsInRecord(vmsBySelfLink, selfLinks),
+  };
+};
+
 export const useSourceVMsQuery = (
   provider: SourceInventoryProvider | null
-): UseQueryResult<SourceVM[]> => {
+): UseQueryResult<IndexedSourceVMs> => {
   let mockVMs: SourceVM[] = [];
   if (provider?.type === 'vsphere') mockVMs = MOCK_VMWARE_VMS;
   if (provider?.type === 'ovirt') mockVMs = MOCK_RHV_VMS;
-  const result = useMockableQuery<SourceVM[]>(
+  return useMockableQuery<SourceVM[], unknown, IndexedSourceVMs>(
     {
       queryKey: ['vms', provider?.name],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}/vms?detail=1`)),
       enabled: !!provider,
       refetchInterval: usePollingContext().refetchInterval,
-      select: (vms: SourceVM[]) => {
-        return sortByName(vms.filter((vm) => !(vm as IVMwareVM).isTemplate));
-      },
+      select: indexVMs,
     },
     mockVMs
   );
-
-  return result;
 };
-
-export const findVMById = (id: string, vmsQuery: UseQueryResult<SourceVM[]>): SourceVM | null =>
-  vmsQuery.data?.find((vm) => vm.id === id) || null;


### PR DESCRIPTION
Backporting to prevent conflicts with the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1985475.

* Simplify and optimize tree code: only traverse the tree once for treePathInfoByVM, install use-async-memo to reduce boilerplate

* Move tree indexing to a single helper used inside the query's select function

* Use pre-indexed tree for getAvailableVMs

* Add getDescendants to IndexedTree to simplify some things

* Use pre-indexed tree for finding selection nodes

* Remove TODO

* Fix test

* Also pre-index the VMs list to avoid looping over all VMs on every render

* Define select function for VMs and trees as a constant

* Trying something weird, maybe revert: don't index in select after all...

* Revert "Trying something weird, maybe revert: don't index in select after all..."

This reverts commit 4aa4968fa3f817d830bb6aef37750d7bedd499fe.

* Temporarily disable eager loading of VMs/trees in the GeneralForm

* Some minor optimization of looking up selectable descendants

* Optimize finding VM descendants

* Fixing a really dumb recursion mistake

* Try re-enabling the eager queries?

* Fix logic for finding selectable descendants on checkbox click

* Remove unused import

* Fix bug with the badge content on the root node

* Add unit tests for indexTree

* Remove use-async-memo after all

* Add unit tests for indexVMs (and fix returning sorted VMs!)

* Don't reindex the tree when switching tabs

* Fix code smells

* Cleanup: Remove recursive traversal in subtreeMatchesSearch, rename some properties for readability

* Fix bug with getDescendants not working for root node