### PR TITLE
[Backport] Bug 1985475: SelectVMsForm: Ensure the latest versions of already-selected VMs are used when re-rendering from new query data

### DIFF
--- a/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
+++ b/src/app/Plans/components/Wizard/VMConcernsDescription.tsx
@@ -33,7 +33,7 @@ const VMConcernsDescription: React.FunctionComponent<IVMConcernsDescriptionProps
   if (vm.revisionValidated < vm.revision) {
     return (
       <TextContent className={spacing.myMd}>
-        <Text component="p">Completing migration Analysis. This might take a few minutes.</Text>
+        <Text component="p">Completing migration analysis. This might take a few minutes.</Text>
       </TextContent>
     );
   } else {

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -266,12 +266,14 @@ export const getAvailableVMs = (
 ): SourceVM[] => {
   if (!indexedTree) return [];
   const treeVMNodes = getAllVMChildren(indexedTree, selectedTreeNodes, treeType);
-  const vmSelfLinks = treeVMNodes.flatMap(({ object }) => (object ? [object.selfLink] : []));
-  const matchingVMs = indexedVMs?.findVMsBySelfLinks(vmSelfLinks) || [];
-  return [
-    ...includeExtraVMs,
-    ...matchingVMs?.filter((vm) => !includeExtraVMs.some((extraVM) => vm.id === extraVM.id)),
+  const vmSelfLinks = [
+    ...includeExtraVMs.map((vm) => vm.selfLink),
+    ...treeVMNodes
+      .flatMap(({ object }) => (object ? [object.selfLink] : []))
+      .filter((selfLink) => !includeExtraVMs.some((extraVM) => selfLink === extraVM.selfLink)),
   ];
+  const matchingVMs = indexedVMs?.findVMsBySelfLinks(vmSelfLinks) || [];
+  return matchingVMs;
 };
 
 export interface IVMTreePathInfo {


### PR DESCRIPTION
Backports #719 (replaces #720)