### PR TITLE
Bug 1990986: Change oauth `redirectUri` to `redirectUrl` to match operator

### DIFF
--- a/config/meta.dev.example.json
+++ b/config/meta.dev.example.json
@@ -4,7 +4,7 @@
   "devServerPort": 9000,
   "oauth": {
     "clientId": "forklift-ui-dev",
-    "redirectUri": "http://localhost:9000/login/callback",
+    "redirectUrl": "http://localhost:9000/login/callback",
     "userScope": "user:full",
     "clientSecret": "bWlncmF0aW9ucy5vcGVuc2hpZnQuaW8K"
   },

--- a/deploy/server.js
+++ b/deploy/server.js
@@ -38,7 +38,7 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
     try {
       const clusterAuth = await getClusterAuth(meta);
       const authorizationUri = clusterAuth.authorizeURL({
-        redirect_uri: meta.oauth.redirectUri,
+        redirect_uri: meta.oauth.redirectUrl,
         scope: meta.oauth.userScope,
       });
 
@@ -56,7 +56,7 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
     const { code } = req.query;
     const options = {
       code,
-      redirect_uri: meta.oauth.redirectUri,
+      redirect_uri: meta.oauth.redirectUrl,
     };
     try {
       const clusterAuth = await getClusterAuth(meta);

--- a/scripts/remote-dev.js
+++ b/scripts/remote-dev.js
@@ -21,7 +21,7 @@ try {
 
 function setupOAuthClient() {
   const meta = helpers.getDevMeta();
-  const oauthRedirectUri = `http://localhost:${meta.devServerPort}/login/callback`;
+  const oauthRedirectUrl = `http://localhost:${meta.devServerPort}/login/callback`;
 
   const oauthClientName = meta.oauth.clientId;
   const remoteDevSecret = meta.oauth.clientSecret;
@@ -51,7 +51,7 @@ function setupOAuthClient() {
       name: oauthClientName,
     },
     grantMethod: 'auto', // consider 'prompt'?
-    redirectURIs: [oauthRedirectUri],
+    redirectURIs: [oauthRedirectUrl],
     secret: remoteDevSecret,
   };
 

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -74,7 +74,7 @@ export const META: IMetaVars =
         devServerPort: 'mock-port',
         oauth: {
           clientId: 'mock-client-id',
-          redirectUri: '/mock/redirect/uri',
+          redirectUrl: '/mock/redirect/uri',
           userScope: '/mock/user-scope',
           clientSecret: 'mock-client-secret',
         },

--- a/src/app/common/types.ts
+++ b/src/app/common/types.ts
@@ -6,7 +6,7 @@ export interface IMetaVars {
   devServerPort: string;
   oauth: {
     clientId: string;
-    redirectUri: string;
+    redirectUrl: string;
     userScope: string;
     clientSecret: string;
   };


### PR DESCRIPTION
In the operator, the `meta.json` file that gets mounted has an `oauth.redirectUrl` property (note the spelling of URL). See https://github.com/konveyor/forklift-operator/blob/main/roles/forkliftcontroller/templates/configmap-ui.yml.j2#L19 In our UI code, when we set up our oauth client we use `redirectUri` (note the spelling of URI, not URL). https://github.com/konveyor/forklift-ui/blob/main/deploy/server.js#L38-L41

In testing things on Jeff's cluster, he was having issues logging in because the `redirect_uri` URL param of his login page URL was blank. Manually changing these to match fixed the issue.

My big open question is.... **_how in the hell did this ever work??_** I've given up on understanding that for now...