### PR TITLE
Bug 1951660: Add support for duplicating a migration plan

### DIFF
--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -66,13 +66,13 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
             </DropdownItem>
           </ConditionalTooltip>,
           <DropdownItem
-            key="clone"
+            key="duplicate"
             onClick={() => {
               setKebabIsOpen(false);
-              history.push(`/plans/${plan.metadata.name}/clone`);
+              history.push(`/plans/${plan.metadata.name}/duplicate`);
             }}
           >
-            Clone
+            Duplicate
           </DropdownItem>,
           <ConditionalTooltip
             key="Delete"

--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -65,6 +65,15 @@ const PlansActionsDropdown: React.FunctionComponent<IPlansActionDropdownProps> =
               Edit
             </DropdownItem>
           </ConditionalTooltip>,
+          <DropdownItem
+            key="clone"
+            onClick={() => {
+              setKebabIsOpen(false);
+              history.push(`/plans/${plan.metadata.name}/clone`);
+            }}
+          >
+            Clone
+          </DropdownItem>,
           <ConditionalTooltip
             key="Delete"
             isTooltipEnabled={hasCondition(conditions, 'Executing') || deletePlanMutation.isLoading}

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -29,14 +29,14 @@ interface IFilterVMsFormProps {
   form: PlanWizardFormState['filterVMs'];
   treeQuery: UseQueryResult<IndexedTree<InventoryTree>, unknown>;
   sourceProvider: SourceInventoryProvider | null;
-  planBeingEdited: IPlan | null;
+  planBeingPrefilled: IPlan | null;
 }
 
 const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
   form,
   treeQuery,
   sourceProvider,
-  planBeingEdited,
+  planBeingPrefilled,
 }: IFilterVMsFormProps) => {
   usePausedPollingEffect();
 
@@ -58,11 +58,11 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
     // Clear or reset selection when the tree type tab changes
     const treeTypeChanged = form.values.treeType !== lastTreeType.current;
     if (!isFirstRender.current && treeTypeChanged) {
-      if (!planBeingEdited || !form.values.isPrefilled) {
+      if (!planBeingPrefilled || !form.values.isPrefilled) {
         treeSelection.selectAll(false);
         lastTreeType.current = form.values.treeType;
       } else if (vmsQuery.isSuccess && treeQuery.isSuccess) {
-        const selectedVMs = getSelectedVMsFromPlan(planBeingEdited, vmsQuery.data);
+        const selectedVMs = getSelectedVMsFromPlan(planBeingPrefilled, vmsQuery.data);
         const selectedTreeNodes = findNodesMatchingSelectedVMs(
           treeQuery.data,
           selectedVMs,
@@ -76,7 +76,7 @@ const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
   }, [
     form.values.treeType,
     form.values.isPrefilled,
-    planBeingEdited,
+    planBeingPrefilled,
     treeQuery,
     vmsQuery,
     treeSelection,

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -33,12 +33,12 @@ import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
-  planBeingEdited: IPlan | null;
+  planBeingPrefilled: IPlan | null;
 }
 
 const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   form,
-  planBeingEdited,
+  planBeingPrefilled,
 }: IGeneralFormProps) => {
   const inventoryProvidersQuery = useInventoryProvidersQuery();
   const clusterProvidersQuery = useClusterProvidersQuery();
@@ -113,7 +113,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
           label="Plan name"
           isRequired
           fieldId="plan-name"
-          inputProps={{ isDisabled: !!planBeingEdited }}
+          inputProps={{ isDisabled: !!planBeingPrefilled }}
         />
         <ValidatedTextInput
           component={TextArea}

--- a/src/app/Plans/components/Wizard/GeneralForm.tsx
+++ b/src/app/Plans/components/Wizard/GeneralForm.tsx
@@ -15,14 +15,14 @@ import {
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { getFormGroupProps, ValidatedTextInput } from '@konveyor/lib-ui';
 
-import { IPlan, POD_NETWORK } from '@app/queries/types';
+import { POD_NETWORK } from '@app/queries/types';
 import {
   useClusterProvidersQuery,
   useInventoryProvidersQuery,
   useOpenShiftNetworksQuery,
   useNamespacesQuery,
 } from '@app/queries';
-import { PlanWizardFormState } from './PlanWizard';
+import { PlanWizardFormState, PlanWizardMode } from './PlanWizard';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import ProviderSelect from '@app/common/components/ProviderSelect';
 import SelectOpenShiftNetworkModal from '@app/common/components/SelectOpenShiftNetworkModal';
@@ -33,12 +33,12 @@ import { PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
-  planBeingPrefilled: IPlan | null;
+  wizardMode: PlanWizardMode;
 }
 
 const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
   form,
-  planBeingPrefilled,
+  wizardMode,
 }: IGeneralFormProps) => {
   const inventoryProvidersQuery = useInventoryProvidersQuery();
   const clusterProvidersQuery = useClusterProvidersQuery();
@@ -113,7 +113,7 @@ const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
           label="Plan name"
           isRequired
           fieldId="plan-name"
-          inputProps={{ isDisabled: !!planBeingPrefilled }}
+          inputProps={{ isDisabled: wizardMode === 'edit' }}
         />
         <ValidatedTextInput
           component={TextArea}

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -50,7 +50,7 @@ interface IMappingFormProps {
   targetProvider: IOpenShiftProvider | null;
   mappingType: MappingType;
   selectedVMs: SourceVM[];
-  planBeingEdited: IPlan | null;
+  planBeingPrefilled: IPlan | null;
 }
 
 const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
@@ -59,7 +59,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
   targetProvider,
   mappingType,
   selectedVMs,
-  planBeingEdited,
+  planBeingPrefilled,
 }: IMappingFormProps) => {
   usePausedPollingEffect();
 
@@ -150,10 +150,10 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
     form.fields.isSaveNewMapping.setValue(false);
   };
 
-  const mappingInPlanRef = planBeingEdited
+  const mappingInPlanRef = planBeingPrefilled
     ? mappingType === MappingType.Network
-      ? planBeingEdited.spec.map.network
-      : planBeingEdited.spec.map.storage
+      ? planBeingPrefilled.spec.map.network
+      : planBeingPrefilled.spec.map.storage
     : null;
   const mappingInPlan =
     (mappingInPlanRef &&
@@ -163,7 +163,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
     null;
   const hasAddedItems = form.values.selectedExistingMapping
     ? form.values.selectedExistingMapping.spec.map.length < form.values.builderItems.length
-    : planBeingEdited && mappingInPlan
+    : planBeingPrefilled && mappingInPlan
     ? mappingInPlan.spec.map.length < form.values.builderItems.length
     : false;
 

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -62,7 +62,7 @@ import { PlanHookInstance } from './PlanAddEditHookModal';
 import './PlanWizard.css';
 import { LONG_LOADING_MESSAGE } from '@app/queries/constants';
 
-export type PlanWizardMode = 'create' | 'edit' | 'clone';
+export type PlanWizardMode = 'create' | 'edit' | 'duplicate';
 
 const useMappingFormState = (mappingsQuery: UseQueryResult<IKubeList<Mapping>>) => {
   const isSaveNewMapping = useFormField(false, yup.boolean().required());
@@ -156,14 +156,14 @@ const PlanWizard: React.FunctionComponent = () => {
     strict: true,
     sensitive: true,
   });
-  const cloneRouteMatch = useRouteMatch<{ planName: string }>({
-    path: '/plans/:planName/clone',
+  const duplicateRouteMatch = useRouteMatch<{ planName: string }>({
+    path: '/plans/:planName/duplicate',
     strict: true,
     sensitive: true,
   });
-  const wizardMode = editRouteMatch ? 'edit' : cloneRouteMatch ? 'clone' : 'create';
+  const wizardMode = editRouteMatch ? 'edit' : duplicateRouteMatch ? 'duplicate' : 'create';
 
-  const prefillPlanName = editRouteMatch?.params.planName || cloneRouteMatch?.params.planName;
+  const prefillPlanName = editRouteMatch?.params.planName || duplicateRouteMatch?.params.planName;
   const planBeingPrefilled =
     plansQuery.data?.items.find((plan) => plan.metadata.name === prefillPlanName) || null;
 
@@ -240,7 +240,7 @@ const PlanWizard: React.FunctionComponent = () => {
   };
 
   const onSave = () => {
-    if (wizardMode === 'create' || wizardMode === 'clone') {
+    if (wizardMode === 'create' || wizardMode === 'duplicate') {
       createPlanMutation.mutate(forms);
     } else if (wizardMode === 'edit' && planBeingPrefilled) {
       patchPlanMutation.mutate({ planBeingEdited: planBeingPrefilled, forms });

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -456,9 +456,7 @@ const PlanWizard: React.FunctionComponent = () => {
               {planBeingPrefilled ? (
                 <BreadcrumbItem>{planBeingPrefilled.metadata.name}</BreadcrumbItem>
               ) : null}
-              <BreadcrumbItem>
-                {wizardMode === 'edit' ? 'Edit' : wizardMode === 'clone' ? 'Clone' : 'Create'}
-              </BreadcrumbItem>
+              <BreadcrumbItem>{wizardMode.replace(/^\w/, (c) => c.toUpperCase())}</BreadcrumbItem>
             </Breadcrumb>
             <Level>
               <LevelItem>

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -161,9 +161,7 @@ const PlanWizard: React.FunctionComponent = () => {
     strict: true,
     sensitive: true,
   });
-  let wizardMode: PlanWizardMode = 'create';
-  if (editRouteMatch) wizardMode = 'edit';
-  if (cloneRouteMatch) wizardMode = 'clone';
+  const wizardMode = editRouteMatch ? 'edit' : cloneRouteMatch ? 'clone' : 'create';
 
   const prefillPlanName = editRouteMatch?.params.planName || cloneRouteMatch?.params.planName;
   const planBeingPrefilled =

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -440,7 +440,6 @@ const PlanWizard: React.FunctionComponent = () => {
         <LoadingEmptyState />
       ) : wizardMode === 'edit' &&
         (!planBeingPrefilled || planBeingPrefilled?.status?.migration?.started) ? (
-        // Trying to edit a plan that doesn't exist or is running
         <Redirect to="/plans" />
       ) : (
         <>

--- a/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -39,7 +39,7 @@ import {
   IMappingBuilderItem,
   mappingBuilderItemsSchema,
 } from '@app/Mappings/components/MappingBuilder';
-import { generateMappings, useEditingPlanPrefillEffect } from './helpers';
+import { generateMappings, usePlanWizardPrefillEffect } from './helpers';
 import {
   getMappingNameSchema,
   useMappingsQuery,
@@ -179,7 +179,7 @@ const PlanWizard: React.FunctionComponent = () => {
 
   const vmsQuery = useSourceVMsQuery(forms.general.values.sourceProvider);
 
-  const { isDonePrefilling, prefillQueries, prefillErrorTitles } = useEditingPlanPrefillEffect(
+  const { isDonePrefilling, prefillQueries, prefillErrorTitles } = usePlanWizardPrefillEffect(
     forms,
     planBeingPrefilled,
     wizardMode

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -14,7 +14,7 @@ interface IReviewProps {
   forms: PlanWizardFormState;
   allMutationResults: UnknownResult[];
   allMutationErrorTitles: string[];
-  planBeingEdited: IPlan | null;
+  planBeingPrefilled: IPlan | null;
   selectedVMs: SourceVM[];
 }
 
@@ -22,7 +22,7 @@ const Review: React.FunctionComponent<IReviewProps> = ({
   forms,
   allMutationResults,
   allMutationErrorTitles,
-  planBeingEdited,
+  planBeingPrefilled,
   selectedVMs,
 }: IReviewProps) => {
   usePausedPollingEffect();
@@ -46,7 +46,7 @@ const Review: React.FunctionComponent<IReviewProps> = ({
     <Form>
       <TextContent>
         <Text component="p">
-          Review the information below and click Finish to {!planBeingEdited ? 'create' : 'save'}{' '}
+          Review the information below and click Finish to {!planBeingPrefilled ? 'create' : 'save'}{' '}
           your migration plan. Use the Back button to make changes.
         </Text>
       </TextContent>

--- a/src/app/Plans/components/Wizard/Review.tsx
+++ b/src/app/Plans/components/Wizard/Review.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TextContent, Text, Form } from '@patternfly/react-core';
 
-import { PlanWizardFormState } from './PlanWizard';
+import { PlanWizardFormState, PlanWizardMode } from './PlanWizard';
 import { IPlan, SourceVM } from '@app/queries/types';
 import { QuerySpinnerMode, ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { generateMappings, generatePlan } from './helpers';
@@ -14,7 +14,7 @@ interface IReviewProps {
   forms: PlanWizardFormState;
   allMutationResults: UnknownResult[];
   allMutationErrorTitles: string[];
-  planBeingPrefilled: IPlan | null;
+  wizardMode: PlanWizardMode;
   selectedVMs: SourceVM[];
 }
 
@@ -22,7 +22,7 @@ const Review: React.FunctionComponent<IReviewProps> = ({
   forms,
   allMutationResults,
   allMutationErrorTitles,
-  planBeingPrefilled,
+  wizardMode,
   selectedVMs,
 }: IReviewProps) => {
   usePausedPollingEffect();
@@ -46,8 +46,9 @@ const Review: React.FunctionComponent<IReviewProps> = ({
     <Form>
       <TextContent>
         <Text component="p">
-          Review the information below and click Finish to {!planBeingPrefilled ? 'create' : 'save'}{' '}
-          your migration plan. Use the Back button to make changes.
+          Review the information below and click Finish to{' '}
+          {wizardMode === 'edit' ? 'save' : 'create'} your migration plan. Use the Back button to
+          make changes.
         </Text>
       </TextContent>
       <PlanDetails

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -24,7 +24,7 @@ import {
   getBuilderItemsWithMissingSources,
   getMappingFromBuilderItems,
 } from '@app/Mappings/components/MappingBuilder/helpers';
-import { PlanWizardFormState } from './PlanWizard';
+import { PlanWizardFormState, PlanWizardMode } from './PlanWizard';
 import { CLUSTER_API_VERSION, META, ProviderType } from '@app/common/constants';
 import {
   getAggregateQueryStatus,
@@ -525,7 +525,7 @@ interface IEditingPrefillResults {
 export const useEditingPlanPrefillEffect = (
   forms: PlanWizardFormState,
   planBeingPrefilled: IPlan | null,
-  isEditMode: boolean
+  wizardMode: PlanWizardMode
 ): IEditingPrefillResults => {
   const providersQuery = useInventoryProvidersQuery();
   const { sourceProvider, targetProvider } = findProvidersByRefs(
@@ -578,7 +578,7 @@ export const useEditingPlanPrefillEffect = (
   const queryError = getFirstQueryError(queries);
 
   const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
-  const [isDonePrefilling, setIsDonePrefilling] = React.useState(!isEditMode);
+  const [isDonePrefilling, setIsDonePrefilling] = React.useState(wizardMode === 'create');
 
   const defaultTreeType = InventoryTreeType.Cluster;
   const isNodeSelectable = useIsNodeSelectableCallback(defaultTreeType);
@@ -604,7 +604,9 @@ export const useEditingPlanPrefillEffect = (
         isSameResource(mapping.metadata, planBeingPrefilled.spec.map.storage)
       );
 
-      forms.general.fields.planName.prefill(planBeingPrefilled.metadata.name);
+      if (wizardMode === 'edit') {
+        forms.general.fields.planName.prefill(planBeingPrefilled.metadata.name);
+      }
       if (planBeingPrefilled.spec.description) {
         forms.general.fields.planDescription.prefill(planBeingPrefilled.spec.description);
       }
@@ -671,6 +673,7 @@ export const useEditingPlanPrefillEffect = (
     queryStatus,
     forms,
     planBeingPrefilled,
+    wizardMode,
     sourceProvider,
     targetProvider,
     networkMappingResourceQueries,

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -612,7 +612,7 @@ export const usePlanWizardPrefillEffect = (
         forms.general.fields.planName.prefill(planBeingPrefilled.metadata.name);
       } else if (wizardMode === 'clone') {
         forms.general.fields.planName.prefill(
-          getClonedPlanDefaultName(planBeingPrefilled, plansQuery)
+          clonedPlanDefaultName(planBeingPrefilled, plansQuery)
         );
       }
       if (planBeingPrefilled.spec.description) {
@@ -705,7 +705,7 @@ export const usePlanWizardPrefillEffect = (
   };
 };
 
-export const getClonedPlanDefaultName = (
+export const clonedPlanDefaultName = (
   planBeingPrefilled: IPlan,
   plansQuery: UseQueryResult<IKubeList<IPlan>>
 ) => {

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -607,6 +607,9 @@ export const useEditingPlanPrefillEffect = (
       if (wizardMode === 'edit') {
         forms.general.fields.planName.prefill(planBeingPrefilled.metadata.name);
       }
+      if (wizardMode === 'clone') {
+        forms.general.fields.planName.setIsTouched(true); // Call attention to the only empty field
+      }
       if (planBeingPrefilled.spec.description) {
         forms.general.fields.planDescription.prefill(planBeingPrefilled.spec.description);
       }

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -709,11 +709,11 @@ export const clonedPlanDefaultName = (
   planBeingPrefilled: IPlan,
   plansQuery: UseQueryResult<IKubeList<IPlan>>
 ) => {
-  let name = `Copy of ${planBeingPrefilled.metadata.name}`;
+  let name = `copy-of-${planBeingPrefilled.metadata.name}`;
   let increment = 0;
   while (plansQuery.data?.items.find((plan) => plan.metadata.name === name)) {
     increment++;
-    name = `Copy of ${planBeingPrefilled.metadata.name} (${increment})`;
+    name = `copy-of-${planBeingPrefilled.metadata.name}-${increment}`;
   }
   return name;
 };

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -507,11 +507,11 @@ export const generatePlan = (
 });
 
 export const getSelectedVMsFromPlan = (
-  planBeingEdited: IPlan | null,
+  planBeingPrefilled: IPlan | null,
   indexedVMs: IndexedSourceVMs | undefined
 ): SourceVM[] => {
-  if (!planBeingEdited || !indexedVMs) return [];
-  return indexedVMs.findVMsByIds(planBeingEdited?.spec.vms.map(({ id }) => id));
+  if (!planBeingPrefilled || !indexedVMs) return [];
+  return indexedVMs.findVMsByIds(planBeingPrefilled?.spec.vms.map(({ id }) => id));
 };
 
 interface IEditingPrefillResults {
@@ -524,12 +524,12 @@ interface IEditingPrefillResults {
 
 export const useEditingPlanPrefillEffect = (
   forms: PlanWizardFormState,
-  planBeingEdited: IPlan | null,
+  planBeingPrefilled: IPlan | null,
   isEditMode: boolean
 ): IEditingPrefillResults => {
   const providersQuery = useInventoryProvidersQuery();
   const { sourceProvider, targetProvider } = findProvidersByRefs(
-    planBeingEdited?.spec.provider || null,
+    planBeingPrefilled?.spec.provider || null,
     providersQuery
   );
   const vmsQuery = useSourceVMsQuery(sourceProvider);
@@ -587,32 +587,32 @@ export const useEditingPlanPrefillEffect = (
     if (
       !isStartedPrefilling &&
       queryStatus === 'success' &&
-      planBeingEdited &&
+      planBeingPrefilled &&
       hostTreeQuery.data
     ) {
       setIsStartedPrefilling(true);
-      const selectedVMs = getSelectedVMsFromPlan(planBeingEdited, vmsQuery.data);
+      const selectedVMs = getSelectedVMsFromPlan(planBeingPrefilled, vmsQuery.data);
       const selectedTreeNodes = findNodesMatchingSelectedVMs(
         hostTreeQuery.data,
         selectedVMs,
         isNodeSelectable
       );
       const networkMapping = networkMappingsQuery.data?.items.find((mapping) =>
-        isSameResource(mapping.metadata, planBeingEdited.spec.map.network)
+        isSameResource(mapping.metadata, planBeingPrefilled.spec.map.network)
       );
       const storageMapping = storageMappingsQuery.data?.items.find((mapping) =>
-        isSameResource(mapping.metadata, planBeingEdited.spec.map.storage)
+        isSameResource(mapping.metadata, planBeingPrefilled.spec.map.storage)
       );
 
-      forms.general.fields.planName.prefill(planBeingEdited.metadata.name);
-      if (planBeingEdited.spec.description) {
-        forms.general.fields.planDescription.prefill(planBeingEdited.spec.description);
+      forms.general.fields.planName.prefill(planBeingPrefilled.metadata.name);
+      if (planBeingPrefilled.spec.description) {
+        forms.general.fields.planDescription.prefill(planBeingPrefilled.spec.description);
       }
       forms.general.fields.sourceProvider.prefill(sourceProvider);
       forms.general.fields.targetProvider.prefill(targetProvider);
-      forms.general.fields.targetNamespace.prefill(planBeingEdited.spec.targetNamespace);
+      forms.general.fields.targetNamespace.prefill(planBeingPrefilled.spec.targetNamespace);
       forms.general.fields.migrationNetwork.prefill(
-        planBeingEdited.spec.transferNetwork?.name || null
+        planBeingPrefilled.spec.transferNetwork?.name || null
       );
 
       forms.filterVMs.fields.treeType.prefill(defaultTreeType);
@@ -655,9 +655,11 @@ export const useEditingPlanPrefillEffect = (
       );
       forms.storageMapping.fields.isPrefilled.prefill(true);
 
-      forms.type.fields.type.prefill(planBeingEdited.spec.warm ? 'Warm' : 'Cold');
+      forms.type.fields.type.prefill(planBeingPrefilled.spec.warm ? 'Warm' : 'Cold');
 
-      forms.hooks.fields.instances.prefill(getPlanHookFormInstances(planBeingEdited, hooksQuery));
+      forms.hooks.fields.instances.prefill(
+        getPlanHookFormInstances(planBeingPrefilled, hooksQuery)
+      );
 
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {
@@ -668,7 +670,7 @@ export const useEditingPlanPrefillEffect = (
     isStartedPrefilling,
     queryStatus,
     forms,
-    planBeingEdited,
+    planBeingPrefilled,
     sourceProvider,
     targetProvider,
     networkMappingResourceQueries,

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -710,7 +710,6 @@ export const clonedPlanDefaultName = (
   plansQuery: UseQueryResult<IKubeList<IPlan>>
 ) => {
   let name = `Copy of ${planBeingPrefilled.metadata.name}`;
-  // Make sure the new name is also unique; if it is already in use put a number at the end of it.
   let increment = 0;
   while (plansQuery.data?.items.find((plan) => plan.metadata.name === name)) {
     increment++;

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -514,7 +514,7 @@ export const getSelectedVMsFromPlan = (
   return indexedVMs.findVMsByIds(planBeingPrefilled?.spec.vms.map(({ id }) => id));
 };
 
-interface IEditingPrefillResults {
+interface IPlanWizardPrefillResults {
   prefillQueryStatus: QueryStatus;
   prefillQueryError: unknown;
   isDonePrefilling: boolean;
@@ -522,11 +522,11 @@ interface IEditingPrefillResults {
   prefillErrorTitles: string[];
 }
 
-export const useEditingPlanPrefillEffect = (
+export const usePlanWizardPrefillEffect = (
   forms: PlanWizardFormState,
   planBeingPrefilled: IPlan | null,
   wizardMode: PlanWizardMode
-): IEditingPrefillResults => {
+): IPlanWizardPrefillResults => {
   const providersQuery = useInventoryProvidersQuery();
   const { sourceProvider, targetProvider } = findProvidersByRefs(
     planBeingPrefilled?.spec.provider || null,

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -610,9 +610,9 @@ export const usePlanWizardPrefillEffect = (
 
       if (wizardMode === 'edit') {
         forms.general.fields.planName.prefill(planBeingPrefilled.metadata.name);
-      } else if (wizardMode === 'clone') {
+      } else if (wizardMode === 'duplicate') {
         forms.general.fields.planName.prefill(
-          clonedPlanDefaultName(planBeingPrefilled, plansQuery)
+          duplicatedPlanDefaultName(planBeingPrefilled, plansQuery)
         );
       }
       if (planBeingPrefilled.spec.description) {
@@ -705,7 +705,7 @@ export const usePlanWizardPrefillEffect = (
   };
 };
 
-export const clonedPlanDefaultName = (
+export const duplicatedPlanDefaultName = (
   planBeingPrefilled: IPlan,
   plansQuery: UseQueryResult<IKubeList<IPlan>>
 ) => {

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -104,8 +104,8 @@ export const routes: AppRouteConfig[] = [
   {
     component: PlanWizard,
     exact: false,
-    path: '/plans/:planName/clone',
-    title: `${APP_TITLE} | Clone Migration Plan`,
+    path: '/plans/:planName/duplicate',
+    title: `${APP_TITLE} | Duplicate Migration Plan`,
     isProtected: true,
   },
   {

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -98,7 +98,14 @@ export const routes: AppRouteConfig[] = [
     component: PlanWizard,
     exact: false,
     path: '/plans/:planName/edit',
-    title: `${APP_TITLE} | Create Migration Plan`,
+    title: `${APP_TITLE} | Edit Migration Plan`,
+    isProtected: true,
+  },
+  {
+    component: PlanWizard,
+    exact: false,
+    path: '/plans/:planName/clone',
+    title: `${APP_TITLE} | Clone Migration Plan`,
     isProtected: true,
   },
   {


### PR DESCRIPTION
Resolves #581 
https://bugzilla.redhat.com/show_bug.cgi?id=1951660
https://issues.redhat.com/browse/MTV-109

Duplicating a plan behaves exactly like editing a plan with a few exceptions:
* The prefilled plan name is changed to have the prefix "copy-of-", and if necessary a numeric suffix which is incremented until a new unique name is found (e.g. `copy-of-myplan-1`). The user can then change it before proceeding, of course.
* The plan name field schema does not allow reusing the original plan name
* "Create" text is used where "Edit" would be shown, except in the breadcrumb bar where it says "Duplicate" after the original plan name
* Submitting the wizard creates a new plan rather than patching one (of course)

This PR leverages the existing mechanism of `planBeingEdited`, renaming it to `planBeingPrefilled`. Navigating to `/plans/:planName/duplicate` will set that value just like it does for `/edit`, and trigger the same prefilling behavior. The difference is that we now have a `wizardMode` which will have one of the values `'create' | 'edit' | 'duplicate'`, and the differences in logic described above are based on `wizardMode`.