### PR TITLE
Add tar to the final container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ RUN npm install && npm run build
 # Runner image
 FROM registry.access.redhat.com/ubi8/nodejs-14
 
+# Add tar package to allow copying files with kubectl scp
+USER root
+RUN dnf -y install tar && dnf clean all
+USER 1001
+
 LABEL name="konveyor/forklift-ui" \
       description="Konveyor for Virtualization - User Interface" \
       help="For more information visit https://konveyor.io" \


### PR DESCRIPTION
To be able to use `kubectl scp`, the container needs to have the `tar` command. This PR adds it.