### PR TITLE
Bug 1986839: If a warm migration is executing but has no precopy data, use Starting state instead of default state (PipelineRunning)

### DIFF
--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -154,18 +154,21 @@ export const getPlanState = (
     const cutoverTimePassed =
       migration?.spec.cutover && new Date(migration.spec.cutover).getTime() < new Date().getTime();
 
-    if (cutoverTimePassed && pipelineHasStarted) {
-      return 'PipelineRunning';
-    }
-
     if (isWarm) {
-      if (cutoverTimePassed && !pipelineHasStarted) {
-        return 'StartingCutover';
+      if (cutoverTimePassed) {
+        if (!pipelineHasStarted) {
+          return 'StartingCutover';
+        } else {
+          return 'PipelineRunning';
+        }
       }
 
       if (plan.status?.migration?.vms?.some((vm) => (vm.warm?.precopies?.length || 0) > 0)) {
         return 'Copying';
       }
+
+      // Warm migration executing, cutover time not passed, no precopy data: show Starting until copy data appears
+      return 'Starting';
     }
 
     return 'PipelineRunning';


### PR DESCRIPTION
Should resolve https://bugzilla.redhat.com/show_bug.cgi?id=1986839

If I'm correct, the issue comes down to a transient state where a warm plan has the Executing condition and does have data in its `status` property, but does not yet have data in any of its `status.migration.vms[].warm.precopies` arrays. So it doesn't fit the cases for 'StartingCutover' or 'Copying', and since the plan has the Executing condition the UI falls back to the 'PipelineRunning' state when none of the other state logic applies. This PR changes the fallback state to 'Starting' in this case (previously, this state was only used if there was no `status` data at all).