### PR TITLE
Centralize PR-BZ map

### DIFF
--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -33,5 +33,5 @@ jobs:
           bz_product: "Migration Toolkit for Virtualization"
           title: ${{ github.event.pull_request.title }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch_to_release: "release-v2.0.0:2.0.0,release-v2.1.0:2.1.0,main:2.1.0"
+          branch_to_release: ${{ secrets.MTV_PR_BZ_MAP }}
           base_branch: ${{ github.base_ref }}


### PR DESCRIPTION
https://github.com/konveyor/bz-github-action/issues/10

This will need to be picked to any active release branches, such as `release-v2.1.0`.