### PR TITLE
Block the plan name 'create' to prevent a URL path conflict

### DIFF
--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -258,8 +258,14 @@ export const getPlanNameSchema = (
   plansQuery: UseQueryResult<IKubeList<IPlan>>,
   planBeingEdited: IPlan | null
 ): yup.StringSchema =>
-  dnsLabelNameSchema.test('unique-name', 'A plan with this name already exists', (value) => {
-    if (planBeingEdited?.metadata.name === value) return true;
-    if (plansQuery.data?.items.find((plan) => plan.metadata.name === value)) return false;
-    return true;
-  });
+  dnsLabelNameSchema
+    .test('unique-name', 'A plan with this name already exists', (value) => {
+      if (planBeingEdited?.metadata.name === value) return true;
+      if (plansQuery.data?.items.find((plan) => plan.metadata.name === value)) return false;
+      return true;
+    })
+    .test(
+      'non-reserved-name',
+      'This name is reserved due to a path conflict and cannot be used',
+      (value) => value !== 'create'
+    );


### PR DESCRIPTION
Here's a dumb one. In our UI if you navigate to `/plans/create` you get the plan wizard, and if you navigate to `/plans/myPlan` you get the migration details for "myPlan". I only just realized that this means if you create a plan with the name "create", you can never view its migration details because the wizard route matches first.

There's probably a better way to fix this, but just for now I'm blocking the name "create" in the plan wizard.

![Screen Shot 2021-07-30 at 11 23 37 AM](https://user-images.githubusercontent.com/811963/127675516-e7020187-9d23-42ed-902a-0a3c545d8da5.png)
