### PR TITLE
DO NOT MERGE: Hack to look up VMs by name instead of id when prefilling wizard

### DIFF
--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -512,7 +512,9 @@ export const getSelectedVMsFromPlan = (
   indexedVMs: IndexedSourceVMs | undefined
 ): SourceVM[] => {
   if (!planBeingPrefilled || !indexedVMs) return [];
-  return indexedVMs.findVMsByIds(planBeingPrefilled?.spec.vms.map(({ id }) => id));
+  return indexedVMs.findVMsByNames(
+    planBeingPrefilled?.spec.vms.map(({ name }) => name) as string[]
+  );
 };
 
 interface IPlanWizardPrefillResults {

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -55,6 +55,7 @@ export interface IPlanVMHook {
 
 export interface IPlanVM {
   id: string;
+  name?: string;
   hooks?: IPlanVMHook[];
 }
 

--- a/src/app/queries/vms.ts
+++ b/src/app/queries/vms.ts
@@ -12,8 +12,10 @@ type SourceVMsRecord = Record<string, SourceVM | undefined>;
 export interface IndexedSourceVMs {
   vms: SourceVM[];
   vmsById: SourceVMsRecord;
+  vmsByName: SourceVMsRecord;
   vmsBySelfLink: SourceVMsRecord;
   findVMsByIds: (ids: string[]) => SourceVM[];
+  findVMsByNames: (ids: string[]) => SourceVM[];
   findVMsBySelfLinks: (selfLinks: string[]) => SourceVM[];
 }
 
@@ -23,16 +25,20 @@ const findVMsInRecord = (record: SourceVMsRecord, keys: string[]) =>
 export const indexVMs = (vms: SourceVM[]): IndexedSourceVMs => {
   const sortedVMs = sortByName(vms.filter((vm) => !(vm as IVMwareVM).isTemplate));
   const vmsById: SourceVMsRecord = {};
+  const vmsByName: SourceVMsRecord = {};
   const vmsBySelfLink: SourceVMsRecord = {};
   sortedVMs.forEach((vm) => {
     vmsById[vm.id] = vm;
+    vmsByName[vm.name] = vm;
     vmsBySelfLink[vm.selfLink] = vm;
   });
   return {
     vms: sortedVMs,
     vmsById,
+    vmsByName,
     vmsBySelfLink,
     findVMsByIds: (ids) => findVMsInRecord(vmsById, ids),
+    findVMsByNames: (names) => findVMsInRecord(vmsByName, names),
     findVMsBySelfLinks: (selfLinks) => findVMsInRecord(vmsBySelfLink, selfLinks),
   };
 };


### PR DESCRIPTION
Just opening this to stash this commit in a reusable place. When recording a demo I realized the plans that were created on the CLI had VMs identified by name instead of id in the plan CR's spec. The UI assumes VMs in the plan spec will have ids, so it breaks prefilling the wizard on edit/duplicate. This commit was used as a hack to allow recording a demo, but we should evaluate whether we need to support both VM identifiers so people can create plans on the CLI and then use the UI for those, or whether we should not support that corner case.