### PR TITLE
fix(plan-status): ensure starting state does not show for completed plans

### DIFF
--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -124,7 +124,8 @@ export const getPlanState = (
     if (hasCondition(conditions, 'Ready')) return 'NotStarted-Ready';
     return 'NotStarted-NotReady';
   }
-  if (isPlanBeingStarted(plan, migration, migrationQuery)) return 'Starting';
+  if (isPlanBeingStarted(plan, migration, migrationQuery) && !hasCondition(conditions, 'Succeeded'))
+    return 'Starting';
 
   if (isWarm && !migration.spec.cutover) {
     if (hasCondition(conditions, 'Canceled')) {


### PR DESCRIPTION
This PR adds a condition to check before marking a plan as in "Starting" state. Should help close https://github.com/konveyor/forklift-ui/issues/753