### PR TITLE
Websocket middleware

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -31,6 +31,11 @@ module.exports = merge(common('development'), {
         ],
         target: `http://localhost:${EXPRESS_PORT}`,
       },
+      {
+        context: ['/inventory-api-socket'],
+        target: `ws://localhost:${EXPRESS_PORT}`,
+        ws: true,
+      },
     ],
   },
   module: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "ejs": "^3.1.6",
         "express": "^4.17.1",
         "fast-deep-equal": "^3.1.3",
-        "http-proxy-middleware": "^2.0.0",
+        "http-proxy-middleware": "^2.0.1",
         "js-yaml": "^4.1.0",
         "netmask": "^2.0.2",
         "node-fetch": "^2.6.1",
@@ -8457,9 +8457,9 @@
       "dev": true
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.0.tgz",
-      "integrity": "sha512-S+RN5njuyvYV760aiVKnyuTXqUMcSIvYOsHA891DOVQyrdZOwaXtBHpt9FUVPEDAsOvsPArZp6VXQLs44yvkow==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
+      "integrity": "sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==",
       "dependencies": {
         "@types/http-proxy": "^1.17.5",
         "http-proxy": "^1.18.1",
@@ -26699,9 +26699,9 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.0.tgz",
-      "integrity": "sha512-S+RN5njuyvYV760aiVKnyuTXqUMcSIvYOsHA891DOVQyrdZOwaXtBHpt9FUVPEDAsOvsPArZp6VXQLs44yvkow==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
+      "integrity": "sha512-cfaXRVoZxSed/BmkA7SwBVNI9Kj7HFltaE5rqYOub5kWzWZ+gofV2koVN1j2rMW7pEfSSlCHGJ31xmuyFyfLOg==",
       "requires": {
         "@types/http-proxy": "^1.17.5",
         "http-proxy": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ejs": "^3.1.6",
     "express": "^4.17.1",
     "fast-deep-equal": "^3.1.3",
-    "http-proxy-middleware": "^2.0.0",
+    "http-proxy-middleware": "^2.0.1",
     "js-yaml": "^4.1.0",
     "netmask": "^2.0.2",
     "node-fetch": "^2.6.1",

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -12,6 +12,7 @@ import {
   NetworkContextProvider,
 } from '@app/common/context';
 import { noop } from '@app/common/constants';
+import { getInventoryApiSocketUrl } from '@app/queries/helpers';
 
 const queryCache = new QueryCache();
 const queryClient = new QueryClient({
@@ -23,6 +24,27 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+const ws = new WebSocket(
+  // getInventoryApiSocketUrl('/healt/watch')
+  getInventoryApiSocketUrl('providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/hosts')
+);
+
+ws.onerror = (error) => {
+  console.log('[ws] ERROR CONNECTION', error);
+};
+
+ws.onopen = () => {
+  console.log('[ws] OPENED CONNECTION');
+};
+
+ws.onclose = () => {
+  console.log('[ws] CLOSED CONNECTION');
+};
+
+ws.onmessage = function (event) {
+  console.log('[ws] ONMESSAGE', event.data);
+};
 
 const App: React.FunctionComponent = () => (
   <QueryClientProvider client={queryClient}>

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -85,6 +85,9 @@ export const useMockableMutation = <
 export const getInventoryApiUrl = (relativePath: string): string =>
   `/inventory-api/${relativePath}`;
 
+export const getInventoryApiSocketUrl = (relativePath: string): string =>
+  `ws://localhost:9001/inventory-api-socket/${relativePath}`;
+
 export const getAggregateQueryStatus = (queryResults: UnknownResult[]): QueryStatus => {
   if (queryResults.some((result) => result.isError)) return 'error';
   if (queryResults.some((result) => result.isLoading)) return 'loading';


### PR DESCRIPTION
Here we have a working websocket proxy middleware.

From same (dev) local machine the following websocket client against `ws://localhost:9001` works fine, full duplex (push are received).

```
$ wscat -n -H X-Watch:snapshot -c ws://localhost:9001/inventory-api-socket/health/watch
Connected (press CTRL+C to quit)
< {"ID":1,"Labels":null,"Action":0,"Resource":null,"Updated":null}
< {"ID":0,"Labels":null,"Action":1,"Resource":null,"Updated":null}
.../...
< {"ID":2,"Labels":null,"Action":32,"Resource":{"status":"ready","timestamp":"2021-09-15T11:44:09.140316109Z"},"Updated":{"status":"ready","timestamp":"2021-09-15T11:45:09.140524151Z"}}
> 
```

And Express server shows proxy rules being applied:
```
[EXPRESS] [HPM] Rewriting path from "/inventory-api-socket/health/watch" to "/health/watch"
[EXPRESS] [HPM] GET /inventory-api-socket/health/watch ~> https://forklift-inventory-konveyor-forklift.apps.cluster-jortel.v2v.bos.redhat.com
[EXPRESS] [HPM] Upgrading to WebSocket
```

Meanwhile a request from web browser doesn't work yet.