### PR TITLE
chore(mg): ensure must gather custom names are namespaced

### DIFF
--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -40,13 +40,12 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
   planState,
   canRestart,
 }: IPlansActionDropdownProps) => {
-  const { mustGatherWatchList, latestAssociatedMustGather } = React.useContext(MustGatherContext);
+  const { withNs, latestAssociatedMustGather } = React.useContext(MustGatherContext);
 
-  const mustGather = latestAssociatedMustGather(plan.metadata.name);
+  const mustGather = latestAssociatedMustGather(withNs(plan.metadata.name, 'plan'));
+  console.log('PlanActionsDropdown', mustGather);
 
-  const isPlanGathering =
-    mustGatherWatchList.map((mg) => mg.name).includes(plan.metadata.name) &&
-    (mustGather?.status === 'inprogress' || mustGather?.status === 'new');
+  const isPlanGathering = mustGather?.status === 'inprogress' || mustGather?.status === 'new';
 
   const history = useHistory();
   const onMigrationStarted = (migration: IMigration) => {

--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -43,7 +43,6 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
   const { withNs, latestAssociatedMustGather } = React.useContext(MustGatherContext);
 
   const mustGather = latestAssociatedMustGather(withNs(plan.metadata.name, 'plan'));
-  console.log('PlanActionsDropdown', mustGather);
 
   const isPlanGathering = mustGather?.status === 'inprogress' || mustGather?.status === 'new';
 

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -286,7 +286,7 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
             >
               <FlexItem align={{ default: 'alignRight' }}>
                 {buttonType === 'MustGather' ? (
-                  <MustGatherBtn type="plan" customName={plan.metadata.name} />
+                  <MustGatherBtn type="plan" displayName={plan.metadata.name} />
                 ) : (
                   <MigrateOrCutoverButton
                     plan={plan}

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -292,7 +292,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
               { title: <VMWarmCopyStatus vmStatus={vmStatus} isCanceled={isCanceled} /> },
             ]),
         {
-          title: <MustGatherBtn type="vm" customName={getVMName(vmStatus)} />,
+          title: <MustGatherBtn type="vm" displayName={getVMName(vmStatus)} />,
         },
       ],
     });

--- a/src/app/common/components/MustGatherBtn.tsx
+++ b/src/app/common/components/MustGatherBtn.tsx
@@ -5,11 +5,11 @@ import { MustGatherContext } from '@app/common/context';
 import { getMustGatherApiUrl } from '@app/queries/helpers';
 
 interface IMustGatherBtn {
-  customName: string;
+  displayName: string;
   type: 'plan' | 'vm';
 }
 
-export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({ customName, type }) => {
+export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({ displayName, type }) => {
   const {
     setMustGatherModalOpen,
     setActiveMustGather,
@@ -19,7 +19,7 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({ customN
     withoutNs,
   } = React.useContext(MustGatherContext);
 
-  const namespacedName = withNs(customName, type);
+  const namespacedName = withNs(displayName, type);
   const mustGather = latestAssociatedMustGather(namespacedName);
 
   return mustGather?.status === 'completed' && mustGather?.['archive-name'] ? (
@@ -27,7 +27,7 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({ customN
       content={
         !mustGathersQuery.isSuccess
           ? `Could not reach must gather service.`
-          : `must-gather-${type}_${customName} available for download.`
+          : `must-gather-${type}_${displayName} available for download.`
       }
     >
       <Button
@@ -73,7 +73,7 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({ customN
           setMustGatherModalOpen(true);
           setActiveMustGather({
             type,
-            customName: customName,
+            displayName: displayName,
             status: 'new',
           });
         }}

--- a/src/app/common/components/MustGatherBtn.tsx
+++ b/src/app/common/components/MustGatherBtn.tsx
@@ -13,20 +13,21 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({ customN
   const {
     setMustGatherModalOpen,
     setActiveMustGather,
-    mustGatherWatchList,
-    setMustGatherWatchList,
     mustGathersQuery,
     latestAssociatedMustGather,
+    withNs,
+    withoutNs,
   } = React.useContext(MustGatherContext);
 
-  const mustGather = latestAssociatedMustGather(customName);
+  const namespacedName = withNs(customName, type);
+  const mustGather = latestAssociatedMustGather(namespacedName);
 
   return mustGather?.status === 'completed' && mustGather?.['archive-name'] ? (
     <Tooltip
       content={
         !mustGathersQuery.isSuccess
           ? `Could not reach must gather service.`
-          : `${mustGather?.['archive-name']} available for download`
+          : `must-gather-${type}_${customName} available for download.`
       }
     >
       <Button
@@ -50,7 +51,7 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({ customN
           : mustGather?.status === 'new'
           ? `Must gather queued for execution.`
           : mustGather?.status === 'error'
-          ? `Could not complete must gather for ${mustGather?.['custom-name']}`
+          ? `Could not complete must gather for ${withoutNs(mustGather?.['custom-name'], type)}`
           : `Collects the current ${
               type === 'plan' ? 'migration plan' : 'VM migration'
             } logs and creates a tar archive file for download.`
@@ -59,13 +60,12 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({ customN
       <Button
         icon={mustGather?.status === 'error' ? <WarningTriangleIcon /> : null}
         isLoading={
-          mustGatherWatchList.map((mg) => mg.name).includes(customName) &&
           !mustGathersQuery.isError &&
           (mustGather?.status === 'inprogress' || mustGather?.status === 'new')
         }
         isAriaDisabled={
-          (mustGatherWatchList.map((mg) => mg.name).includes(customName) &&
-            (mustGather?.status === 'inprogress' || mustGather?.status === 'new')) ||
+          mustGather?.status === 'inprogress' ||
+          mustGather?.status === 'new' ||
           !mustGathersQuery.isSuccess
         }
         variant="secondary"
@@ -76,15 +76,6 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({ customN
             customName: customName,
             status: 'new',
           });
-
-          setMustGatherWatchList([
-            ...mustGatherWatchList,
-            {
-              name: customName,
-              // ensure the "inprogress" state is reflected in the button
-              isGathering: true,
-            },
-          ]);
         }}
       >
         {mustGather?.status === 'completed' ? 'Download logs' : 'Get logs'}

--- a/src/app/common/components/MustGatherModal.tsx
+++ b/src/app/common/components/MustGatherModal.tsx
@@ -11,9 +11,9 @@ export const MustGatherModal: React.FunctionComponent = () => {
   const handleMustGatherSuccess = () => {
     if (activeMustGather) {
       pushNotification({
-        title: `Started must gather for ${activeMustGather.customName}`,
+        title: `Started must gather for ${activeMustGather.displayName}`,
         message: '',
-        key: activeMustGather.customName,
+        key: activeMustGather.displayName,
         variant: 'info',
         actionClose: true,
         timeout: 4000,
@@ -24,9 +24,9 @@ export const MustGatherModal: React.FunctionComponent = () => {
   const handleMustGatherError = () => {
     if (activeMustGather) {
       pushNotification({
-        title: `Could not run must gather for ${activeMustGather.customName}`,
+        title: `Could not run must gather for ${activeMustGather.displayName}`,
         message: '',
-        key: activeMustGather.customName,
+        key: activeMustGather.displayName,
         variant: 'danger',
         actionClose: true,
       });
@@ -39,8 +39,8 @@ export const MustGatherModal: React.FunctionComponent = () => {
     handleMustGatherError
   );
 
-  const handleMustGatherRequest = ({ customName, type }: MustGatherObjType) => {
-    const namespacedName = withNs(customName, type);
+  const handleMustGatherRequest = ({ displayName, type }: MustGatherObjType) => {
+    const namespacedName = withNs(displayName, type);
     registerMustGather.mutate({
       'custom-name': namespacedName,
       command:
@@ -84,7 +84,7 @@ export const MustGatherModal: React.FunctionComponent = () => {
         <Text component="p">
           The migration logs will be consolidated into a single archive file named{' '}
           <strong>
-            must-gather-{activeMustGather?.type}_{activeMustGather?.customName}.tar.gz
+            must-gather-{activeMustGather?.type}_{activeMustGather?.displayName}.tar.gz
           </strong>
           .
         </Text>

--- a/src/app/common/components/MustGatherWatcher.tsx
+++ b/src/app/common/components/MustGatherWatcher.tsx
@@ -4,6 +4,7 @@ import { NotificationContext } from '@app/common/context';
 import { useMustGatherQuery } from '@app/queries';
 import { mustGatherStatus } from '@app/client/types';
 import { getMustGatherApiUrl } from '@app/queries/helpers';
+import { MustGatherContext } from '@app/common/context';
 
 interface IMustGatherWatcherProps {
   name: string;
@@ -20,10 +21,11 @@ export const MustGatherWatcher: React.FunctionComponent<IMustGatherWatcherProps>
   const [notified, setNotified] = React.useState(completedPreviously || erroredPreviously);
   const [hasCompleted, setHasCompleted] = React.useState(completedPreviously || erroredPreviously);
   const { data, isSuccess } = useMustGatherQuery(name, hasCompleted);
+  const { withoutNs } = React.useContext(MustGatherContext);
 
   React.useEffect(() => {
     const type = data?.command.toLowerCase().includes('plan') ? 'plan' : 'vm';
-
+    const unprefixedName = data && withoutNs(data['custom-name'], type);
     if (
       data?.status === 'completed' ||
       completedPreviously ||
@@ -49,7 +51,7 @@ export const MustGatherWatcher: React.FunctionComponent<IMustGatherWatcherProps>
               variant="link"
               isInline
             >
-              {data?.['custom-name']}
+              {unprefixedName}
             </Button>
           </div>
         ),
@@ -65,7 +67,7 @@ export const MustGatherWatcher: React.FunctionComponent<IMustGatherWatcherProps>
     if (isSuccess && !!data?.['custom-name'] && listStatus === 'error' && !notified) {
       pushNotification({
         title: 'Log collection unsuccessful.',
-        message: `An error was encountered while gathering the migration logs for the ${type} ${data?.['custom-name']}`,
+        message: `An error was encountered while gathering the migration logs for the ${type} ${unprefixedName}`,
         key: `${data?.['custom-name']}-error`,
         variant: 'danger',
         actionClose: true,
@@ -82,6 +84,7 @@ export const MustGatherWatcher: React.FunctionComponent<IMustGatherWatcherProps>
     hasCompleted,
     completedPreviously,
     erroredPreviously,
+    withoutNs,
     setNotified,
     setHasCompleted,
     pushNotification,

--- a/src/app/common/context/MustGatherContext.tsx
+++ b/src/app/common/context/MustGatherContext.tsx
@@ -6,7 +6,7 @@ import { MustGatherWatcher } from '@app/common/components/MustGatherWatcher';
 import { NotificationContext } from '@app/common/context';
 
 export type MustGatherObjType = {
-  customName: string;
+  displayName: string;
   type: 'plan' | 'vm';
   status: mustGatherStatus;
 };
@@ -52,7 +52,7 @@ export const MustGatherContextProvider: React.FunctionComponent<IMustGatherConte
     (data) => {
       const updatedMgList: mustGatherListType = data.map((mg): MustGatherObjType => {
         return {
-          customName: mg['custom-name'],
+          displayName: mg['custom-name'],
           status: mg.status,
           type: mg.command.toLowerCase().includes('plan') ? 'plan' : 'vm',
         };
@@ -110,24 +110,24 @@ export const MustGatherContextProvider: React.FunctionComponent<IMustGatherConte
       <>
         {children}
         {mustGatherList.map((mg, idx) => {
-          return mg.customName && process.env.NODE_ENV !== 'production' ? (
+          return mg.displayName && process.env.NODE_ENV !== 'production' ? (
             <div
-              data-mg-watcher={mg.customName}
+              data-mg-watcher={mg.displayName}
               data-type={mg.type}
               data-status={mg.status}
               key={idx}
             >
               <MustGatherWatcher
                 listStatus={mg.status}
-                key={`${mg.customName}-${idx}`}
-                name={mg.customName}
+                key={`${mg.displayName}-${idx}`}
+                name={mg.displayName}
               />
             </div>
           ) : (
             <MustGatherWatcher
               listStatus={mg.status}
-              key={`${mg.customName}-${idx}`}
-              name={mg.customName}
+              key={`${mg.displayName}-${idx}`}
+              name={mg.displayName}
             />
           );
         })}

--- a/src/app/common/context/MustGatherContext.tsx
+++ b/src/app/common/context/MustGatherContext.tsx
@@ -23,10 +23,10 @@ interface IMustGatherContext {
   mustGatherList: mustGatherListType;
   setActiveMustGather: (mustGatherObj: MustGatherObjType) => void;
   activeMustGather: MustGatherObjType | undefined;
-  mustGatherWatchList: mgWatchListType;
-  setMustGatherWatchList: (list: mgWatchListType) => void;
   mustGathersQuery: UseQueryResult<IMustGatherResponse[], Response>;
   latestAssociatedMustGather: (name: string) => IMustGatherResponse | undefined;
+  withNs: (resourceName: string, type: 'plan' | 'vm') => string;
+  withoutNs: (namespacedResourceName: string, type: 'plan' | 'vm') => string;
 }
 
 const mustGatherContextDefaultValue = {} as IMustGatherContext;
@@ -45,7 +45,6 @@ export const MustGatherContextProvider: React.FunctionComponent<IMustGatherConte
   const [mustGatherModalOpen, setMustGatherModalOpen] = React.useState(false);
   const [mustGatherList, setMustGatherList] = React.useState<mustGatherListType>([]);
   const [activeMustGather, setActiveMustGather] = React.useState<MustGatherObjType>();
-  const [mustGatherWatchList, setMustGatherWatchList] = React.useState<mgWatchListType>([]);
   const [errorNotified, setErrorNotified] = React.useState(false);
 
   const mustGathersQuery = useMustGathersQuery(
@@ -55,7 +54,7 @@ export const MustGatherContextProvider: React.FunctionComponent<IMustGatherConte
         return {
           customName: mg['custom-name'],
           status: mg.status,
-          type: mg.command.toLowerCase().indexOf('plan') ? 'plan' : 'vm',
+          type: mg.command.toLowerCase().includes('plan') ? 'plan' : 'vm',
         };
       });
       setMustGatherList(updatedMgList);
@@ -90,37 +89,34 @@ export const MustGatherContextProvider: React.FunctionComponent<IMustGatherConte
       })
       .find((mg) => mg['custom-name'] === name);
 
-  React.useEffect(() => {
-    const mgToMonitor = mustGatherList.map((mg) => ({
-      name: mg.customName,
-      // if it was inprogress when the ui started...
-      isGathering: mg.status === 'inprogress',
-    }));
-    // the /must-gather list query doesn't update with latest status when it changes back to "inprogress"
-    // after reaching an error state, the list query only seems to update when the mg changes to completed or error
-    // so this glue code is here to ensure we can represent the inprogress state when a user retries a must gather
-    setMustGatherWatchList(Array.from(new Set(mgToMonitor)));
-  }, [mustGatherList]);
+  const withNs = (resourceName: string, type: 'plan' | 'vm') => `${type}:${resourceName}`;
+  const withoutNs = (namespacedResourceName: string, type: 'plan' | 'vm') =>
+    namespacedResourceName.replace(`${type}:`, '');
 
   return (
     <MustGatherContext.Provider
       value={{
         mustGathersQuery,
-        mustGatherWatchList,
-        setMustGatherWatchList,
         mustGatherModalOpen,
         setMustGatherModalOpen,
         mustGatherList,
         activeMustGather,
         setActiveMustGather,
         latestAssociatedMustGather,
+        withNs,
+        withoutNs,
       }}
     >
       <>
         {children}
         {mustGatherList.map((mg, idx) => {
           return mg.customName && process.env.NODE_ENV !== 'production' ? (
-            <div data-mg-watcher={mg.customName} data-status={mg.status} key={idx}>
+            <div
+              data-mg-watcher={mg.customName}
+              data-type={mg.type}
+              data-status={mg.status}
+              key={idx}
+            >
               <MustGatherWatcher
                 listStatus={mg.status}
                 key={`${mg.customName}-${idx}`}


### PR DESCRIPTION
This PR prefixes the customName used for must gather service to help avoid a case where users may have the same name for a plan/vm must gather. Was able to get rid of the inprogress glue code we used before to determine if a must gather was being executed.

Should help close https://github.com/konveyor/forklift-ui/issues/779.



