### PR TITLE
Make sure prettier is properly plugged with eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+dr-surge.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,8 @@
 {
-  // tells eslint to use the TypeScript parser
+  "root": true,
   "parser": "@typescript-eslint/parser",
-  // tell the TypeScript parser that we want to use JSX syntax
   "parserOptions": {
+    "ecmaVersion": 2015,
     "tsx": true,
     "jsx": true,
     "js": true,
@@ -10,12 +10,13 @@
     "project": ["./tsconfig.json", "./qe-tests/tsconfig.json"],
     "tsconfigRootDir": "."
   },
-  // we want to use the recommended rules provided from the typescript plugin
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "prettier"
   ],
   "globals": {
     "window": "readonly",
@@ -31,8 +32,7 @@
       "version": "^16.11.0"
     }
   },
-  // includes the typescript specific rules found here: https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules
-  "plugins": ["@typescript-eslint", "react-hooks", "eslint-plugin-react-hooks"],
+  "plugins": ["prettier", "@typescript-eslint", "react-hooks", "eslint-plugin-react-hooks"],
   "rules": {
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
@@ -42,7 +42,13 @@
     "import/no-unresolved": "off",
     "import/extensions": "off",
     "react/prop-types": "off",
-    "prettier/prettier": "error"
+    "prettier/prettier": [
+      "error",
+      {
+        "singleQuote": true,
+        "semi": true
+      }
+    ]  
   },
   "env": {
     "browser": true,

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-package.json

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const path = require('path');
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const { stylePaths } = require('./stylePaths');

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -9,9 +9,7 @@ module.exports = merge(common('production'), {
   mode: 'production',
   devtool: 'source-map',
   optimization: {
-    minimizer: [
-      new TerserJSPlugin({}),
-    ],
+    minimizer: [new TerserJSPlugin({})],
   },
   plugins: [
     new MiniCssExtractPlugin({
@@ -24,10 +22,7 @@ module.exports = merge(common('production'), {
       {
         test: /\.css$/,
         include: [...stylePaths],
-        use: [
-          { loader: MiniCssExtractPlugin.loader },
-          { loader: 'css-loader' },
-        ],
+        use: [{ loader: MiniCssExtractPlugin.loader }, { loader: 'css-loader' }],
       },
     ],
   },

--- a/dr-surge.js
+++ b/dr-surge.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+
 const indexPath = path.resolve(__dirname, 'dist/index.html');
 const targetFilePath = path.resolve(__dirname, 'dist/200.html');
 // ensure we have bookmarkable url's when publishing to surge

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "npm run test:unit -- --coverage",
     "test:unit": "DATA_SOURCE=mock $(npm bin)/jest --rootDir=. --config=config/jest.config.js",
     "test:watch": "npm run test:unit -- --watch",
-    "lint": "$(npm bin)/eslint --ext .tsx,.ts,.js ./src/ ./qe-tests/",
+    "lint": "$(npm bin)/eslint .",
     "lint:fix": "npm run lint -- --fix",
     "format": "$(npm bin)/prettier --check --write ./src/**/*.{tsx,ts} ./qe-tests/**/*.{ts,js}",
     "tsc-src": "$(npm bin)/tsc --project ./tsconfig.json --noEmit",


### PR DESCRIPTION
Having eslint autosave not working with my VS Code environment, I verified the eslint/prettier config and noticed the prettier plugin wasn't full configured. 

Also:
Add `.eslintignore`file and changed lint rule to apply across the project.
The latter helps detect eslint issues in webpack configuration files.
Remove `.prettierignore` file which contained only package.json and seemed not relevant anymore.