### PR TITLE
[Backport] Bug 1993995: fix(fetch): relax query/polling logic (#746)

### DIFF
--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TreeView, Tabs, Tab, TabTitleText, TextContent, Text } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useSelectionState } from '@konveyor/lib-ui';
-import { useInventoryTreeQuery, useSourceVMsQuery } from '@app/queries';
+import { IndexedTree, useSourceVMsQuery } from '@app/queries';
 import {
   IPlan,
   SourceInventoryProvider,
@@ -23,15 +23,18 @@ import { PlanWizardFormState } from './PlanWizard';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { usePausedPollingEffect } from '@app/common/context';
 import { LONG_LOADING_MESSAGE } from '@app/queries/constants';
+import { UseQueryResult } from 'react-query';
 
 interface IFilterVMsFormProps {
   form: PlanWizardFormState['filterVMs'];
+  treeQuery: UseQueryResult<IndexedTree<InventoryTree>, unknown>;
   sourceProvider: SourceInventoryProvider | null;
   planBeingEdited: IPlan | null;
 }
 
 const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
   form,
+  treeQuery,
   sourceProvider,
   planBeingEdited,
 }: IFilterVMsFormProps) => {
@@ -40,10 +43,6 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
   const [searchText, setSearchText] = React.useState('');
 
   const vmsQuery = useSourceVMsQuery(sourceProvider);
-  const clusterTreeQuery = useInventoryTreeQuery(sourceProvider, InventoryTreeType.Cluster);
-  const vmTreeQuery = useInventoryTreeQuery(sourceProvider, InventoryTreeType.VM);
-  const treeQuery =
-    form.values.treeType === InventoryTreeType.Cluster ? clusterTreeQuery : vmTreeQuery;
 
   const isNodeSelectable = useIsNodeSelectableCallback(form.values.treeType);
 

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -15,11 +15,10 @@ import {
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { getFormGroupProps, ValidatedTextInput } from '@konveyor/lib-ui';
 
-import { IPlan, POD_NETWORK, InventoryTreeType } from '@app/queries/types';
+import { IPlan, POD_NETWORK } from '@app/queries/types';
 import {
   useClusterProvidersQuery,
   useInventoryProvidersQuery,
-  useInventoryTreeQuery,
   useOpenShiftNetworksQuery,
   useNamespacesQuery,
 } from '@app/queries';
@@ -96,10 +95,6 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
       form.fields.migrationNetwork.prefill(matchingNetwork?.name || null);
     }
   };
-
-  // Cache these queries as soon as a source provider is selected so they are ready in later wizard steps
-  useInventoryTreeQuery(form.values.sourceProvider, InventoryTreeType.Cluster);
-  useInventoryTreeQuery(form.values.sourceProvider, InventoryTreeType.VM);
 
   return (
     <ResolvedQueries

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -33,6 +33,7 @@ import {
   SourceInventoryProvider,
   InventoryTree,
   InventoryTreeType,
+  IVMwareFolderTree,
 } from '@app/queries/types';
 import {
   IMappingBuilderItem,
@@ -48,6 +49,8 @@ import {
   usePlansQuery,
   useCreateMappingMutations,
   useSourceVMsQuery,
+  useInventoryTreeQuery,
+  IndexedTree,
 } from '@app/queries';
 import { getAggregateQueryStatus } from '@app/queries/helpers';
 import { dnsLabelNameSchema } from '@app/common/constants';
@@ -253,6 +256,15 @@ const PlanWizard: React.FunctionComponent = () => {
 
   const selectedVMs = vmsQuery.data?.findVMsByIds(forms.selectVMs.values.selectedVMIds) || [];
 
+  const clusterTreeQuery = useInventoryTreeQuery(
+    forms.general.values.sourceProvider,
+    InventoryTreeType.Cluster
+  );
+  const vmTreeQuery = useInventoryTreeQuery(
+    forms.general.values.sourceProvider,
+    InventoryTreeType.VM
+  );
+
   const steps: WizardStep[] = [
     {
       id: StepId.General,
@@ -273,6 +285,11 @@ const PlanWizard: React.FunctionComponent = () => {
           component: (
             <WizardStepContainer title="Filter by VM location">
               <FilterVMsForm
+                treeQuery={
+                  forms.filterVMs.values.treeType === InventoryTreeType.Cluster
+                    ? clusterTreeQuery
+                    : vmTreeQuery
+                }
                 form={forms.filterVMs}
                 sourceProvider={forms.general.values.sourceProvider}
                 planBeingEdited={planBeingEdited}
@@ -288,6 +305,8 @@ const PlanWizard: React.FunctionComponent = () => {
           component: (
             <WizardStepContainer title="Select VMs">
               <SelectVMsForm
+                hostTreeQuery={clusterTreeQuery}
+                vmTreeQuery={vmTreeQuery as UseQueryResult<IndexedTree<IVMwareFolderTree>, unknown>}
                 form={forms.selectVMs}
                 treeType={forms.filterVMs.values.treeType}
                 selectedTreeNodes={forms.filterVMs.values.selectedTreeNodes}

--- a/src/app/Plans/components/Wizard/SelectVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/SelectVMsForm.tsx
@@ -48,7 +48,7 @@ import {
   getVMTreePathInfo,
   vmMatchesConcernFilter,
 } from './helpers';
-import { IndexedTree, useInventoryTreeQuery, useSourceVMsQuery } from '@app/queries';
+import { IndexedTree, useSourceVMsQuery } from '@app/queries';
 import TableEmptyState from '@app/common/components/TableEmptyState';
 import { FilterToolbar, FilterType, FilterCategory } from '@app/common/components/FilterToolbar';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
@@ -56,6 +56,7 @@ import VMConcernsIcon from './VMConcernsIcon';
 import VMConcernsDescription from './VMConcernsDescription';
 import { LONG_LOADING_MESSAGE } from '@app/queries/constants';
 import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
+import { UseQueryResult } from 'react-query';
 
 interface ISelectVMsFormProps {
   form: PlanWizardFormState['selectVMs'];
@@ -63,6 +64,8 @@ interface ISelectVMsFormProps {
   selectedTreeNodes: InventoryTree[];
   sourceProvider: SourceInventoryProvider | null;
   selectedVMs: SourceVM[];
+  hostTreeQuery: UseQueryResult<IndexedTree<IInventoryHostTree>, unknown>;
+  vmTreeQuery: UseQueryResult<IndexedTree<IVMwareFolderTree>, unknown>;
 }
 
 const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
@@ -71,15 +74,9 @@ const SelectVMsForm: React.FunctionComponent<ISelectVMsFormProps> = ({
   selectedTreeNodes,
   sourceProvider,
   selectedVMs,
+  hostTreeQuery,
+  vmTreeQuery,
 }: ISelectVMsFormProps) => {
-  const hostTreeQuery = useInventoryTreeQuery<IInventoryHostTree>(
-    sourceProvider,
-    InventoryTreeType.Cluster
-  );
-  const vmTreeQuery = useInventoryTreeQuery<IVMwareFolderTree>(
-    sourceProvider,
-    InventoryTreeType.VM
-  );
   const vmsQuery = useSourceVMsQuery(sourceProvider);
 
   const indexedTree: IndexedTree | undefined =

--- a/src/app/common/context/PollingContext.tsx
+++ b/src/app/common/context/PollingContext.tsx
@@ -1,14 +1,9 @@
-import {
-  AFTER_MUTATION_WINDOW,
-  POLLING_INTERVAL,
-  POLLING_INTERVAL_AFTER_MUTATION,
-} from '@app/queries/constants';
+import { POLLING_INTERVAL } from '@app/queries/constants';
 import * as React from 'react';
 
 interface IPollingContext {
   isPollingEnabled: boolean;
   refetchInterval: number | false;
-  pollFasterAfterMutation: () => void;
   pausePolling: () => void;
   resumePolling: () => void;
 }
@@ -16,7 +11,6 @@ interface IPollingContext {
 const PollingContext = React.createContext<IPollingContext>({
   isPollingEnabled: true,
   refetchInterval: false,
-  pollFasterAfterMutation: () => undefined,
   pausePolling: () => undefined,
   resumePolling: () => undefined,
 });
@@ -29,31 +23,14 @@ export const PollingContextProvider: React.FunctionComponent<IPollingContextProv
   children,
 }: IPollingContextProviderProps) => {
   const [isPollingEnabled, setIsPollingEnabled] = React.useState(true);
-  const [isJustAfterMutation, setIsJustAfterMutation] = React.useState(false);
 
-  const refetchInterval = !isPollingEnabled
-    ? false
-    : isJustAfterMutation
-    ? POLLING_INTERVAL_AFTER_MUTATION
-    : POLLING_INTERVAL;
-
-  const timeoutRef = React.useRef<number | null>(null);
-
-  const pollFasterAfterMutation = () => {
-    setIsJustAfterMutation(true);
-    if (timeoutRef.current) window.clearTimeout(timeoutRef.current);
-    timeoutRef.current = window.setTimeout(
-      () => setIsJustAfterMutation(false),
-      AFTER_MUTATION_WINDOW
-    );
-  };
+  const refetchInterval = !isPollingEnabled ? false : POLLING_INTERVAL;
 
   return (
     <PollingContext.Provider
       value={{
         isPollingEnabled,
         refetchInterval,
-        pollFasterAfterMutation,
         pausePolling: () => setIsPollingEnabled(false),
         resumePolling: () => setIsPollingEnabled(true),
       }}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -13,7 +13,15 @@ import {
 } from '@app/common/context';
 
 const queryCache = new QueryCache();
-const queryClient = new QueryClient({ queryCache });
+const queryClient = new QueryClient({
+  queryCache,
+  defaultOptions: {
+    queries: {
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 const App: React.FunctionComponent = () => (
   <QueryClientProvider client={queryClient}>

--- a/src/app/queries/constants.ts
+++ b/src/app/queries/constants.ts
@@ -1,5 +1,3 @@
-export const POLLING_INTERVAL = process.env.NODE_ENV !== 'production' ? 10000 : 5000;
-export const POLLING_INTERVAL_AFTER_MUTATION = 2000;
-export const AFTER_MUTATION_WINDOW = 6000;
+export const POLLING_INTERVAL = 10000;
 
 export const LONG_LOADING_MESSAGE = 'For large environments, this may take several seconds.';

--- a/src/app/queries/hooks.ts
+++ b/src/app/queries/hooks.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { UseQueryResult } from 'react-query';
 import * as yup from 'yup';
 import yaml from 'js-yaml';
@@ -14,13 +15,17 @@ import { useAuthorizedK8sClient } from './fetchHelpers';
 const hookResource = new ForkliftResource(ForkliftResourceKind.Hook, META.namespace);
 
 export const useHooksQuery = (): UseQueryResult<IKubeList<IHook>> => {
+  const sortKubeListByNameCallback = React.useCallback(
+    (data): IKubeList<IHook> => sortKubeListByName(data),
+    []
+  );
   const client = useAuthorizedK8sClient();
   const result = useMockableQuery<IKubeList<IHook>>(
     {
       queryKey: 'hooks',
       queryFn: async () => (await client.list<IKubeList<IHook>>(hookResource)).data,
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortKubeListByName,
+      select: sortKubeListByNameCallback,
     },
     mockKubeList(MOCK_HOOKS, 'Hook')
   );

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { UseMutationResult, useQueryClient, UseQueryResult, QueryStatus } from 'react-query';
 import * as yup from 'yup';
 import {
@@ -41,13 +42,17 @@ export const getMappingResource = (
 
 export const useMappingsQuery = (mappingType: MappingType): UseQueryResult<IKubeList<Mapping>> => {
   const client = useAuthorizedK8sClient();
+  const sortKubeListByNameCallback = React.useCallback(
+    (data): IKubeList<Mapping> => sortKubeListByName(data),
+    []
+  );
   const result = useMockableQuery<IKubeList<Mapping>>(
     {
       queryKey: ['mappings', mappingType],
       queryFn: async () =>
         (await client.list<IKubeList<Mapping>>(getMappingResource(mappingType).resource)).data,
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortKubeListByName,
+      select: sortKubeListByNameCallback,
     },
     mappingType === MappingType.Network
       ? mockKubeList(MOCK_NETWORK_MAPPINGS, 'NetworkMapList')

--- a/src/app/queries/namespaces.ts
+++ b/src/app/queries/namespaces.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { usePollingContext } from '@app/common/context';
 import { getInventoryApiUrl, sortByName, useMockableQuery } from './helpers';
 import { IOpenShiftProvider } from './types';
@@ -6,13 +7,17 @@ import { IOpenShiftNamespace } from './types/namespaces.types';
 import { MOCK_OPENSHIFT_NAMESPACES } from './mocks/namespaces.mock';
 
 export const useNamespacesQuery = (provider: IOpenShiftProvider | null) => {
+  const sortByNameCallback = React.useCallback(
+    (data): IOpenShiftNamespace[] => sortByName(data),
+    []
+  );
   const result = useMockableQuery<IOpenShiftNamespace[]>(
     {
       queryKey: ['namespaces', provider?.name],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}/namespaces`)),
       enabled: !!provider,
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortByName,
+      select: sortByNameCallback,
     },
     MOCK_OPENSHIFT_NAMESPACES
   );

--- a/src/app/queries/networks.ts
+++ b/src/app/queries/networks.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { usePollingContext } from '@app/common/context';
 import { useMockableQuery, getInventoryApiUrl, sortByName } from './helpers';
 import {
@@ -22,13 +23,14 @@ export const useNetworksQuery = <T extends ISourceNetwork | IOpenShiftNetwork>(
   mockNetworks: T[]
 ) => {
   const apiSlug = providerRole === 'source' ? '/networks' : '/networkattachmentdefinitions';
+  const sortByNameCallback = React.useCallback((data): T[] => sortByName(data), []);
   const result = useMockableQuery<T[]>(
     {
       queryKey: ['networks', providerRole, provider?.name],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}${apiSlug}`)),
       enabled: !!provider && (!mappingType || mappingType === MappingType.Network),
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortByName,
+      select: sortByNameCallback,
     },
     mockNetworks
   );

--- a/src/app/queries/providers.ts
+++ b/src/app/queries/providers.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useQueryClient, UseQueryResult, UseMutationResult } from 'react-query';
 import * as yup from 'yup';
 import Q from 'q';
@@ -51,12 +52,16 @@ export const useClusterProvidersQuery = (): UseQueryResult<IKubeList<IProviderOb
 };
 
 export const useInventoryProvidersQuery = () => {
+  const sortIndexedDataByNameCallback = React.useCallback(
+    (data): IProvidersByType => sortIndexedDataByName(data),
+    []
+  );
   const result = useMockableQuery<IProvidersByType>(
     {
       queryKey: 'inventory-providers',
       queryFn: useAuthorizedFetch(getInventoryApiUrl('/providers?detail=1')),
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortIndexedDataByName,
+      select: sortIndexedDataByNameCallback,
     },
     MOCK_INVENTORY_PROVIDERS
   );
@@ -74,7 +79,6 @@ export const useCreateProviderMutation = (
 > => {
   const client = useAuthorizedK8sClient();
   const queryClient = useQueryClient();
-  const { pollFasterAfterMutation } = usePollingContext();
 
   const postProvider = async (values: AddProviderFormValues) => {
     const providerWithoutSecret: IProviderObject = convertFormValuesToProvider(
@@ -184,7 +188,6 @@ export const useCreateProviderMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries('cluster-providers');
       queryClient.invalidateQueries('inventory-providers');
-      pollFasterAfterMutation();
       onSuccess(providerType);
     },
   });
@@ -202,7 +205,6 @@ export const usePatchProviderMutation = (
 > => {
   const client = useAuthorizedK8sClient();
   const queryClient = useQueryClient();
-  const { pollFasterAfterMutation } = usePollingContext();
 
   const patchProvider = async (values: AddProviderFormValues) => {
     const providerWithoutSecret: IProviderObject = convertFormValuesToProvider(
@@ -237,7 +239,6 @@ export const usePatchProviderMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries('cluster-providers');
       queryClient.invalidateQueries('inventory-providers');
-      pollFasterAfterMutation();
       onSuccess && onSuccess();
     },
   });

--- a/src/app/queries/storages.ts
+++ b/src/app/queries/storages.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { usePollingContext } from '@app/common/context';
 import { useMockableQuery, getInventoryApiUrl, sortByName } from './helpers';
 import {
@@ -20,13 +21,14 @@ export const useSourceStoragesQuery = (
   mappingType: MappingType
 ) => {
   const apiSlug = provider?.type === 'vsphere' ? '/datastores' : '/storagedomains';
+  const sortByNameCallback = React.useCallback((data): ISourceStorage[] => sortByName(data), []);
   const result = useMockableQuery<ISourceStorage[]>(
     {
       queryKey: ['source-storages', provider?.name],
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}${apiSlug}`)),
       enabled: !!provider && mappingType === MappingType.Storage,
       refetchInterval: usePollingContext().refetchInterval,
-      select: sortByName,
+      select: sortByNameCallback,
     },
     provider?.type === 'vsphere' ? MOCK_VMWARE_DATASTORES : MOCK_RHV_STORAGE_DOMAINS
   );

--- a/src/app/queries/vms.ts
+++ b/src/app/queries/vms.ts
@@ -1,5 +1,6 @@
-import { UseQueryResult } from 'react-query';
+import * as React from 'react';
 import { usePollingContext } from '@app/common/context';
+import { UseQueryResult } from 'react-query';
 import { useAuthorizedFetch } from './fetchHelpers';
 import { useMockableQuery, getInventoryApiUrl, sortByName } from './helpers';
 import { MOCK_RHV_VMS, MOCK_VMWARE_VMS } from './mocks/vms.mock';
@@ -39,6 +40,7 @@ export const indexVMs = (vms: SourceVM[]): IndexedSourceVMs => {
 export const useSourceVMsQuery = (
   provider: SourceInventoryProvider | null
 ): UseQueryResult<IndexedSourceVMs> => {
+  const indexVmsCallback = React.useCallback((data) => indexVMs(data), []);
   let mockVMs: SourceVM[] = [];
   if (provider?.type === 'vsphere') mockVMs = MOCK_VMWARE_VMS;
   if (provider?.type === 'ovirt') mockVMs = MOCK_RHV_VMS;
@@ -48,7 +50,7 @@ export const useSourceVMsQuery = (
       queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}/vms?detail=1`)),
       enabled: !!provider,
       refetchInterval: usePollingContext().refetchInterval,
-      select: indexVMs,
+      select: indexVmsCallback,
     },
     mockVMs
   );


### PR DESCRIPTION
Backports https://github.com/konveyor/forklift-ui/pull/746

Should help close [bz-1993995](https://bugzilla.redhat.com/show_bug.cgi?id=1993995)

* fix(fetch): relax query/polling logic

Remove faster polling strategy
Reduce global polling interval
Introduce 15 second stale time
Enforce caching with keepPreviousData
Reduce amount of refetching/reindexing for vms trees

* index trees/vm data in a callback so it only runs once per update cycle, instead of on every render

* lift state for inventory-tree query up to PlanWiz so it's not re-created in batches

wrap select handlers in callback hooks to avoid being called multiple times
keep previous data for tree query
set cacheTime to zero so tree query may collect garbage at next convenience

* add back polling for vms