### PR TITLE
Bug 1985787: Fix blank columns in Select VMs step for RHV VMs

### DIFF
--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -274,7 +274,7 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
         vm.name,
         datacenter?.name || '',
         cluster?.name || '',
-        host?.name || '',
+        host?.name || 'N/A',
         ...(sourceProvider?.type === 'vsphere' ? [folderPathStr || ''] : []),
       ],
     });

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -308,7 +308,9 @@ export const getVMTreePathInfo = (
         .map((node) => node.object) as ICommonTreeObject[]) || null;
   }
   return {
-    datacenter: hostTreeAncestors?.find((node) => node.kind === 'Datacenter')?.object || null,
+    datacenter:
+      hostTreeAncestors?.find((node) => node.kind === 'Datacenter' || node.kind === 'DataCenter')
+        ?.object || null,
     cluster: hostTreeAncestors?.find((node) => node.kind === 'Cluster')?.object || null,
     host: hostTreeAncestors?.find((node) => node.kind === 'Host')?.object || null,
     folders,

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -79,7 +79,7 @@ export const useIsNodeSelectableCallback = (
     (node: InventoryTree) => {
       if (isIncludedLeafNode(node)) return true;
       if (treeType === InventoryTreeType.VM) {
-        return node.kind === 'Folder' || node.kind === 'Datacenter';
+        return node.kind === 'Folder' || node.kind.toLowerCase() === 'datacenter';
       }
       return false;
     },
@@ -246,7 +246,7 @@ const getAllVMChildren = (
         // Only include direct children of nodes in the folder tree so we can exclude subfolders
         if (
           node.kind === 'Folder' ||
-          (treeType === InventoryTreeType.VM && node.kind === 'Datacenter')
+          (treeType === InventoryTreeType.VM && node.kind.toLowerCase() === 'datacenter')
         ) {
           return node.children?.filter((child) => child.kind === 'VM') || [];
         }
@@ -309,8 +309,7 @@ export const getVMTreePathInfo = (
   }
   return {
     datacenter:
-      hostTreeAncestors?.find((node) => node.kind === 'Datacenter' || node.kind === 'DataCenter')
-        ?.object || null,
+      hostTreeAncestors?.find((node) => node.kind.toLowerCase() === 'datacenter')?.object || null,
     cluster: hostTreeAncestors?.find((node) => node.kind === 'Cluster')?.object || null,
     host: hostTreeAncestors?.find((node) => node.kind === 'Host')?.object || null,
     folders,

--- a/src/app/queries/mocks/tree.mock.ts
+++ b/src/app/queries/mocks/tree.mock.ts
@@ -142,7 +142,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     object: null,
     children: [
       {
-        kind: 'Datacenter',
+        kind: 'DataCenter',
         object: {
           id: '30528e0a-23eb-11e8-805f-00163e18b6f7',
           name: 'Default',


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1985787.

Resolves #724

* In the RHV/oVirt tree data, the `Datacenter` kind is spelled differently: `DataCenter` with a capital C. Our `getVMTreePathInfo` helper was not accounting for this, so that column was showing up empty for RHV VMs. This PR adds a condition for that in `getVMTreePathInfo` and updates the mock data to match.
* RHV VMs that are powered off are not associated with a host, so that column was blank for those VMs. Instead of leaving it blank, this PR changes it to say 'N/A' so as to be less broken-looking (based on discussion with @vconzola).