### PR TITLE
Bug 1984471: Fix passing wrong bearer token to inventory API, clean up NetworkContext usage of auth token

### DIFF
--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -200,10 +200,9 @@ export const checkIfResourceExists = async (
 
 export const useClientInstance = (): KubeClient.ClusterClient => {
   const { currentUser } = useNetworkContext();
-  const currentUserString = currentUser !== null ? JSON.parse(currentUser || '{}') : {};
   const user = {
-    access_token: currentUserString.access_token,
-    expiry_time: currentUserString.expiry_time,
+    access_token: currentUser.access_token || '',
+    expiry_time: currentUser.expiry_time || 0,
   };
   return ClientFactory.cluster(user, '/cluster-api');
 };

--- a/src/app/queries/fetchHelpers.ts
+++ b/src/app/queries/fetchHelpers.ts
@@ -1,4 +1,3 @@
-import { META } from '@app/common/constants';
 import { INetworkContext, useNetworkContext } from '@app/common/context/NetworkContext';
 import { QueryFunction, MutateFunction } from 'react-query/types/core/types';
 import { useHistory } from 'react-router-dom';
@@ -10,12 +9,13 @@ import { IKubeResponse, IKubeStatus } from '@app/client/types';
 interface IFetchContext {
   history: History<LocationState>;
   checkExpiry: INetworkContext['checkExpiry'];
+  currentUser: INetworkContext['currentUser'];
 }
 
-export const useFetchContext = (): IFetchContext => ({
-  history: useHistory(),
-  checkExpiry: useNetworkContext().checkExpiry,
-});
+export const useFetchContext = (): IFetchContext => {
+  const { checkExpiry, currentUser } = useNetworkContext();
+  return { history: useHistory(), checkExpiry, currentUser };
+};
 
 export const authorizedFetch = async <T>(
   url: string,
@@ -26,7 +26,7 @@ export const authorizedFetch = async <T>(
   try {
     const response = await fetch(url, {
       headers: {
-        Authorization: `Bearer ${META.oauth.clientSecret}`,
+        Authorization: `Bearer ${fetchContext.currentUser.access_token}`,
         ...extraHeaders,
       },
     });


### PR DESCRIPTION
In https://github.com/konveyor/forklift-ui/pull/94 we set the `Authorization` header to pass the `oauth.clientSecret` from meta.json as the bearer token to the inventory API. That has been incorrect all along, and was just fine because the inventory ignores that token currently. @jortel is testing enabling auth in the inventory API and this is causing errors.

This PR passes the oauth `access_token` correctly in this header to resolve the new issues with the authenticated inventory requests.

I also cleaned up how we handle the `currentUser` value in our `useNetworkContext`. Instead of passing around the JSON-stringified value and parsing it where we need it, it gets parsed in that hook and the parsed value is available everywhere.

https://bugzilla.redhat.com/show_bug.cgi?id=1984471