### PR TITLE
Add server-only env vars for UI_TLS_ENABLED, UI_TLS_CERTIFICATE and UI_TLS_KEY

### DIFF
--- a/config/helpers.js
+++ b/config/helpers.js
@@ -43,10 +43,28 @@ const FORKLIFT_ENV = [
   'FORKLIFT_VALIDATION_GIT_COMMIT',
   'FORKLIFT_CLUSTER_VERSION',
 ];
+const FORKLIFT_SERVER_ONLY_ENV = [
+  'META_FILE',
+  'EXPRESS_PORT',
+  'STATIC_DIR',
+  'UI_TLS_ENABLED',
+  'UI_TLS_KEY',
+  'UI_TLS_CERTIFICATE',
+];
 
-const getEnv = () =>
-  FORKLIFT_ENV.reduce((newObj, varName) => ({ ...newObj, [varName]: process.env[varName] }), {});
+const getEnv = (vars = FORKLIFT_ENV) =>
+  vars.reduce((newObj, varName) => ({ ...newObj, [varName]: process.env[varName] }), {});
+const getServerOnlyEnv = () => getEnv(FORKLIFT_SERVER_ONLY_ENV);
+const getBuildEnv = () => getEnv([...FORKLIFT_ENV, ...FORKLIFT_SERVER_ONLY_ENV]);
 
 const getEncodedEnv = () => Buffer.from(JSON.stringify(getEnv())).toString('base64');
 
-module.exports = { getDevMeta, sanitizeAndEncodeMeta, getAppTitle, getEnv, getEncodedEnv };
+module.exports = {
+  getDevMeta,
+  sanitizeAndEncodeMeta,
+  getAppTitle,
+  getEnv,
+  getServerOnlyEnv,
+  getBuildEnv,
+  getEncodedEnv,
+};

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -7,7 +7,7 @@ const BG_IMAGES_DIRNAME = 'bgimages';
 const helpers = require('./helpers');
 
 console.log('\nEnvironment at build time:');
-console.log(helpers.getEnv());
+console.log(helpers.getBuildEnv());
 
 module.exports = (env) => {
   return {

--- a/deploy/server.js
+++ b/deploy/server.js
@@ -18,14 +18,16 @@ if (process.env['DATA_SOURCE'] === 'mock') {
   metaStr = fs.readFileSync(metaFile, 'utf8');
 }
 
-console.log('\nEnvironment at run time:');
-console.log(helpers.getEnv());
+console.log('\nEnvironment at run time:\n');
+console.log('Available to server and browser:', helpers.getEnv());
+console.log('Available to server only:', helpers.getServerOnlyEnv());
 
-console.log(`\nValues from meta.json:\n${metaStr}\n\n`);
 const meta = JSON.parse(metaStr);
+console.log('\nValues from meta.json:', meta);
 
 const app = express();
-const port = process.env['EXPRESS_PORT'] || 8080;
+const port =
+  process.env['EXPRESS_PORT'] || (process.env['UI_TLS_ENABLED'] !== 'false' ? 8443 : 8080);
 const staticDir = process.env['STATIC_DIR'] || path.join(__dirname, '../dist');
 
 app.engine('ejs', require('ejs').renderFile);
@@ -148,12 +150,20 @@ app.get('*', (_, res) => {
   }
 });
 
-if (process.env['NODE_ENV'] !== 'development' && process.env['DATA_SOURCE'] !== 'mock') {
+if (
+  process.env['UI_TLS_ENABLED'] !== 'false' &&
+  process.env['NODE_ENV'] !== 'development' &&
+  process.env['DATA_SOURCE'] !== 'mock'
+) {
   const options = {
-    key: fs.readFileSync('/var/run/secrets/forklift-ui-serving-cert/tls.key'),
-    cert: fs.readFileSync('/var/run/secrets/forklift-ui-serving-cert/tls.crt'),
+    key: fs.readFileSync(
+      process.env['UI_TLS_KEY'] || '/var/run/secrets/forklift-ui-serving-cert/tls.key'
+    ),
+    cert: fs.readFileSync(
+      process.env['UI_TLS_CERTIFICATE'] || '/var/run/secrets/forklift-ui-serving-cert/tls.crt'
+    ),
   };
-  https.createServer(options, app).listen(8443);
+  https.createServer(options, app).listen(port);
 } else {
   app.listen(port, () => console.log(`Listening on port ${port}`));
 }


### PR DESCRIPTION
Resolves #738.

The Express server now looks for three new environment variables at run time. If omitted, Express will default to its prior behavior (TLS enabled, using the key and crt files from `/var/run/secrets/forklift-ui-serving-cert/`).

* `UI_TLS_ENABLED`
  * If set to `false`, Express will listen using HTTP on the port set by `EXPRESS_PORT` or default to port 8080.
  * If omitted or set to `true`, Express will listen using HTTPS on the port set by `EXPRESS_PORT` or default to port 8443.
* `UI_TLS_CERTIFICATE`
  * The file path to the serving `.crt` file. Defaults to `/var/run/secrets/forklift-ui-serving-cert/tls.crt`.
* `UI_TLS_KEY`
  * The file path to the serving cert's `.key` file. Defaults to `/var/run/secrets/forklift-ui-serving-cert/tls.key`.

For debugging purposes, this PR also adds a log statement for environment variables not included in the browser's encoded `_env` object, including the existing `META_FILE`, `EXPRESS_PORT` and `STATIC_DIR`.