### PR TITLE
Websocket support

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -169,9 +169,6 @@ module.exports = (env) => {
       }),
     ],
     resolve: {
-      alias: {
-        'react-dom': '@hot-loader/react-dom',
-      },
       extensions: ['.js', '.ts', '.tsx', '.jsx'],
       plugins: [
         new TsconfigPathsPlugin({

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -27,17 +27,20 @@ module.exports = merge(common('development'), {
           '/login/callback',
           '/cluster-api',
           '/inventory-api',
+          '/inventory-api-socket',
           '/inventory-payload-api',
         ],
         target: `http://localhost:${EXPRESS_PORT}`,
+        // ws: true
       },
-      {
-        context: [
-          '/inventory-api-socket',
-        ],
-        target: `ws://localhost:${EXPRESS_PORT}`,
-        secure: true,
-      }
+      // {
+      //   context: [
+      //     '/inventory-api-socket',
+      //   ],
+      //   target: `http://localhost:${EXPRESS_PORT}`,
+      //   ws: true,
+      //   secure: true,
+      // }
     ],
   },
   module: {

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -31,13 +31,13 @@ module.exports = merge(common('development'), {
         ],
         target: `http://localhost:${EXPRESS_PORT}`,
       },
-      // {
-      //   context: [
-      //     '/inventory-api-socket',
-      //   ],
-      //   target: `http://localhost:${EXPRESS_PORT}`,
-      //   ws: true
-      // }
+      {
+        context: [
+          '/inventory-api-socket',
+        ],
+        target: `ws://[::1]:${EXPRESS_PORT}`, // [::1] instead of localhost
+        ws: true
+      }
     ],
   },
   module: {

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -35,7 +35,8 @@ module.exports = merge(common('development'), {
         context: [
           '/inventory-api-socket',
         ],
-        target: `ws://localhost:${EXPRESS_PORT}`,
+        target: `wss://localhost:${EXPRESS_PORT}`,
+        secure: true,
       }
     ],
   },

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -31,6 +31,12 @@ module.exports = merge(common('development'), {
         ],
         target: `http://localhost:${EXPRESS_PORT}`,
       },
+      {
+        context: [
+          '/inventory-api-socket',
+        ],
+        target: `ws://localhost:${EXPRESS_PORT}`,
+      }
     ],
   },
   module: {

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -27,19 +27,16 @@ module.exports = merge(common('development'), {
           '/login/callback',
           '/cluster-api',
           '/inventory-api',
-          '/inventory-api-socket',
           '/inventory-payload-api',
         ],
         target: `http://localhost:${EXPRESS_PORT}`,
-        // ws: true
       },
       // {
       //   context: [
       //     '/inventory-api-socket',
       //   ],
       //   target: `http://localhost:${EXPRESS_PORT}`,
-      //   ws: true,
-      //   secure: true,
+      //   ws: true
       // }
     ],
   },

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -35,7 +35,7 @@ module.exports = merge(common('development'), {
         context: [
           '/inventory-api-socket',
         ],
-        target: `wss://localhost:${EXPRESS_PORT}`,
+        target: `ws://localhost:${EXPRESS_PORT}`,
         secure: true,
       }
     ],

--- a/deploy/server.js
+++ b/deploy/server.js
@@ -254,38 +254,47 @@ if (
 
   // https://github.com/websockets/ws/issues/1787
   const wss = new WebSocketServer.Server({
+    // clientTracking: true,
+    // path: 'inventory-api-socket',
     // server: httpServer, // allows for calling // wss.handleUpgrade() manually
     server: expressServer, // works without handleUpgrade
     // noServer: true // allows for calling // wss.handleUpgrade() manually
   });
 
-  wss.on('connection', (ws, request) => {
-    console.log('==================');
-    console.log('[wss] CONNECTION');
+  // wss.on('message', (msg) => {
+  //   console.log('wss received a message');
+  // });
 
-    ws.on('upgrade', () => {
-      console.log('===============================');
-      console.log('[wss] UPGRADE');
-    })
+  // wss.on('connection', (ws, request) => {
+  //   console.log('==================');
+  //   console.log('[wss] CONNECTION');
 
-    ws.on('message', (msg) => {
-      console.log('===============================');
-      console.log('[wss] MESSAGE', msg.toString());
-    })
+  //   ws.on('upgrade', () => {
+  //     console.log('===============================');
+  //     console.log('[wss] UPGRADE');
+  //   })
 
-    ws.on('open', (msg) => {
-      console.log('===============================');
-      console.log('[wss] OPEN');
-    })
+  //   ws.on('message', (msg) => {
+  //     console.log('===============================');
+  //     console.log('[wss] MESSAGE', msg.toString());
+  //     // wss.clients.forEach(client => {
+  //     //   client.send(msg.toString());
+  //     // });
+  //   })
 
-    ws.on('close', (msg) => {
-      console.log('===============================');
-      console.log('[wss] CLOSE');
-    })
+  //   ws.on('open', (msg) => {
+  //     console.log('===============================');
+  //     console.log('[wss] OPEN');
+  //   })
 
-    ws.send('ping');
-    ws.send('pong');
-  })
+  //   ws.on('close', (msg) => {
+  //     console.log('===============================');
+  //     console.log('[wss] CLOSE');
+  //   })
+
+  //   ws.send('ping');
+  //   ws.send('pong');
+  // })
 
 
   // httpServer.on('upgrade', (request, socket, head) => {
@@ -302,6 +311,8 @@ if (
   //   // })
   // });
 
-  expressServer.on('upgrade', inventoryApiSocketProxy.upgrade);
+  expressServer.on('upgrade', (request, socket, head) => {
+    inventoryApiSocketProxy.upgrade(request, socket, head);
+  });
 
 }

--- a/deploy/server.js
+++ b/deploy/server.js
@@ -4,6 +4,8 @@ const express = require('express');
 // import express from 'express';
 // import { WebSocketServer } from 'ws';
 const WebSocketServer = require('ws');
+const HttpsProxyAgent = require('https-proxy-agent');
+const url = require('url');
 // const WebSocketServer = require('websocket').server;
 const https = require('https');
 const http = require('http');
@@ -99,6 +101,13 @@ inventoryApiProxyOptions$ = {
 
 const inventoryApiSocketProxy = createProxyMiddleware(inventoryApiProxyOptions$);
 
+const parsed = url.parse(`wss://localhost:${port}`);
+console.log('attempting to connect to WebSocket %j', parsed.href);
+
+// create an instance of the `HttpsProxyAgent` class with the proxy server information
+// var options = url.parse(proxy);
+const agent = new HttpsProxyAgent(parsed.href);
+
 if (process.env['DATA_SOURCE'] !== 'mock') {
   let clusterApiProxyOptions = {
     target: meta.clusterApi,
@@ -192,9 +201,10 @@ if (
   const server = http.createServer(app);
   const wss = new WebSocketServer.Server({
     server: app,
-    // port: port
-    // noServer: true
+    agent
   });
+
+  // const wss = new WebSocketServer(parsed.href, agent);
 
   wss.on('connection', (ws) => {
     console.log('==================');
@@ -260,6 +270,6 @@ if (
 
   })
 
-  server.on('upgrade', inventoryApiSocketProxy.upgrade)
+  // server.on('upgrade', inventoryApiSocketProxy.upgrade)
 
 }

--- a/deploy/server.js
+++ b/deploy/server.js
@@ -94,7 +94,7 @@ let inventoryApiProxyOptions$ = {
 
 inventoryApiProxyOptions$ = {
   ...inventoryApiProxyOptions$,
-  secure: false,
+  secure: true,
 };
 
 const inventoryApiSocketProxy = createProxyMiddleware(inventoryApiProxyOptions$);
@@ -218,6 +218,12 @@ if (
 
   })
 
+  wss.on('upgrade', (request, socket, head) => {
+    console.log('----------------------------');
+    console.log('WS upgrade!!!!!!');
+
+  })
+
   server.listen(port, () => console.log(`Listening on port ${port}`));
 
   server.on('error', event => {
@@ -247,12 +253,13 @@ if (
   server.on('upgrade', (request, socket, head) => {
     console.log('----------------------------');
     console.log('express WS upgrade');
+
     wss.handleUpgrade(request, socket, head, (ws) => {
       wss.emit('connection', ws, request);
     })
 
   })
 
-  // server.on('upgrade', inventoryApiSocketProxy.upgrade)
+  server.on('upgrade', inventoryApiSocketProxy.upgrade)
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20170,6 +20170,21 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
+      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
@@ -21621,6 +21636,30 @@
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
       "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow=="
     },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
     "@types/aria-query": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
@@ -22621,6 +22660,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
@@ -23859,6 +23904,12 @@
         "yaml": "^1.10.0"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -24609,6 +24660,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.5.tgz",
       "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diff-sequences": {
@@ -34147,6 +34204,40 @@
         }
       }
     },
+    "ts-node": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
+      "integrity": "sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "0.6.1",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -35875,6 +35966,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22465,7 +22465,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       },
@@ -22474,7 +22473,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -22482,8 +22480,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -26715,17 +26712,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -26733,8 +26728,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22049,6 +22049,15 @@
         "@types/react": "*"
       }
     },
+    "@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.11",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
@@ -23285,6 +23294,14 @@
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
       "dev": true
     },
+    "bufferutil": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
+      "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -24350,7 +24367,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -24934,7 +24950,6 @@
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -24945,7 +24960,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -24956,7 +24970,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -25674,7 +25687,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
       "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "dev": true,
       "requires": {
         "type": "^2.0.0"
       },
@@ -25682,8 +25694,7 @@
         "type": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
-          "dev": true
+          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
         }
       }
     },
@@ -27253,8 +27264,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -30017,6 +30027,12 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
+        },
+        "ws": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
+          "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+          "dev": true
         }
       }
     },
@@ -30812,8 +30828,7 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -30841,6 +30856,11 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -34276,8 +34296,7 @@
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -34313,7 +34332,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -34582,9 +34600,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
@@ -34605,6 +34623,14 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "utf-8-validate": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.5.tgz",
+      "integrity": "sha512-+pnxRYsS/axEpkrrEpzYfNZGXp0IjC/9RIxwM5gntY4Koi8SHmUGSfxfWqxZdRxrtaoVstuOzUp/rbs3JSPELQ==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -34882,6 +34908,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "ws": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
+          "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
+          "dev": true
         }
       }
     },
@@ -35630,6 +35662,19 @@
         "source-map": "~0.6.1"
       }
     },
+    "websocket": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
+      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "requires": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      }
+    },
     "websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -35778,10 +35823,9 @@
       }
     },
     "ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.1.tgz",
+      "integrity": "sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ=="
     },
     "xdg-basedir": {
       "version": "4.0.0",
@@ -35811,6 +35855,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20399,27 +20399,6 @@
         "@hapi/hoek": "9.x.x"
       }
     },
-    "@hot-loader/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-QttzEibkIFkl/WV1dsLXg73YIweNo9ySbB0/26068RqFGWyv7pKyictWsaQXqSj1y66/BDn3kglCHgroGrv3vA==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
-      },
-      "dependencies": {
-        "scheduler": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "express": "^4.17.1",
     "fast-deep-equal": "^3.1.3",
     "http-proxy-middleware": "^2.0.0",
+    "https-proxy-agent": "^5.0.0",
     "js-yaml": "^4.1.0",
     "netmask": "^2.0.2",
     "node-fetch": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "terser-webpack-plugin": "^5.1.3",
     "ts-jest": "^27.0.3",
     "ts-loader": "^9.2.3",
+    "ts-node": "^10.2.1",
     "tsconfig-paths-webpack-plugin": "^3.5.1",
     "tslib": "^2.3.1",
     "typescript": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/react-syntax-highlighter": "^13.5.0",
     "@types/simple-oauth2": "^4.1.0",
     "@types/victory": "^33.1.4",
+    "@types/ws": "^7.4.7",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "concurrently": "^6.2.0",
@@ -116,6 +117,8 @@
     "react-dom": "^17.0.2",
     "react-router-last-location": "^2.0.1",
     "react-syntax-highlighter": "^15.4.3",
+    "websocket": "^1.0.34",
+    "ws": "^8.2.1",
     "yup": "^0.32.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@hot-loader/react-dom": "^17.0.1",
     "@konveyor/lib-ui": "^5.0.0",
     "@patternfly/react-core": "^4.152.4",
     "@patternfly/react-icons": "^4.11.14",

--- a/src/app/common/context/WebSocketContext.tsx
+++ b/src/app/common/context/WebSocketContext.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import {
+  // useVmsSocketMutation,
+  // useTestSubscription,
+} from '@app/queries';
+import { getInventoryApiSocketUrl } from '@app/queries/helpers';
+import { QueryClient } from 'react-query';
+
+interface IWebSocketContext {
+  // isPollingEnabled: boolean;
+}
+
+const WebSocketContext = React.createContext<IWebSocketContext>({
+  // isPollingEnabled: true,
+});
+
+interface IWebSocketContextProviderProps {
+  children: React.ReactNode;
+  queryClient: QueryClient;
+}
+
+export const WebSocketContextProvider: React.FunctionComponent<IWebSocketContextProviderProps> = ({
+  children,
+  queryClient
+}: IWebSocketContextProviderProps) => {
+
+  React.useEffect(() => {
+
+    // const options = 'snapshot';
+    // document.cookie = 'X-Watch=' + options + '; path=/';
+
+    // authorizedFetch(
+    //   `${getInventoryApiSocketUrl('providers')}`,
+    //   fetchContext,
+    //   {
+    //     // 'X-Watch': ''
+    //   }
+    //   ).then((result) => {
+    //     console.log('result', result);
+    //   })
+
+    console.log('setting up WebSocket instance');
+
+    // const websocket = new WebSocket(`${getInventoryApiSocketUrl('providers')}`);
+    const websocket = new WebSocket(`ws://localhost:9000${getInventoryApiSocketUrl('providers')}`);
+
+    // console.log('websocket', websocket);
+
+    websocket.onerror = (error) => {
+      console.log('ERROR CONNECTION', error)
+    }
+
+    websocket.onopen = () => {
+      console.log('OPENED CONNECTION')
+    }
+
+    websocket.onclose = () => {
+      console.log('CLOSED CONNECTION');
+    }
+
+    websocket.onmessage = (event) => {
+      console.log('ONMESSAGE', event.data);
+        // event.type == ''
+      // queryClient.invalidateQueries('');
+    }
+
+    return () => {
+      console.log('tearing down WebSocket instance');
+      websocket.close()
+    }
+  }, [queryClient]);
+
+  return (
+    <WebSocketContext.Provider
+      value={{
+        // isPollingEnabled,
+      }}
+    >
+      {children}
+    </WebSocketContext.Provider>
+  );
+};
+
+export const useWebSocketContext = (): IWebSocketContext => React.useContext(WebSocketContext);

--- a/src/app/common/context/WebSocketContext.tsx
+++ b/src/app/common/context/WebSocketContext.tsx
@@ -6,14 +6,11 @@ import {
 import { useNetworkContext } from '@app/common/context/NetworkContext';
 import { getInventoryApiSocketUrl } from '@app/queries/helpers';
 import { QueryClient } from 'react-query';
+import { authorizedFetch, useFetchContext } from '@app/queries/fetchHelpers';
 
-interface IWebSocketContext {
-  // isPollingEnabled: boolean;
-}
+interface IWebSocketContext {}
 
-const WebSocketContext = React.createContext<IWebSocketContext>({
-  // isPollingEnabled: true,
-});
+const WebSocketContext = React.createContext<IWebSocketContext>({});
 
 interface IWebSocketContextProviderProps {
   children: React.ReactNode;
@@ -24,68 +21,46 @@ export const WebSocketContextProvider: React.FunctionComponent<IWebSocketContext
   children,
   queryClient
 }: IWebSocketContextProviderProps) => {
-  const { currentUser } = useNetworkContext();
+
   React.useEffect(() => {
-
-
-    // const options = 'snapshot';
-    // document.cookie = 'X-Watch=' + options + '; path=/';
-
-    // authorizedFetch(
-    //   `${getInventoryApiSocketUrl('providers')}`,
-    //   fetchContext,
-    //   {
-    //     // 'X-Watch': ''
-    //   }
-    //   ).then((result) => {
-    //     console.log('result', result);
-    //   })
 
     let websocket: WebSocket | null = null;
 
-    if (currentUser) {
-      console.log('setting up WebSocket instance');
 
-      // const websocket = new WebSocket(`${getInventoryApiSocketUrl('providers')}`);
+    if (queryClient) {
+
       // const websocket = new WebSocket(`ws://localhost:9001${getInventoryApiSocketUrl('providers/openshift/b245f43c-8448-4643-b697-c2e9d21e40a9/vms')}`);
-      websocket = new WebSocket(`ws://localhost:9001/inventory-api-socket/providers/vsphere/c872d364-d62b-46f0-bd42-16799f40324e/hosts`);
-
-
-      // console.log('websocket', websocket);
+      // websocket = new WebSocket(`ws://localhost:9001/inventory-api-socket/providers/vsphere/c872d364-d62b-46f0-bd42-16799f40324e/hosts`);
+      websocket = new WebSocket(`ws://localhost:9001/inventory-api-socket/health/watch`);
 
       websocket.onerror = (error) => {
-        console.log('ERROR CONNECTION', error)
+        console.log('[ws] ERROR CONNECTION', error);
       }
 
       websocket.onopen = () => {
-        console.log('OPENED CONNECTION')
+        console.log('[ws] OPENED CONNECTION');
+        websocket?.send('test from client');
       }
 
       websocket.onclose = () => {
-        console.log('CLOSED CONNECTION');
+        console.log('[ws] CLOSED CONNECTION');
       }
 
       websocket.onmessage = (event) => {
-        console.log('ONMESSAGE', event.data);
-          // event.type == ''
+        console.log('[ws] ONMESSAGE', event.data);
+        // if (event.type === '') {}
         // queryClient.invalidateQueries('');
       }
     }
 
-
-
     return () => {
-      console.log('tearing down WebSocket instance');
+      console.log('[ws] destroying WS instance');
       websocket?.close()
     }
-  }, [currentUser]);
+  }, [queryClient]);
 
   return (
-    <WebSocketContext.Provider
-      value={{
-        // isPollingEnabled,
-      }}
-    >
+    <WebSocketContext.Provider value={{}}>
       {children}
     </WebSocketContext.Provider>
   );

--- a/src/app/common/context/WebSocketContext.tsx
+++ b/src/app/common/context/WebSocketContext.tsx
@@ -42,7 +42,7 @@ export const WebSocketContextProvider: React.FunctionComponent<IWebSocketContext
     console.log('setting up WebSocket instance');
 
     // const websocket = new WebSocket(`${getInventoryApiSocketUrl('providers')}`);
-    const websocket = new WebSocket(`ws://localhost:9000${getInventoryApiSocketUrl('providers')}`);
+    const websocket = new WebSocket(`ws://localhost:9001${getInventoryApiSocketUrl('providers')}`);
 
     // console.log('websocket', websocket);
 

--- a/src/app/common/context/WebSocketContext.tsx
+++ b/src/app/common/context/WebSocketContext.tsx
@@ -32,6 +32,7 @@ export const WebSocketContextProvider: React.FunctionComponent<IWebSocketContext
       // const websocket = new WebSocket(`ws://localhost:9001${getInventoryApiSocketUrl('providers/openshift/b245f43c-8448-4643-b697-c2e9d21e40a9/vms')}`);
       // websocket = new WebSocket(`ws://localhost:9001/inventory-api-socket/providers/vsphere/c872d364-d62b-46f0-bd42-16799f40324e/hosts`);
       websocket = new WebSocket(`ws://localhost:9001/inventory-api-socket/health/watch`);
+      // websocket = new WebSocket(`/inventory-api-socket/health/watch`);
 
       websocket.onerror = (error) => {
         console.log('[ws] ERROR CONNECTION', error);

--- a/src/app/common/context/WebSocketContext.tsx
+++ b/src/app/common/context/WebSocketContext.tsx
@@ -3,6 +3,7 @@ import {
   // useVmsSocketMutation,
   // useTestSubscription,
 } from '@app/queries';
+import { useNetworkContext } from '@app/common/context/NetworkContext';
 import { getInventoryApiSocketUrl } from '@app/queries/helpers';
 import { QueryClient } from 'react-query';
 
@@ -23,8 +24,9 @@ export const WebSocketContextProvider: React.FunctionComponent<IWebSocketContext
   children,
   queryClient
 }: IWebSocketContextProviderProps) => {
-
+  const { currentUser } = useNetworkContext();
   React.useEffect(() => {
+
 
     // const options = 'snapshot';
     // document.cookie = 'X-Watch=' + options + '; path=/';
@@ -39,36 +41,44 @@ export const WebSocketContextProvider: React.FunctionComponent<IWebSocketContext
     //     console.log('result', result);
     //   })
 
-    console.log('setting up WebSocket instance');
+    let websocket: WebSocket | null = null;
 
-    // const websocket = new WebSocket(`${getInventoryApiSocketUrl('providers')}`);
-    const websocket = new WebSocket(`ws://localhost:9001${getInventoryApiSocketUrl('providers')}`);
+    if (currentUser) {
+      console.log('setting up WebSocket instance');
 
-    // console.log('websocket', websocket);
+      // const websocket = new WebSocket(`${getInventoryApiSocketUrl('providers')}`);
+      // const websocket = new WebSocket(`ws://localhost:9001${getInventoryApiSocketUrl('providers/openshift/b245f43c-8448-4643-b697-c2e9d21e40a9/vms')}`);
+      websocket = new WebSocket(`ws://localhost:9001/inventory-api-socket/providers/vsphere/c872d364-d62b-46f0-bd42-16799f40324e/hosts`);
 
-    websocket.onerror = (error) => {
-      console.log('ERROR CONNECTION', error)
+
+      // console.log('websocket', websocket);
+
+      websocket.onerror = (error) => {
+        console.log('ERROR CONNECTION', error)
+      }
+
+      websocket.onopen = () => {
+        console.log('OPENED CONNECTION')
+      }
+
+      websocket.onclose = () => {
+        console.log('CLOSED CONNECTION');
+      }
+
+      websocket.onmessage = (event) => {
+        console.log('ONMESSAGE', event.data);
+          // event.type == ''
+        // queryClient.invalidateQueries('');
+      }
     }
 
-    websocket.onopen = () => {
-      console.log('OPENED CONNECTION')
-    }
 
-    websocket.onclose = () => {
-      console.log('CLOSED CONNECTION');
-    }
-
-    websocket.onmessage = (event) => {
-      console.log('ONMESSAGE', event.data);
-        // event.type == ''
-      // queryClient.invalidateQueries('');
-    }
 
     return () => {
       console.log('tearing down WebSocket instance');
-      websocket.close()
+      websocket?.close()
     }
-  }, [queryClient]);
+  }, [currentUser]);
 
   return (
     <WebSocketContext.Provider

--- a/src/app/common/context/index.ts
+++ b/src/app/common/context/index.ts
@@ -1,3 +1,4 @@
 export * from './LocalStorageContext';
 export * from './PollingContext';
 export * from './NetworkContext';
+export * from './WebSocketContext';

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -10,8 +10,15 @@ import {
   PollingContextProvider,
   LocalStorageContextProvider,
   NetworkContextProvider,
+  WebSocketContextProvider
 } from '@app/common/context';
 import { noop } from '@app/common/constants';
+import {
+  // useVmsSocketMutation,
+  // useTestSubscription,
+} from '@app/queries';
+import { getInventoryApiSocketUrl } from '@app/queries/helpers';
+import { authorizedFetch, useFetchContext } from '@app/queries/fetchHelpers';
 
 const queryCache = new QueryCache();
 const queryClient = new QueryClient({
@@ -24,21 +31,26 @@ const queryClient = new QueryClient({
   },
 });
 
-const App: React.FunctionComponent = () => (
-  <QueryClientProvider client={queryClient}>
-    <PollingContextProvider>
-      <LocalStorageContextProvider>
-        <NetworkContextProvider>
-          <Router getUserConfirmation={noop}>
-            <AppLayout>
-              <AppRoutes />
-            </AppLayout>
-          </Router>
-        </NetworkContextProvider>
-      </LocalStorageContextProvider>
-    </PollingContextProvider>
-    {process.env.NODE_ENV !== 'test' ? <ReactQueryDevtools /> : null}
-  </QueryClientProvider>
-);
+const App: React.FunctionComponent = () => {
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <WebSocketContextProvider queryClient={queryClient}>
+        <PollingContextProvider>
+          <LocalStorageContextProvider>
+            <NetworkContextProvider>
+              <Router getUserConfirmation={noop}>
+                <AppLayout>
+                  <AppRoutes />
+                </AppLayout>
+              </Router>
+            </NetworkContextProvider>
+          </LocalStorageContextProvider>
+        </PollingContextProvider>
+        {process.env.NODE_ENV !== 'test' ? <ReactQueryDevtools /> : null}
+      </WebSocketContextProvider>
+    </QueryClientProvider>
+  )
+};
 
 export { App };

--- a/src/app/queries/fetchHelpers.ts
+++ b/src/app/queries/fetchHelpers.ts
@@ -36,6 +36,7 @@ export const authorizedFetch = async <T>(
       throw response;
     }
   } catch (error: any) {
+    console.log('error with authorized fetch', error);
     checkExpiry(error, history);
     throw error;
   }

--- a/src/app/queries/fetchHelpers.ts
+++ b/src/app/queries/fetchHelpers.ts
@@ -35,7 +35,7 @@ export const authorizedFetch = async <T>(
     } else {
       throw response;
     }
-  } catch (error) {
+  } catch (error: any) {
     checkExpiry(error, history);
     throw error;
   }
@@ -70,7 +70,7 @@ export const authorizedK8sRequest = async <T>(
     } else {
       throw response;
     }
-  } catch (error) {
+  } catch (error: any) {
     checkExpiry(error, history);
     throw error;
   }

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -85,6 +85,9 @@ export const useMockableMutation = <
 export const getInventoryApiUrl = (relativePath: string): string =>
   `/inventory-api/${relativePath}`;
 
+  export const getInventoryApiSocketUrl = (relativePath: string): string =>
+  `/inventory-api-socket/${relativePath}`;
+
 export const getAggregateQueryStatus = (queryResults: UnknownResult[]): QueryStatus => {
   if (queryResults.some((result) => result.isError)) return 'error';
   if (queryResults.some((result) => result.isLoading)) return 'loading';

--- a/src/app/queries/index.ts
+++ b/src/app/queries/index.ts
@@ -11,3 +11,4 @@ export * from './migrations';
 export * from './secrets';
 export * from './namespaces';
 export * from './provisioners';
+export * from './vms.socket';

--- a/src/app/queries/vms.socket.ts
+++ b/src/app/queries/vms.socket.ts
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { useQueryClient } from 'react-query';
+import { useMockableQuery, useMockableMutation, getInventoryApiUrl } from './helpers';
+import { authorizedFetch, useAuthorizedFetch, useFetchContext } from './fetchHelpers';
+
+export const openVmsConnection = (url: string) => {
+
+}
+
+// const vmsSocket = useVmsSocketMutation('vms?detail=1');
+
+// vmsSocket.mutate({
+//   foo: 'bar'
+// });
+
+// export const useVmsSocketMutation = (
+//   url: string,
+//   onSuccess?: () => void,
+//   onError?: () => void
+// ) => {
+//   console.log('prepped for vms.socket');
+//   // const queryClient = useQueryClient();
+//   const fetchContext = useFetchContext();
+
+//   const result = useMockableMutation<any>(
+//     async (options: any) => {
+//       // await authorizedFetch(
+//       //   getMustGatherApiUrl(url),
+//       //   fetchContext,
+//       //   { 'Content-Type': 'application/json' },
+//       //   'post',
+//       //   options
+//       // )
+
+//       return new Promise((res, rej) => {
+//         console.log('called vms.socket promise');
+//         authorizedFetch<any>(
+//           getInventoryApiUrl(url),
+//           fetchContext,
+//           { 'X-Watch': '' },
+//           // 'post'
+//         )
+//           .then((wsData) => {
+//             console.log('wsData', wsData);
+//             res(wsData);
+//           })
+//           .catch((error) => {
+//             console.log('wsError', error);
+//             rej({
+//               result: 'error',
+//               error: error,
+//             });
+//           });
+//       });
+//     },
+//     {
+//       onSuccess: (data) => {
+//         // queryClient.invalidateQueries(['must-gather-list']);
+//         onSuccess && onSuccess();
+//       },
+//       onError: () => {
+//         onError && onError();
+//       },
+//     }
+//   );
+//   return result;
+// };
+
+
+
+// export const useTestSubscription = () => {
+//   React.useEffect(() => {
+//     console.log('websocket useEffect ran');
+
+//     const websocket = new WebSocket('ws://echo.websocket.org/');
+//     console.log('websocket', websocket);
+
+//     websocket.onopen = () => {
+//       console.log('connected')
+//     }
+
+//     return () => {
+//       websocket.close()
+//     }
+//   }, [])
+// }


### PR DESCRIPTION
Figured I'd join the club and post my draft PR for websocket support for comparison. It's pretty similar in implementation to https://github.com/konveyor/forklift-ui/pull/768/ - I've exhausted a few more options with the `http-proxy-middleware` and `ws` packages, but while I can send events between the UI and node app, I can't seem to receive events from the inventory on the node app (although I was able to get same type confirmation logs for "Upgrading to websocket" as observed in https://github.com/konveyor/forklift-ui/pull/774.

I think next step is to try swapping usage of either of those two npm packages (just for the ws endpoint) and see if we can get message events going from the inventory to the node app - once we are there we're home free as communication from the react app and the websocket server is already working great.

The new WebSocket constructor in the browser seems to require `ws://` schema to be specified, which prevents us from being able to use the dev server proxy config, so in the mean time I'm just hitting the express server directly for now. I did get a tip from a fellow UXD member to check into the webpack [webSocketServer](https://webpack.js.org/configuration/dev-server/#devserverwebsocketserver) config, so I'm thinking that will help move things along on that front. I'll give it a spin as soon as I get back to this work.