### PR TITLE
feat(vms): use minimal payload for vms query

### DIFF
--- a/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -19,7 +19,7 @@ import { getMappingSourceById, getMappingTargetByRef } from '../helpers';
 import { CLUSTER_API_VERSION, META, ProviderType } from '@app/common/constants';
 import { nameAndNamespace } from '@app/queries/helpers';
 import { filterSourcesBySelectedVMs } from '@app/Plans/components/Wizard/helpers';
-import { IMappingResourcesResult } from '@app/queries';
+import { IDisk, IMappingResourcesResult, INicProfile } from '@app/queries';
 import { getObjectRef } from '@app/common/helpers';
 
 export const getBuilderItemsFromMappingItems = (
@@ -159,14 +159,18 @@ export const getBuilderItemsWithMissingSources = (
   selectedVMs: SourceVM[],
   mappingType: MappingType,
   sourceProviderType: ProviderType,
-  keepNonRequiredSources: boolean
+  keepNonRequiredSources: boolean,
+  nicProfiles: INicProfile[],
+  disks: IDisk[]
 ): IMappingBuilderItem[] => {
   const nonEmptyItems = builderItems.filter((item) => item.source && item.target);
   const requiredSources = filterSourcesBySelectedVMs(
     mappingResourceQueries.availableSources,
     selectedVMs,
     mappingType,
-    sourceProviderType
+    sourceProviderType,
+    nicProfiles,
+    disks
   );
   const itemsToKeep = keepNonRequiredSources
     ? nonEmptyItems

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -17,7 +17,6 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { ValidatedTextInput } from '@konveyor/lib-ui';
-
 import { OptionWithValue } from '@app/common/components/SimpleSelect';
 import {
   MappingType,
@@ -29,7 +28,13 @@ import {
   SourceInventoryProvider,
 } from '@app/queries/types';
 import { MappingBuilder, IMappingBuilderItem } from '@app/Mappings/components/MappingBuilder';
-import { filterSharedMappings, useMappingResourceQueries, useMappingsQuery } from '@app/queries';
+import {
+  filterSharedMappings,
+  useMappingResourceQueries,
+  useMappingsQuery,
+  useDisksQuery,
+  useNicProfilesQuery,
+} from '@app/queries';
 import { PlanWizardFormState } from './PlanWizard';
 import {
   getBuilderItemsFromMapping,
@@ -63,16 +68,27 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
 }: IMappingFormProps) => {
   usePausedPollingEffect();
 
+  const nicProfilesQuery = useNicProfilesQuery(sourceProvider);
+  const disksQuery = useDisksQuery(sourceProvider);
+
+  const rhvResourcesLoaded = nicProfilesQuery.isSuccess && disksQuery.isSuccess;
+
   const mappingResourceQueries = useMappingResourceQueries(
     sourceProvider,
     targetProvider,
     mappingType
   );
+
   const { availableSources, availableTargets } = mappingResourceQueries;
 
   const hasInitialized = React.useRef(false);
   React.useEffect(() => {
-    if (!hasInitialized.current && mappingResourceQueries.status === 'success') {
+    if (
+      !hasInitialized.current &&
+      mappingResourceQueries.status === 'success' &&
+      sourceProvider?.type === 'ovirt' &&
+      rhvResourcesLoaded
+    ) {
       hasInitialized.current = true;
       if (form.values.builderItems.length > 0) {
         form.fields.builderItems.setValue(
@@ -82,7 +98,9 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
             selectedVMs,
             mappingType,
             sourceProvider?.type || 'vsphere',
-            !!form.values.selectedExistingMapping
+            !!form.values.selectedExistingMapping,
+            nicProfilesQuery?.data || [],
+            disksQuery?.data || []
           )
         );
       }
@@ -95,6 +113,9 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
     mappingType,
     selectedVMs,
     sourceProvider,
+    rhvResourcesLoaded,
+    disksQuery?.data,
+    nicProfilesQuery?.data,
   ]);
 
   const mappingsQuery = useMappingsQuery(mappingType);
@@ -144,7 +165,9 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
         selectedVMs,
         mappingType,
         sourceProviderType,
-        true
+        true,
+        nicProfilesQuery?.data || [],
+        disksQuery?.data || []
       )
     );
     form.fields.isSaveNewMapping.setValue(false);

--- a/src/app/Plans/components/Wizard/MappingForm.tsx
+++ b/src/app/Plans/components/Wizard/MappingForm.tsx
@@ -86,8 +86,7 @@ const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
     if (
       !hasInitialized.current &&
       mappingResourceQueries.status === 'success' &&
-      sourceProvider?.type === 'ovirt' &&
-      rhvResourcesLoaded
+      (sourceProvider?.type !== 'ovirt' || rhvResourcesLoaded)
     ) {
       hasInitialized.current = true;
       if (form.values.builderItems.length > 0) {

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -367,10 +367,10 @@ export const filterSourcesBySelectedVMs = (
             return (vm as IVMwareVM).networks.map((network) => network.id);
           }
           if (sourceProviderType === 'ovirt') {
-            const networkIds = (vm as IRHVVM).nics.map((nic) => {
-              const nicProfile = nicProfiles.find((nicProfile) => nicProfile.id === nic.profile);
-              return nicProfile?.network;
-            });
+            const vmNicProfiles = (vm as IRHVVM).nics.map((nic) =>
+              nicProfiles.find((nicProfile) => nicProfile.id === nic.profile)
+            );
+            const networkIds = vmNicProfiles.map((nicProfile) => nicProfile?.network);
             return networkIds;
           }
         }

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -43,6 +43,10 @@ import {
   IndexedTree,
   IndexedSourceVMs,
   usePlansQuery,
+  useNicProfilesQuery,
+  useDisksQuery,
+  INicProfile,
+  IDisk,
 } from '@app/queries';
 import { UseQueryResult, QueryStatus } from 'react-query';
 import { StatusType } from '@konveyor/lib-ui';
@@ -351,9 +355,11 @@ export const filterSourcesBySelectedVMs = (
   availableSources: MappingSource[],
   selectedVMs: SourceVM[],
   mappingType: MappingType,
-  sourceProviderType: ProviderType
+  sourceProviderType: ProviderType,
+  nicProfiles: INicProfile[],
+  disks: IDisk[]
 ): MappingSource[] => {
-  const sourceIds = Array.from(
+  const sourceIds: (string | undefined)[] = Array.from(
     new Set(
       selectedVMs.flatMap((vm) => {
         if (mappingType === MappingType.Network) {
@@ -361,22 +367,33 @@ export const filterSourcesBySelectedVMs = (
             return (vm as IVMwareVM).networks.map((network) => network.id);
           }
           if (sourceProviderType === 'ovirt') {
-            return (vm as IRHVVM).nics.map((nic) => nic.profile.network);
+            const networkIds = (vm as IRHVVM).nics.map((nic) => {
+              const nicProfile = nicProfiles.find((nicProfile) => nicProfile.id === nic.profile);
+              return nicProfile?.network;
+            });
+            return networkIds;
           }
         }
+
         if (mappingType === MappingType.Storage) {
           if (sourceProviderType === 'vsphere') {
             return (vm as IVMwareVM).disks.map((disk) => disk.datastore.id);
           }
           if (sourceProviderType === 'ovirt') {
-            return (vm as IRHVVM).diskAttachments.map((da) => da.disk.storageDomain);
+            const vmDisks = (vm as IRHVVM).diskAttachments.map((da) =>
+              disks.find((disk) => disk.id === da.disk)
+            );
+            const storageDomainIds = vmDisks.map((disk) => disk?.storageDomain);
+            return storageDomainIds;
           }
         }
         return [];
       })
     )
   );
-  return availableSources.filter((source) => sourceIds.includes(source.id));
+
+  const filteredSources = availableSources.filter((source) => sourceIds.includes(source.id));
+  return filteredSources;
 };
 
 export const warmCriticalConcerns = ['Changed Block Tracking (CBT) not enabled'];
@@ -586,6 +603,8 @@ export const usePlanWizardPrefillEffect = (
 
   const defaultTreeType = InventoryTreeType.Cluster;
   const isNodeSelectable = useIsNodeSelectableCallback(defaultTreeType);
+  const nicProfilesQuery = useNicProfilesQuery(sourceProvider);
+  const disksQuery = useDisksQuery(sourceProvider);
 
   React.useEffect(() => {
     if (
@@ -643,7 +662,9 @@ export const usePlanWizardPrefillEffect = (
           selectedVMs,
           MappingType.Network,
           sourceProvider?.type || 'vsphere',
-          false
+          false,
+          nicProfilesQuery?.data || [],
+          disksQuery?.data || []
         )
       );
       forms.networkMapping.fields.isPrefilled.prefill(true);
@@ -660,7 +681,9 @@ export const usePlanWizardPrefillEffect = (
           selectedVMs,
           MappingType.Storage,
           sourceProvider?.type || 'vsphere',
-          false
+          false,
+          nicProfilesQuery?.data || [],
+          disksQuery?.data || []
         )
       );
       forms.storageMapping.fields.isPrefilled.prefill(true);
@@ -694,6 +717,8 @@ export const usePlanWizardPrefillEffect = (
     plansQuery,
     defaultTreeType,
     isNodeSelectable,
+    disksQuery?.data,
+    nicProfilesQuery?.data,
   ]);
 
   return {

--- a/src/app/queries/disks.ts
+++ b/src/app/queries/disks.ts
@@ -1,0 +1,29 @@
+import { usePollingContext } from '@app/common/context';
+import { UseQueryResult } from 'react-query';
+import { useAuthorizedFetch } from './fetchHelpers';
+import { useMockableQuery, getInventoryApiUrl } from './helpers';
+import { SourceInventoryProvider } from './types';
+import { MOCK_DISKS } from '@app/queries/mocks/disks.mock';
+
+export interface IDisk {
+  id: string;
+  name: string;
+  revision: number;
+  selfLink: string;
+  // properties available with ?detail=1
+  storageDomain: string;
+}
+
+export const useDisksQuery = (
+  provider: SourceInventoryProvider | null
+): UseQueryResult<IDisk[]> => {
+  return useMockableQuery<IDisk[], unknown>(
+    {
+      queryKey: ['disks', provider?.selfLink],
+      queryFn: useAuthorizedFetch(getInventoryApiUrl(`${provider?.selfLink || ''}/disks?detail=1`)),
+      enabled: !!provider && provider.type === 'ovirt',
+      refetchInterval: usePollingContext().refetchInterval,
+    },
+    MOCK_DISKS
+  );
+};

--- a/src/app/queries/index.ts
+++ b/src/app/queries/index.ts
@@ -12,3 +12,5 @@ export * from './secrets';
 export * from './namespaces';
 export * from './provisioners';
 export * from './mustGather';
+export * from './nicProfiles';
+export * from './disks';

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -27,8 +27,6 @@ import { MOCK_NETWORK_MAPPINGS, MOCK_STORAGE_MAPPINGS } from './mocks/mappings.m
 import { usePollingContext } from '@app/common/context';
 import { useAuthorizedK8sClient } from './fetchHelpers';
 import {
-  // useDiskProfilesQuery,
-  // useNicProfilesQuery,
   useOpenShiftNetworksQuery,
   useSourceNetworksQuery,
   useSourceStoragesQuery,

--- a/src/app/queries/mappings.ts
+++ b/src/app/queries/mappings.ts
@@ -19,15 +19,23 @@ import {
   useMockableMutation,
   useMockableQuery,
 } from './helpers';
-import { useOpenShiftNetworksQuery, useSourceNetworksQuery } from './networks';
-import { useSourceStoragesQuery, useStorageClassesQuery } from './storages';
+
 import { checkIfResourceExists, ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
 import { dnsLabelNameSchema, META } from '@app/common/constants';
 import { KubeClientError, IKubeList, IKubeResponse, IKubeStatus } from '@app/client/types';
 import { MOCK_NETWORK_MAPPINGS, MOCK_STORAGE_MAPPINGS } from './mocks/mappings.mock';
 import { usePollingContext } from '@app/common/context';
 import { useAuthorizedK8sClient } from './fetchHelpers';
-import { findProvidersByRefs, useInventoryProvidersQuery } from './providers';
+import {
+  // useDiskProfilesQuery,
+  // useNicProfilesQuery,
+  useOpenShiftNetworksQuery,
+  useSourceNetworksQuery,
+  useSourceStoragesQuery,
+  useStorageClassesQuery,
+  findProvidersByRefs,
+  useInventoryProvidersQuery,
+} from '@app/queries';
 
 export const getMappingResource = (
   mappingType: MappingType

--- a/src/app/queries/mocks/disks.mock.ts
+++ b/src/app/queries/mocks/disks.mock.ts
@@ -1,0 +1,69 @@
+import { IDisk } from '@app/queries';
+import { IRHVDiskAttachment } from '@app/queries/types';
+
+const disk1DaId = '10564686-1464-4baa-b65a-0dc2eb4645a8';
+const disk2DaId = '2d948af7-11be-4817-a9b9-36d7330586b1';
+const disk3DaId = '33f51a02-6d51-46e6-85d7-f4864a90ae10';
+const disk4DaId = '45b22939-31f9-4ff7-a290-104b59cfcf75';
+const disk5DaId = '52f84502-3bd1-4ac5-9107-fb7629cc2fdd';
+
+export const MOCK_DISK_ATTACHMENTS: IRHVDiskAttachment[] = [
+  {
+    disk: disk1DaId,
+    id: disk1DaId,
+  },
+  {
+    disk: disk2DaId,
+    id: disk2DaId,
+  },
+  {
+    disk: disk3DaId,
+    id: disk3DaId,
+  },
+  {
+    disk: disk4DaId,
+    id: disk4DaId,
+  },
+  {
+    disk: disk5DaId,
+    id: disk5DaId,
+  },
+];
+
+export const MOCK_DISKS: IDisk[] = [
+  {
+    id: disk1DaId,
+    name: 'MOCK_DISK_STORE-1',
+    revision: 1,
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/disks/${disk1DaId}`,
+    storageDomain: '1',
+  },
+  {
+    id: disk2DaId,
+    name: 'MOCK_DISK_STORE-2',
+    revision: 1,
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/disks/${disk2DaId}`,
+    storageDomain: '2',
+  },
+  {
+    id: disk3DaId,
+    name: 'MOCK_DISK_STORE-3',
+    revision: 1,
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/disks/${disk3DaId}`,
+    storageDomain: '3',
+  },
+  {
+    id: disk4DaId,
+    name: 'MOCK_DISK_STORE-4',
+    revision: 1,
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/disks/${disk4DaId}`,
+    storageDomain: '4',
+  },
+  {
+    id: disk5DaId,
+    name: 'MOCK_DISK_STORE-5',
+    revision: 1,
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/disks/${disk5DaId}`,
+    storageDomain: '5',
+  },
+];

--- a/src/app/queries/mocks/nicProfiles.mock.ts
+++ b/src/app/queries/mocks/nicProfiles.mock.ts
@@ -1,0 +1,74 @@
+import { INicProfile } from '@app/queries';
+import { IRHVNIC } from '@app/queries/types';
+
+const np1Id = '2ef3e5a3-974c-4a9c-9185-861cb049c966';
+const np2Id = '5d69b6cd-6610-44e2-a55f-425035a260da';
+const np3Id = '71c3bfa0-67da-4b5b-9ca8-41297f7cfba6';
+const np4Id = 'f9db7fae-7b41-4037-ba7b-fafd53783272';
+const np5Id = 'b63804a9-46f9-4015-ba6e-94784135430b';
+
+export const MOCK_NICS: IRHVNIC[] = [
+  {
+    id: '1794dcdd-565d-43c7-824b-ba0074855a82',
+    name: 'nic1',
+    profile: np1Id,
+  },
+  {
+    id: 'af66ab23-4edc-4f45-9f70-fb3541891d1a',
+    name: 'nic2',
+    profile: np2Id,
+  },
+  {
+    id: '755a532d-51b3-428f-a795-1b3d97544fed',
+    name: 'nic3',
+    profile: np3Id,
+  },
+  {
+    id: '0ee644d5-9976-470a-8524-e4048a97304c',
+    name: 'nic4',
+    profile: np4Id,
+  },
+  {
+    id: 'd3ed0a91-6029-4e55-bfad-0e07891d35b1',
+    name: 'nic5',
+    profile: np5Id,
+  },
+];
+
+export const MOCK_NIC_PROFILES: INicProfile[] = [
+  {
+    id: np1Id,
+    revision: 1,
+    name: 'TestNicProfile1',
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/nicprofiles/${np1Id}`,
+    network: '1',
+  },
+  {
+    id: np2Id,
+    revision: 1,
+    name: 'TestNicProfile2',
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/nicprofiles/${np2Id}`,
+    network: '2',
+  },
+  {
+    id: np3Id,
+    revision: 1,
+    name: 'TestNicProfile3',
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/nicprofiles/${np3Id}`,
+    network: '3',
+  },
+  {
+    id: np4Id,
+    revision: 1,
+    name: 'TestNicProfile4',
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/nicprofiles/${np4Id}`,
+    network: '4',
+  },
+  {
+    id: np5Id,
+    revision: 1,
+    name: 'TestNicProfile5',
+    selfLink: `providers/ovirt/acd5584c-fe75-453f-b970-b29a8c290254/nicprofiles/${np5Id}`,
+    network: '5',
+  },
+];

--- a/src/app/queries/mocks/vms.mock.ts
+++ b/src/app/queries/mocks/vms.mock.ts
@@ -1,5 +1,6 @@
 import { IVMwareVM, IRHVVM } from '../types/vms.types';
-
+import { MOCK_DISK_ATTACHMENTS } from '@app/queries/mocks/disks.mock';
+import { MOCK_NICS } from '@app/queries/mocks/nicProfiles.mock';
 export let MOCK_VMWARE_VMS: IVMwareVM[] = [];
 export let MOCK_RHV_VMS: IRHVVM[] = [];
 
@@ -144,25 +145,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/3dcaf3ec-6b51-4ca0-8345-6d61841731d7',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '1',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '1',
-          },
-        },
-        {
-          disk: {
-            storageDomain: '1',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[0]], // network 1
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[0], MOCK_DISK_ATTACHMENTS[0]], // storageDomain 1
       concerns: [],
     },
     {
@@ -172,20 +156,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/2a66a719-440c-4544-9da0-692d14338b12',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '2',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '1',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[1]], // network 2
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[0]], // storageDomain 1
       concerns: [],
     },
     {
@@ -195,20 +167,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/64333a40-ffbb-4c28-add7-5560bdf082fb',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '1',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[0]], // network 1
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[1]], // storageDomain 2
       concerns: [],
     },
     {
@@ -218,30 +178,12 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/6f9de857-ef39-43b7-8853-af982286dc59',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '3',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[2]], // network 3
       diskAttachments: [
-        {
-          disk: {
-            storageDomain: '1',
-          },
-        },
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-        {
-          disk: {
-            storageDomain: '1',
-          },
-        },
-      ],
+        MOCK_DISK_ATTACHMENTS[0],
+        MOCK_DISK_ATTACHMENTS[1],
+        MOCK_DISK_ATTACHMENTS[0],
+      ], // storageDomain 1 & 2
       concerns: [],
     },
     {
@@ -251,25 +193,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/bea5f184-972e-44e2-811a-2357829ab590',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '1',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[0]], // network 1
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[1], MOCK_DISK_ATTACHMENTS[1]], // storageDomain 2
       concerns: [],
     },
     {
@@ -279,20 +204,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/b3eb91d4-2c42-4dc6-98fb-fee94f1df30d',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '1',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '3',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[0]], // network 1
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[2]], // storageDomain 3
       concerns: [],
     },
     {
@@ -302,25 +215,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/be55c259-2415-448d-841e-f4b9d743242e',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '2',
-          },
-        },
-        {
-          profile: {
-            network: '4',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '4',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[1], MOCK_NICS[3]], // networks 2 & 4
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[3]], // storageDomain 4
       concerns: [],
     },
     {
@@ -330,20 +226,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/54426696-297d-4ae4-a2a3-c7bc43ee5ccf',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '3',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '3',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[2]], // network 3
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[2]], // storageDomain 3
       concerns: [],
     },
     {
@@ -353,20 +237,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/84d2359c-45d3-401f-a942-81020d6a58bd',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '3',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[2]], // network 3
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[1]], // storageDomain 2
       concerns: [],
     },
     {
@@ -376,20 +248,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/25284d90-3684-4643-8f60-c72cc8ccfbff',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '3',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[2]], // network 3
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[1]], // storageDomain 2
       concerns: [],
     },
     {
@@ -399,20 +259,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/aa6eca14-b91d-447f-8050-4a7127d33244',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '1',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[0]], // network 1
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[1]], // storageDomain 2
       concerns: [],
     },
     {
@@ -422,20 +270,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/cdb41d1c-481a-4d24-a239-fe77813608cd',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '3',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[2]], // network 3
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[1]], // storageDomain 2
       concerns: [],
     },
     {
@@ -445,30 +281,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/fe91d819-94e4-4e77-8d8d-399484601937',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '4',
-          },
-        },
-        {
-          profile: {
-            network: '1',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '5',
-          },
-        },
-        {
-          disk: {
-            storageDomain: '5',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[3], MOCK_NICS[0]], // networks 4 & 1
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[4], MOCK_DISK_ATTACHMENTS[4]], // storageDomain 5
       concerns: [],
     },
     {
@@ -478,20 +292,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/18d82ffd-8c1a-407a-a2c4-119b6d81375a',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '1',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '3',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[0]], // network 1
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[2]], // storageDomain 3
       concerns: [],
     },
     {
@@ -501,20 +303,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/f9ee4c85-e880-48eb-86d4-639bf2956049',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '3',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[2]], // network 3
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[1]], // storageDomain 2
       concerns: [],
     },
     {
@@ -524,20 +314,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       selfLink:
         'providers/ovirt/85292227-48fc-4571-a2ea-ba1f04634bc9/vms/35c259ac-603a-458e-81f6-8d9ed3a8e1ee',
       revisionValidated: 0,
-      nics: [
-        {
-          profile: {
-            network: '1',
-          },
-        },
-      ],
-      diskAttachments: [
-        {
-          disk: {
-            storageDomain: '2',
-          },
-        },
-      ],
+      nics: [MOCK_NICS[0]], // network 1
+      diskAttachments: [MOCK_DISK_ATTACHMENTS[1]], // storageDomain 2
       concerns: [],
     },
   ];

--- a/src/app/queries/nicProfiles.ts
+++ b/src/app/queries/nicProfiles.ts
@@ -1,0 +1,31 @@
+import { usePollingContext } from '@app/common/context';
+import { UseQueryResult } from 'react-query';
+import { useAuthorizedFetch } from './fetchHelpers';
+import { useMockableQuery, getInventoryApiUrl } from './helpers';
+import { SourceInventoryProvider } from './types';
+import { MOCK_NIC_PROFILES } from '@app/queries/mocks/nicProfiles.mock';
+
+export interface INicProfile {
+  id: string;
+  name: string;
+  revision: number;
+  selfLink: string;
+  // properties available with ?detail=1
+  network: string; // the network id
+}
+
+export const useNicProfilesQuery = (
+  provider: SourceInventoryProvider | null
+): UseQueryResult<INicProfile[]> => {
+  return useMockableQuery<INicProfile[], unknown>(
+    {
+      queryKey: ['nicProfiles', provider?.selfLink],
+      queryFn: useAuthorizedFetch(
+        getInventoryApiUrl(`${provider?.selfLink || ''}/nicprofiles?detail=1`)
+      ),
+      enabled: !!provider && provider.type === 'ovirt',
+      refetchInterval: usePollingContext().refetchInterval,
+    },
+    MOCK_NIC_PROFILES
+  );
+};

--- a/src/app/queries/types/vms.types.ts
+++ b/src/app/queries/types/vms.types.ts
@@ -26,15 +26,22 @@ export interface IVMwareVM extends IBaseSourceVM {
 }
 
 export interface IRHVNIC {
-  profile: {
-    network: string;
-  };
+  profile: string;
+  name: string;
+  id: string;
+  // plugged: boolean;
+  // ipAddress: {
+  //   address: string;
+  //   version: string;
+  // }[];
+  // interface: string;
 }
 
 export interface IRHVDiskAttachment {
-  disk: {
-    storageDomain: string;
-  };
+  disk: string;
+  id: string;
+  // interface: string;
+  // scsiReservation: boolean;
 }
 
 export interface IRHVVM extends IBaseSourceVM {

--- a/src/app/queries/types/vms.types.ts
+++ b/src/app/queries/types/vms.types.ts
@@ -29,19 +29,11 @@ export interface IRHVNIC {
   profile: string;
   name: string;
   id: string;
-  // plugged: boolean;
-  // ipAddress: {
-  //   address: string;
-  //   version: string;
-  // }[];
-  // interface: string;
 }
 
 export interface IRHVDiskAttachment {
   disk: string;
   id: string;
-  // interface: string;
-  // scsiReservation: boolean;
 }
 
 export interface IRHVVM extends IBaseSourceVM {


### PR DESCRIPTION
This PR makes corresponding changes in the UI to support the slimmed down api payloads work (https://github.com/konveyor/forklift-controller/pull/343).

The vms payloads are cut in half and the nic/disk data is no longer duplicated across vm objects and instead fetched in similar manner to other service requests we make. Had to re-map the references to disks and nics, seems to be working but that's definitely the main thing to verify in review. Thx for all the help @mturley!

Related to [MTV-139](https://issues.redhat.com/browse/MTV-139)