### PR TITLE
Bug: 1994042 feat(tooltip): add tooltip info to assist with crafting sa token

### DIFF
--- a/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -420,18 +420,20 @@ const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModalProps> 
                     isRequired
                     fieldId="openshift-sa-token"
                     formGroupProps={{
+                      helperText: 'Input a service account token with cluster-admin privileges.',
                       labelIcon: (
                         <Popover
                           bodyContent={
                             <>
-                              To obtain SA token, run the following command:
-                              <br />
-                              <i>
+                              <div className="pf-u-mb-md">
+                                To obtain SA token, run the following command:
+                              </div>
+                              <code>
                                 $ oc serviceaccounts get-token serviceaccount_name -n namespace_name
-                              </i>
-                              <br />
-                              <br />
-                              <b>** Be sure to use the namespace in which you created the SA.</b>
+                              </code>
+                              <div className="pf-u-mt-md">
+                                <b>** Be sure to use the namespace in which you created the SA.</b>
+                              </div>
                             </>
                           }
                         >


### PR DESCRIPTION
This PR adds some description text and updates the popover text for the service account token field in the add provider modal. Should help close https://github.com/konveyor/forklift-ui/issues/751 and [bz-1994042](https://bugzilla.redhat.com/show_bug.cgi?id=1994042).

<img width="500" alt="Screen Shot 2021-08-25 at 9 36 43 AM" src="https://user-images.githubusercontent.com/5942899/130810104-8fd3356e-4c24-41dd-aaf4-73a4adaf53f3.png">
