### PR TITLE
Bug: 1994146 feat(mappings) add support for datacenter/directory meta for storage/network mappings

### DIFF
--- a/src/app/Mappings/components/AddEditMappingModal.tsx
+++ b/src/app/Mappings/components/AddEditMappingModal.tsx
@@ -252,6 +252,7 @@ const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalProps> = 
                 >
                   <MappingBuilder
                     mappingType={mappingType}
+                    sourceProvider={form.values.sourceProvider}
                     sourceProviderType={form.values.sourceProvider?.type || 'vsphere'}
                     availableSources={mappingResourceQueries.availableSources}
                     availableTargets={mappingResourceQueries.availableTargets}

--- a/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -3,7 +3,12 @@ import * as yup from 'yup';
 import { Button, TextContent, Text, Grid, GridItem, Bullseye, Flex } from '@patternfly/react-core';
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { MappingType, MappingSource, MappingTarget } from '@app/queries/types';
+import {
+  MappingType,
+  MappingSource,
+  MappingTarget,
+  SourceInventoryProvider,
+} from '@app/queries/types';
 import LineArrow from '@app/common/components/LineArrow';
 import MappingSourceSelect from './MappingSourceSelect';
 import MappingTargetSelect from './MappingTargetSelect';
@@ -30,6 +35,7 @@ export const mappingBuilderItemsSchema = yup
 interface IMappingBuilderProps {
   mappingType: MappingType;
   sourceProviderType: ProviderType;
+  sourceProvider: SourceInventoryProvider | null;
   availableSources: MappingSource[];
   availableTargets: MappingTarget[];
   builderItems: IMappingBuilderItem[];
@@ -40,6 +46,7 @@ interface IMappingBuilderProps {
 export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
   mappingType,
   sourceProviderType,
+  sourceProvider,
   availableSources,
   availableTargets,
   builderItems,
@@ -112,6 +119,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                 </Bullseye>
               ) : (
                 <MappingSourceSelect
+                  sourceProvider={sourceProvider}
                   id={`mapping-sources-for-${key}`}
                   builderItems={builderItems}
                   itemIndex={itemIndex}

--- a/src/app/Mappings/components/helpers.ts
+++ b/src/app/Mappings/components/helpers.ts
@@ -48,10 +48,10 @@ export const getMappingSourceTitle = (
   providerType: ProviderType
 ): string => {
   if (mappingType === MappingType.Network) {
-    return 'Source networks';
+    return 'Source datacenters / networks';
   }
   if (mappingType === MappingType.Storage) {
-    return `Source ${getStorageTitle(providerType)}`;
+    return `Source datacenters / ${getStorageTitle(providerType)}`;
   }
   return '';
 };

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -250,6 +250,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
               <MappingBuilder
                 mappingType={mappingType}
                 sourceProviderType={sourceProvider?.type || 'vsphere'}
+                sourceProvider={sourceProvider}
                 availableSources={availableSources}
                 availableTargets={availableTargets}
                 builderItems={form.values.builderItems}

--- a/src/app/queries/datacenters.ts
+++ b/src/app/queries/datacenters.ts
@@ -1,0 +1,18 @@
+import { usePollingContext } from '@app/common/context';
+import { useMockableQuery, getInventoryApiUrl } from './helpers';
+import { InventoryProvider } from './types';
+import { useAuthorizedFetch } from './fetchHelpers';
+import { IDataCenter } from '@app/queries/types/datacenters.types';
+
+export const useDataCentersQuery = <T extends IDataCenter>(provider: InventoryProvider | null) => {
+  const result = useMockableQuery<T[]>(
+    {
+      queryKey: ['datacenters', provider?.name],
+      queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}/datacenters`)),
+      enabled: !!provider,
+      refetchInterval: usePollingContext().refetchInterval,
+    },
+    []
+  );
+  return result;
+};

--- a/src/app/queries/index.ts
+++ b/src/app/queries/index.ts
@@ -11,3 +11,4 @@ export * from './migrations';
 export * from './secrets';
 export * from './namespaces';
 export * from './provisioners';
+export * from './datacenters';

--- a/src/app/queries/networks.ts
+++ b/src/app/queries/networks.ts
@@ -15,6 +15,7 @@ import {
   SourceInventoryProvider,
 } from './types';
 import { useAuthorizedFetch } from './fetchHelpers';
+// import { useDataCentersQuery } from '@app/queries';
 
 export const useNetworksQuery = <T extends ISourceNetwork | IOpenShiftNetwork>(
   provider: InventoryProvider | null,
@@ -22,8 +23,12 @@ export const useNetworksQuery = <T extends ISourceNetwork | IOpenShiftNetwork>(
   mappingType: MappingType | null,
   mockNetworks: T[]
 ) => {
-  const apiSlug = providerRole === 'source' ? '/networks' : '/networkattachmentdefinitions';
-  const sortByNameCallback = React.useCallback((data): T[] => sortByName(data), []);
+  const apiSlug =
+    providerRole === 'source' ? '/networks?detail=1' : '/networkattachmentdefinitions';
+  const sortByNameCallback = React.useCallback((data): T[] => {
+    // console.log('networkQuery callback', data);
+    return sortByName(data);
+  }, []);
   const result = useMockableQuery<T[]>(
     {
       queryKey: ['networks', providerRole, provider?.name],
@@ -40,13 +45,14 @@ export const useNetworksQuery = <T extends ISourceNetwork | IOpenShiftNetwork>(
 export const useSourceNetworksQuery = (
   provider: SourceInventoryProvider | null,
   mappingType?: MappingType
-) =>
-  useNetworksQuery(
+) => {
+  return useNetworksQuery(
     provider,
     'source',
     mappingType || null,
     provider?.type === 'vsphere' ? MOCK_VMWARE_NETWORKS : MOCK_RHV_NETWORKS
   );
+};
 
 export const useOpenShiftNetworksQuery = (
   provider: IOpenShiftProvider | null,

--- a/src/app/queries/networks.ts
+++ b/src/app/queries/networks.ts
@@ -15,7 +15,6 @@ import {
   SourceInventoryProvider,
 } from './types';
 import { useAuthorizedFetch } from './fetchHelpers';
-// import { useDataCentersQuery } from '@app/queries';
 
 export const useNetworksQuery = <T extends ISourceNetwork | IOpenShiftNetwork>(
   provider: InventoryProvider | null,
@@ -25,10 +24,7 @@ export const useNetworksQuery = <T extends ISourceNetwork | IOpenShiftNetwork>(
 ) => {
   const apiSlug =
     providerRole === 'source' ? '/networks?detail=1' : '/networkattachmentdefinitions';
-  const sortByNameCallback = React.useCallback((data): T[] => {
-    // console.log('networkQuery callback', data);
-    return sortByName(data);
-  }, []);
+  const sortByNameCallback = React.useCallback((data): T[] => sortByName(data), []);
   const result = useMockableQuery<T[]>(
     {
       queryKey: ['networks', providerRole, provider?.name],
@@ -45,14 +41,12 @@ export const useNetworksQuery = <T extends ISourceNetwork | IOpenShiftNetwork>(
 export const useSourceNetworksQuery = (
   provider: SourceInventoryProvider | null,
   mappingType?: MappingType
-) => {
-  return useNetworksQuery(
-    provider,
-    'source',
-    mappingType || null,
-    provider?.type === 'vsphere' ? MOCK_VMWARE_NETWORKS : MOCK_RHV_NETWORKS
-  );
-};
+) => useNetworksQuery(
+  provider,
+  'source',
+  mappingType || null,
+  provider?.type === 'vsphere' ? MOCK_VMWARE_NETWORKS : MOCK_RHV_NETWORKS
+);
 
 export const useOpenShiftNetworksQuery = (
   provider: IOpenShiftProvider | null,

--- a/src/app/queries/storages.ts
+++ b/src/app/queries/storages.ts
@@ -20,7 +20,7 @@ export const useSourceStoragesQuery = (
   provider: SourceInventoryProvider | null,
   mappingType: MappingType
 ) => {
-  const apiSlug = provider?.type === 'vsphere' ? '/datastores' : '/storagedomains';
+  const apiSlug = provider?.type === 'vsphere' ? '/datastores' : '/storagedomains?detail=1';
   const sortByNameCallback = React.useCallback((data): ISourceStorage[] => sortByName(data), []);
   const result = useMockableQuery<ISourceStorage[]>(
     {

--- a/src/app/queries/types/datacenters.types.ts
+++ b/src/app/queries/types/datacenters.types.ts
@@ -1,0 +1,19 @@
+export interface IDataCenter {
+  id: string;
+  name: string;
+  selfLink: string;
+  revision: number;
+}
+
+export interface IOvirtDc extends IDataCenter {
+  description: string;
+  revision: number;
+}
+
+export interface IVSphereDc extends IDataCenter {
+  description: string;
+  parent: {
+    kind: string;
+    id: string;
+  };
+}

--- a/src/app/queries/types/networks.types.ts
+++ b/src/app/queries/types/networks.types.ts
@@ -4,6 +4,11 @@ export interface ISourceNetwork {
   selfLink: string;
 }
 
+export interface IOvirtNetwork extends ISourceNetwork {
+  dataCenter: string;
+  description: string;
+}
+
 export interface IOpenShiftNetwork {
   uid: string;
   namespace: string;


### PR DESCRIPTION
This PR adds some description text, when available, to the select dropdown for selecting storage/network maps. For ovirt I added information about the corresponding datacenter, and for vsphere I added information about the associated folder.

Also added a new query hook for polling datacenter data.


<img width="500" alt="Screen Shot 2021-08-24 at 8 57 56 AM" src="https://user-images.githubusercontent.com/5942899/130625273-e0ba357e-eb60-4b7c-8d22-27cdeddbeb97.png">

<img width="500" alt="Screen Shot 2021-08-24 at 8 59 04 AM" src="https://user-images.githubusercontent.com/5942899/130625277-f95eb964-ba6c-4f2d-a473-c916fe8f5438.png">

<img width="500" alt="Screen Shot 2021-08-24 at 8 57 18 AM" src="https://user-images.githubusercontent.com/5942899/130625448-eb87dea9-1190-4768-bfcf-64b11ee02720.png">

<img width="500" alt="Screen Shot 2021-08-24 at 8 58 14 AM" src="https://user-images.githubusercontent.com/5942899/130625503-b2d59eb0-1b3a-4d1c-9419-1985d4c95f37.png">


Should help close https://github.com/konveyor/forklift-ui/issues/749