### PR TITLE
fix(fetch): relax query/polling logic

### DIFF
--- a/src/app/common/context/PollingContext.tsx
+++ b/src/app/common/context/PollingContext.tsx
@@ -1,14 +1,9 @@
-import {
-  AFTER_MUTATION_WINDOW,
-  POLLING_INTERVAL,
-  POLLING_INTERVAL_AFTER_MUTATION,
-} from '@app/queries/constants';
+import { POLLING_INTERVAL } from '@app/queries/constants';
 import * as React from 'react';
 
 interface IPollingContext {
   isPollingEnabled: boolean;
   refetchInterval: number | false;
-  pollFasterAfterMutation: () => void;
   pausePolling: () => void;
   resumePolling: () => void;
 }
@@ -16,7 +11,6 @@ interface IPollingContext {
 const PollingContext = React.createContext<IPollingContext>({
   isPollingEnabled: true,
   refetchInterval: false,
-  pollFasterAfterMutation: () => undefined,
   pausePolling: () => undefined,
   resumePolling: () => undefined,
 });
@@ -29,31 +23,16 @@ export const PollingContextProvider: React.FunctionComponent<IPollingContextProv
   children,
 }: IPollingContextProviderProps) => {
   const [isPollingEnabled, setIsPollingEnabled] = React.useState(true);
-  const [isJustAfterMutation, setIsJustAfterMutation] = React.useState(false);
 
-  const refetchInterval = !isPollingEnabled
-    ? false
-    : isJustAfterMutation
-    ? POLLING_INTERVAL_AFTER_MUTATION
-    : POLLING_INTERVAL;
+  const refetchInterval = !isPollingEnabled ? false : POLLING_INTERVAL;
 
   const timeoutRef = React.useRef<number | null>(null);
-
-  const pollFasterAfterMutation = () => {
-    setIsJustAfterMutation(true);
-    if (timeoutRef.current) window.clearTimeout(timeoutRef.current);
-    timeoutRef.current = window.setTimeout(
-      () => setIsJustAfterMutation(false),
-      AFTER_MUTATION_WINDOW
-    );
-  };
 
   return (
     <PollingContext.Provider
       value={{
         isPollingEnabled,
         refetchInterval,
-        pollFasterAfterMutation,
         pausePolling: () => setIsPollingEnabled(false),
         resumePolling: () => setIsPollingEnabled(true),
       }}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -14,7 +14,15 @@ import {
 import { noop } from '@app/common/constants';
 
 const queryCache = new QueryCache();
-const queryClient = new QueryClient({ queryCache });
+const queryClient = new QueryClient({
+  queryCache,
+  defaultOptions: {
+    queries: {
+      staleTime: 15000,
+      keepPreviousData: true,
+    },
+  },
+});
 
 const App: React.FunctionComponent = () => (
   <QueryClientProvider client={queryClient}>

--- a/src/app/queries/constants.ts
+++ b/src/app/queries/constants.ts
@@ -1,5 +1,3 @@
-export const POLLING_INTERVAL = process.env.NODE_ENV !== 'production' ? 10000 : 5000;
-export const POLLING_INTERVAL_AFTER_MUTATION = 2000;
-export const AFTER_MUTATION_WINDOW = 6000;
+export const POLLING_INTERVAL = 10000;
 
 export const LONG_LOADING_MESSAGE = 'For large environments, this may take several seconds.';

--- a/src/app/queries/hosts.ts
+++ b/src/app/queries/hosts.ts
@@ -24,7 +24,7 @@ export const hostConfigResource = new ForkliftResource(ForkliftResourceKind.Host
 export const useHostsQuery = (provider: IVMwareProvider | null) => {
   const result = useMockableQuery<IHost[]>(
     {
-      queryKey: 'hosts',
+      queryKey: ['hosts', provider?.selfLink],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}/hosts?detail=1`)),
       enabled: !!provider,
       refetchInterval: usePollingContext().refetchInterval,
@@ -137,7 +137,6 @@ export const useConfigureHostsMutation = (
 > => {
   const client = useAuthorizedK8sClient();
   const queryClient = useQueryClient();
-  const { pollFasterAfterMutation } = usePollingContext();
 
   const configureHosts = (values: SelectNetworkFormValues) => {
     const existingHostConfigs = getExistingHostConfigs(selectedHosts, allHostConfigs, provider);
@@ -187,7 +186,6 @@ export const useConfigureHostsMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries('hosts');
       queryClient.invalidateQueries('hostconfigs');
-      pollFasterAfterMutation();
       onSuccess && onSuccess();
     },
   });

--- a/src/app/queries/migrations.ts
+++ b/src/app/queries/migrations.ts
@@ -25,7 +25,6 @@ export const useCreateMigrationMutation = (
 ): UseMutationResult<IKubeResponse<IMigration>, KubeClientError, IPlan, unknown> => {
   const client = useAuthorizedK8sClient();
   const queryClient = useQueryClient();
-  const { pollFasterAfterMutation } = usePollingContext();
   return useMockableMutation<IKubeResponse<IMigration>, KubeClientError, IPlan>(
     async (plan: IPlan) => {
       const migration: IMigration = {
@@ -52,7 +51,6 @@ export const useCreateMigrationMutation = (
       onSuccess: ({ data }) => {
         queryClient.invalidateQueries('plans');
         queryClient.invalidateQueries('migrations');
-        pollFasterAfterMutation();
         onSuccess && onSuccess(data);
       },
     }

--- a/src/app/queries/plans.ts
+++ b/src/app/queries/plans.ts
@@ -44,7 +44,6 @@ export const useCreatePlanMutation = (
 ): UseMutationResult<IKubeResponse<IPlan>, KubeClientError, PlanWizardFormState, unknown> => {
   const client = useAuthorizedK8sClient();
   const queryClient = useQueryClient();
-  const { pollFasterAfterMutation } = usePollingContext();
   return useMockableMutation<IKubeResponse<IPlan>, KubeClientError, PlanWizardFormState>(
     async (forms) => {
       await checkIfResourceExists(
@@ -118,7 +117,6 @@ export const useCreatePlanMutation = (
         queryClient.invalidateQueries('plans');
         queryClient.invalidateQueries('mappings');
         queryClient.invalidateQueries('hooks');
-        pollFasterAfterMutation();
         onSuccess && onSuccess();
       },
     }
@@ -135,7 +133,6 @@ export const usePatchPlanMutation = (
 ): UseMutationResult<IKubeResponse<IPlan>, KubeClientError, IPatchPlanArgs, unknown> => {
   const client = useAuthorizedK8sClient();
   const queryClient = useQueryClient();
-  const { pollFasterAfterMutation } = usePollingContext();
 
   return useMockableMutation<IKubeResponse<IPlan>, KubeClientError, IPatchPlanArgs>(
     async ({ planBeingEdited, forms }) => {
@@ -230,7 +227,6 @@ export const usePatchPlanMutation = (
         queryClient.invalidateQueries('plans');
         queryClient.invalidateQueries('hooks');
         queryClient.invalidateQueries('mappings');
-        pollFasterAfterMutation();
         onSuccess && onSuccess();
       },
     }

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -74,7 +74,6 @@ export const useCreateProviderMutation = (
 > => {
   const client = useAuthorizedK8sClient();
   const queryClient = useQueryClient();
-  const { pollFasterAfterMutation } = usePollingContext();
 
   const postProvider = async (values: AddProviderFormValues) => {
     const providerWithoutSecret: IProviderObject = convertFormValuesToProvider(
@@ -184,7 +183,6 @@ export const useCreateProviderMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries('cluster-providers');
       queryClient.invalidateQueries('inventory-providers');
-      pollFasterAfterMutation();
       onSuccess(providerType);
     },
   });
@@ -202,7 +200,6 @@ export const usePatchProviderMutation = (
 > => {
   const client = useAuthorizedK8sClient();
   const queryClient = useQueryClient();
-  const { pollFasterAfterMutation } = usePollingContext();
 
   const patchProvider = async (values: AddProviderFormValues) => {
     const providerWithoutSecret: IProviderObject = convertFormValuesToProvider(
@@ -237,7 +234,6 @@ export const usePatchProviderMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries('cluster-providers');
       queryClient.invalidateQueries('inventory-providers');
-      pollFasterAfterMutation();
       onSuccess && onSuccess();
     },
   });

--- a/src/app/queries/tree.ts
+++ b/src/app/queries/tree.ts
@@ -86,12 +86,15 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
         ? '/tree/host' // TODO in the future, this vsphere tree will also be at /tree/cluster
         : '/tree/cluster'
       : '/tree/vm';
+
   return useMockableQuery<T, unknown, IndexedTree<T>>(
     {
       queryKey: ['inventory-tree', provider?.name, treeType],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}${apiSlug}`)),
       enabled: isValidQuery && !!provider,
       refetchInterval: usePollingContext().refetchInterval,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
       select: indexTree,
     },
     (treeType === InventoryTreeType.Cluster

--- a/src/app/queries/vms.ts
+++ b/src/app/queries/vms.ts
@@ -48,6 +48,8 @@ export const useSourceVMsQuery = (
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}/vms?detail=1`)),
       enabled: !!provider,
       refetchInterval: usePollingContext().refetchInterval,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
       select: indexVMs,
     },
     mockVMs


### PR DESCRIPTION
This PR makes a few changes to how and when react-query goes about fetching data for the UI, mostly just relaxing the amount of refetching that's going on and attempts to better cache data where possible. Please double check for stale data in the UI as you test, we may need to manually invalidate a cache somewhere now that I've flipped the overall strategy to keep the previous data around by default.

Remove faster polling strategy
Reduce global polling interval
Introduce 15 second stale time
Enforce caching with keepPreviousData
Reduce amount of refetching/reindexing for vms trees