### PR TITLE
fix(723): ensure user is navigated to new provider tab on adding a new provider

### DIFF
--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -18,7 +18,7 @@ import {
   IVMwareVM,
   IRHVVM,
 } from '@app/queries/types';
-import { ClusterIcon, OutlinedHddIcon, FolderIcon } from '@patternfly/react-icons';
+import { ClusterIcon, FolderIcon } from '@patternfly/react-icons';
 import {
   getBuilderItemsFromMappingItems,
   getBuilderItemsWithMissingSources,

--- a/src/app/Providers/ProvidersPage.tsx
+++ b/src/app/Providers/ProvidersPage.tsx
@@ -134,7 +134,12 @@ const ProvidersPage: React.FunctionComponent = () => {
         <ResolvedQueries results={allQueries} errorTitles={allErrorTitles} errorsInline={false}>
           <Card>
             <CardBody>
-              {!clusterProvidersQuery.data || !inventoryProvidersQuery.data || areProvidersEmpty ? (
+              {!clusterProvidersQuery.data ||
+              !inventoryProvidersQuery.data ||
+              areProvidersEmpty ||
+              !clusterProvidersQuery.data?.items
+                .map((provider) => provider.spec.type)
+                .includes(activeProviderType) ? (
                 <EmptyState className={spacing.my_2xl}>
                   <EmptyStateIcon icon={PlusCircleIcon} />
                   <Title headingLevel="h2" size="lg">

--- a/src/app/Providers/ProvidersPage.tsx
+++ b/src/app/Providers/ProvidersPage.tsx
@@ -18,7 +18,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useHistory } from 'react-router-dom';
 
-import { ProviderType, PROVIDER_TYPE_NAMES } from '@app/common/constants';
+import { ProviderType, PROVIDER_TYPE_NAMES, PROVIDER_TYPES } from '@app/common/constants';
 import { useClusterProvidersQuery, useInventoryProvidersQuery, usePlansQuery } from '@app/queries';
 
 import ProvidersTable from './components/ProvidersTable';
@@ -72,13 +72,13 @@ const ProvidersPage: React.FunctionComponent = () => {
 
   const activeProviderType = match?.params.providerType || null;
 
+  const isValidProviderType = !!(activeProviderType && PROVIDER_TYPES.includes(activeProviderType));
+
   React.useEffect(() => {
-    if (
-      (!activeProviderType && availableProviderTypes.length > 0) ||
-      (activeProviderType && !availableProviderTypes.includes(activeProviderType))
-    )
+    if ((!isValidProviderType || !activeProviderType) && availableProviderTypes.length > 0) {
       history.replace(`/providers/${availableProviderTypes[0]}`);
-  }, [activeProviderType, availableProviderTypes, history]);
+    }
+  }, [activeProviderType, availableProviderTypes, history, isValidProviderType]);
 
   const [isAddEditModalOpen, toggleAddEditModal] = React.useReducer((isOpen) => !isOpen, false);
   const [providerBeingEdited, setProviderBeingEdited] = React.useState<IProviderObject | null>(

--- a/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
+++ b/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
@@ -7,6 +7,7 @@ import {
   AlertActionCloseButton,
   SpinnerProps,
   AlertProps,
+  AlertGroup,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { KubeClientError } from '@app/client/types';
@@ -61,10 +62,9 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
       {status === 'loading' || forceLoadingState ? (
         spinner
       ) : status === 'error' ? (
-        <div>
+        <AlertGroup aria-live="assertive">
           {erroredResults.map((result, index) => (
             <Alert
-              isLiveRegion
               key={`error-${index}`}
               variant="danger"
               isInline={errorsInline}
@@ -99,7 +99,7 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
               ) : null}
             </Alert>
           ))}
-        </div>
+        </AlertGroup>
       ) : (
         children
       )}

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -259,7 +259,7 @@ export const useDeleteProviderMutation = (
             ? {
                 ...oldData,
                 items: oldData.items.filter(
-                  (item) => item.metadata.name !== provider.metadata.name
+                  (item) => !isSameResource(item.metadata, provider.metadata)
                 ),
               }
             : mockKubeList([], 'Providers')
@@ -271,7 +271,7 @@ export const useDeleteProviderMutation = (
               ...oldData,
               [providerType]: (
                 (oldData ? oldData[providerType] : []) as InventoryProvider[]
-              ).filter((p) => p.name !== provider.metadata.name),
+              ).filter((p) => !isSameResource(p, provider.metadata)),
             } as IProvidersByType)
         );
         onSuccess && onSuccess();


### PR DESCRIPTION
This PR updates the logic around when a first or last provider is added/deleted to ensure the user is always sent to a correct provider tab.

- Adding a new provider always switches you to that provider tab
- Navigating to an unknown provider (for example /providers/foo) should redirect you to `/providers` (or `/providers/availableProviderType` if one exist)
- Removing the last provider of a given type should also redirect you to `/providers` (or `/providers/availableProviderType` if one exist)

Should help close https://github.com/konveyor/forklift-ui/issues/723