### PR TITLE
Use meta file for must-gather-api config

### DIFF
--- a/deploy/server.js
+++ b/deploy/server.js
@@ -97,7 +97,7 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
   };
 
   let mustGatherApiProxyOptions = {
-    target: 'http://localhost:8080',
+    target: meta.mustGatherApi,
     changeOrigin: true,
     pathRewrite: {
       '^/must-gather-api/': '/',


### PR DESCRIPTION
This pull request replaces the hard-coded value with a field from the meta file.