### PR TITLE
Add a confirmation modal when starting or restarting a plan or starting cutover + Fix error reporting on confirm modal when archiving a plan.

### DIFF
--- a/src/app/Plans/PlansPage.tsx
+++ b/src/app/Plans/PlansPage.tsx
@@ -29,15 +29,12 @@ const PlansPage: React.FunctionComponent = () => {
   const plansQuery = usePlansQuery();
   const migrationsQuery = useMigrationsQuery();
 
-  const errorContainerRef = React.useRef<HTMLDivElement>(null);
-
   return (
     <>
       <PageSection variant="light">
         <Title headingLevel="h1">Migration plans</Title>
       </PageSection>
       <PageSection>
-        <div ref={errorContainerRef} />
         <ResolvedQueries
           results={[
             sufficientProvidersQuery.result,
@@ -68,10 +65,7 @@ const PlansPage: React.FunctionComponent = () => {
                   <CreatePlanButton />
                 </EmptyState>
               ) : (
-                <PlansTable
-                  plans={plansQuery.data?.items || []}
-                  errorContainerRef={errorContainerRef}
-                />
+                <PlansTable plans={plansQuery.data?.items || []} />
               )}
             </CardBody>
           </Card>

--- a/src/app/Plans/components/MigrateOrCutoverButton.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverButton.tsx
@@ -3,7 +3,6 @@ import { useHistory } from 'react-router-dom';
 import { Button, Spinner } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useCreateMigrationMutation, useSetCutoverMutation } from '@app/queries';
-import { IMigration } from '@app/queries/types/migrations.types';
 import { IPlan } from '@app/queries/types';
 import { PlanActionButtonType } from './PlansTable';
 import ConfirmModal from '@app/common/components/ConfirmModal';
@@ -20,11 +19,12 @@ const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonPro
   isBeingStarted,
 }: IMigrateOrCutoverButtonProps) => {
   const history = useHistory();
-  const onMigrationStarted = (migration: IMigration) => {
-    history.push(`/plans/${migration.spec.plan.name}`);
+  const onMigrationStarted = () => {
+    toggleConfirmModal();
+    history.push(`/plans/${plan.metadata.name}`);
   };
   const createMigrationMutation = useCreateMigrationMutation(onMigrationStarted);
-  const setCutoverMutation = useSetCutoverMutation();
+  const setCutoverMutation = useSetCutoverMutation(onMigrationStarted);
 
   const [isConfirmModalOpen, toggleConfirmModal] = React.useReducer((isOpen) => !isOpen, false);
 
@@ -36,14 +36,15 @@ const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonPro
     }
   };
 
-  if (isBeingStarted || createMigrationMutation.isLoading || setCutoverMutation.isLoading) {
-    return <Spinner size="md" className={spacing.mxLg} />;
-  }
   return (
     <>
-      <Button variant="secondary" onClick={toggleConfirmModal}>
-        {buttonType}
-      </Button>
+      {isBeingStarted ? (
+        <Spinner size="md" className={spacing.mxLg} />
+      ) : (
+        <Button variant="secondary" onClick={toggleConfirmModal}>
+          {buttonType}
+        </Button>
+      )}
       <ConfirmModal
         isOpen={isConfirmModalOpen}
         toggleOpen={toggleConfirmModal}

--- a/src/app/Plans/components/MigrateOrCutoverButton.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverButton.tsx
@@ -5,7 +5,7 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useCreateMigrationMutation, useSetCutoverMutation } from '@app/queries';
 import { IPlan } from '@app/queries/types';
 import { PlanActionButtonType } from './PlansTable';
-import ConfirmModal from '@app/common/components/ConfirmModal';
+import MigrateOrCutoverConfirmModal from './MigrateOrCutoverConfirmModal';
 
 interface IMigrateOrCutoverButtonProps {
   plan: IPlan;
@@ -45,20 +45,13 @@ const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonPro
           {buttonType}
         </Button>
       )}
-      <ConfirmModal
+      <MigrateOrCutoverConfirmModal
         isOpen={isConfirmModalOpen}
         toggleOpen={toggleConfirmModal}
         mutateFn={doMigrateOrCutover}
         mutateResult={buttonType === 'Start' ? createMigrationMutation : setCutoverMutation}
-        title={buttonType === 'Start' ? 'Start migration?' : 'Start cutover?'}
-        body={
-          <>
-            Start the {buttonType === 'Start' ? 'migration' : 'cutover'} for plan &quot;
-            {plan.metadata.name}&quot;?
-          </>
-        }
-        confirmButtonText={buttonType}
-        errorText={`Could not ${buttonType === 'Start' ? 'start migration' : 'set cutover time'}`}
+        plan={plan}
+        action={buttonType === 'Start' ? 'start' : 'cutover'}
       />
     </>
   );

--- a/src/app/Plans/components/MigrateOrCutoverButton.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverButton.tsx
@@ -57,7 +57,7 @@ const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonPro
             {plan.metadata.name}&quot;?
           </>
         }
-        confirmButtonText="Start"
+        confirmButtonText={buttonType}
         errorText={`Could not ${buttonType === 'Start' ? 'start migration' : 'set cutover time'}`}
       />
     </>

--- a/src/app/Plans/components/MigrateOrCutoverConfirmModal.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverConfirmModal.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import ConfirmModal, { IConfirmModalProps } from '@app/common/components/ConfirmModal';
+import { IPlan } from '@app/queries/types';
+import { TextContent, Text } from '@patternfly/react-core';
+
+interface IMigrateOrCutoverConfirmModalProps
+  extends Pick<IConfirmModalProps, 'isOpen' | 'toggleOpen' | 'mutateFn' | 'mutateResult'> {
+  plan: IPlan;
+  action: 'start' | 'restart' | 'cutover';
+}
+
+const MigrateOrCutoverConfirmModal: React.FunctionComponent<IMigrateOrCutoverConfirmModalProps> = ({
+  isOpen,
+  toggleOpen,
+  mutateFn,
+  mutateResult,
+  plan,
+  action,
+}: IMigrateOrCutoverConfirmModalProps) => {
+  const verb = action === 'restart' ? 'Restart' : 'Start';
+  const noun =
+    action === 'cutover' ? 'cutover' : plan.spec.warm ? 'incremental copies' : 'migration';
+  return (
+    <ConfirmModal
+      isOpen={isOpen}
+      toggleOpen={toggleOpen}
+      mutateFn={mutateFn}
+      mutateResult={mutateResult}
+      title={`${verb} ${noun}?`}
+      body={
+        <TextContent>
+          <Text>
+            {verb} the {noun} for plan &quot;{plan.metadata.name}&quot;?
+          </Text>
+          <Text>
+            {action === 'cutover' || !plan.spec.warm
+              ? 'VMs included in the migration plan will be shut down.'
+              : 'VMs included in the migration plan will remain powered on until cutover is started.'}{' '}
+            See the product documentation for more information.
+          </Text>
+        </TextContent>
+      }
+      confirmButtonText={verb}
+      errorText={`Could not ${verb} ${noun}`}
+    />
+  );
+};
+
+export default MigrateOrCutoverConfirmModal;

--- a/src/app/Plans/components/MigrateOrCutoverConfirmModal.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverConfirmModal.tsx
@@ -40,7 +40,7 @@ const MigrateOrCutoverConfirmModal: React.FunctionComponent<IMigrateOrCutoverCon
           </Text>
         </TextContent>
       }
-      confirmButtonText={verb}
+      confirmButtonText={action === 'cutover' ? 'Cutover' : verb}
       errorText={`Could not ${verb.toLowerCase()} ${noun}`}
     />
   );

--- a/src/app/Plans/components/MigrateOrCutoverConfirmModal.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverConfirmModal.tsx
@@ -35,7 +35,7 @@ const MigrateOrCutoverConfirmModal: React.FunctionComponent<IMigrateOrCutoverCon
           <Text>
             {action === 'cutover' || !plan.spec.warm
               ? 'VMs included in the migration plan will be shut down.'
-              : 'VMs included in the migration plan will remain powered on until cutover is started.'}{' '}
+              : 'VM data will be copied incrementally until cutover migration. To start cutover, click the button on the Plans page.'}{' '}
             See the product documentation for more information.
           </Text>
         </TextContent>

--- a/src/app/Plans/components/MigrateOrCutoverConfirmModal.tsx
+++ b/src/app/Plans/components/MigrateOrCutoverConfirmModal.tsx
@@ -41,7 +41,7 @@ const MigrateOrCutoverConfirmModal: React.FunctionComponent<IMigrateOrCutoverCon
         </TextContent>
       }
       confirmButtonText={verb}
-      errorText={`Could not ${verb} ${noun}`}
+      errorText={`Could not ${verb.toLowerCase()} ${noun}`}
     />
   );
 };

--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -28,6 +28,7 @@ import { areAssociatedProvidersReady } from '@app/queries/helpers';
 import PlanDetailsModal from './PlanDetailsModal';
 import { IMigration } from '@app/queries/types/migrations.types';
 import { PlanState, archivedPlanLabel } from '@app/common/constants';
+import MigrateOrCutoverConfirmModal from './MigrateOrCutoverConfirmModal';
 
 interface IPlansActionDropdownProps {
   plan: IPlan;
@@ -209,15 +210,13 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
         body={`All data for migration plan "${plan.metadata.name}" will be lost.`}
         errorText="Could not delete migration plan"
       />
-      <ConfirmModal
+      <MigrateOrCutoverConfirmModal
         isOpen={isRestartModalOpen}
         toggleOpen={toggleRestartModal}
         mutateFn={() => createMigrationMutation.mutate(plan)}
         mutateResult={createMigrationMutation}
-        title="Restart migration?"
-        body={<>Restart the migration for plan &quot;{plan.metadata.name}&quot;?</>}
-        confirmButtonText="Restart"
-        errorText="Could not restart migration"
+        plan={plan}
+        action="restart"
       />
       <Modal
         variant="medium"

--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -232,37 +232,28 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
       >
         <PlanDetailsModal plan={plan} />
       </Modal>
-      <Modal
+      <ConfirmModal
         variant="medium"
-        title="Archive plan"
         isOpen={isArchivePlanModalOpen}
-        onClose={toggleArchivePlanModal}
-        actions={[
-          <Button
-            key="archive"
-            variant="primary"
-            onClick={() => {
-              archivePlanMutation.mutate(plan);
-            }}
-          >
-            Archive
-          </Button>,
-          <Button key="cancel-archive" variant="secondary" onClick={toggleArchivePlanModal}>
-            Cancel
-          </Button>,
-        ]}
-      >
-        <TextContent>
-          <Text>Archiving a plan means:</Text>
-          <List>
-            <ListItem>All migration history and metadata are cleaned up and discarded.</ListItem>
-            <ListItem>Migration logs are deleted.</ListItem>
-            <ListItem>
-              The plan can no longer be edited or restarted, but it can be viewed.
-            </ListItem>
-          </List>
-        </TextContent>
-      </Modal>
+        toggleOpen={toggleArchivePlanModal}
+        mutateFn={() => archivePlanMutation.mutate(plan)}
+        mutateResult={archivePlanMutation}
+        title="Archive plan?"
+        body={
+          <TextContent>
+            <Text>Archiving a plan means:</Text>
+            <List>
+              <ListItem>All migration history and metadata are cleaned up and discarded.</ListItem>
+              <ListItem>Migration logs are deleted.</ListItem>
+              <ListItem>
+                The plan can no longer be edited or restarted, but it can be viewed.
+              </ListItem>
+            </List>
+          </TextContent>
+        }
+        confirmButtonText="Archive"
+        errorText="Could not archive plan"
+      />
     </>
   );
 };

--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -48,11 +48,13 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
 
   const history = useHistory();
   const onMigrationStarted = (migration: IMigration) => {
+    toggleRestartModal();
     history.push(`/plans/${migration.spec.plan.name}`);
   };
   const createMigrationMutation = useCreateMigrationMutation(onMigrationStarted);
   const [kebabIsOpen, setKebabIsOpen] = React.useState(false);
   const [isDeleteModalOpen, toggleDeleteModal] = React.useReducer((isOpen) => !isOpen, false);
+  const [isRestartModalOpen, toggleRestartModal] = React.useReducer((isOpen) => !isOpen, false);
   const [isDetailsModalOpen, toggleDetailsModal] = React.useReducer((isOpen) => !isOpen, false);
   const [isArchivePlanModalOpen, toggleArchivePlanModal] = React.useReducer(
     (isOpen) => !isOpen,
@@ -185,7 +187,8 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
               <DropdownItem
                 isDisabled={isPlanGathering}
                 onClick={() => {
-                  createMigrationMutation.mutate(plan);
+                  setKebabIsOpen(false);
+                  toggleRestartModal();
                 }}
               >
                 Restart
@@ -205,6 +208,16 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
         confirmButtonText="Delete"
         body={`All data for migration plan "${plan.metadata.name}" will be lost.`}
         errorText="Could not delete migration plan"
+      />
+      <ConfirmModal
+        isOpen={isRestartModalOpen}
+        toggleOpen={toggleRestartModal}
+        mutateFn={() => createMigrationMutation.mutate(plan)}
+        mutateResult={createMigrationMutation}
+        title="Restart migration?"
+        body={<>Restart the migration for plan &quot;{plan.metadata.name}&quot;?</>}
+        confirmButtonText="Restart"
+        errorText="Could not restart migration"
       />
       <Modal
         variant="medium"

--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -64,13 +64,9 @@ import { MustGatherBtn } from '@app/common/components/MustGatherBtn';
 export type PlanActionButtonType = 'Start' | 'Cutover' | 'MustGather';
 interface IPlansTableProps {
   plans: IPlan[];
-  errorContainerRef: React.RefObject<HTMLDivElement>;
 }
 
-const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
-  plans,
-  errorContainerRef,
-}: IPlansTableProps) => {
+const PlansTable: React.FunctionComponent<IPlansTableProps> = ({ plans }: IPlansTableProps) => {
   const [showArchivedPlans, toggleShowArchivedPlans] = React.useReducer((show) => !show, false);
   const providersQuery = useInventoryProvidersQuery();
   const migrationsQuery = useMigrationsQuery();
@@ -292,7 +288,6 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
                     plan={plan}
                     buttonType={buttonType}
                     isBeingStarted={isBeingStarted}
-                    errorContainerRef={errorContainerRef}
                   />
                 )}
               </FlexItem>

--- a/src/app/common/components/ConfirmModal.tsx
+++ b/src/app/common/components/ConfirmModal.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { Modal, Stack, Flex, Button } from '@patternfly/react-core';
+import { Modal, Stack, Flex, Button, ModalProps } from '@patternfly/react-core';
 import { QuerySpinnerMode, ResolvedQuery } from './ResolvedQuery';
 import { UnknownMutationResult } from '../types';
 
 // TODO lib-ui candidate
 
 interface IConfirmModalProps {
+  variant?: ModalProps['variant'];
   isOpen: boolean;
   toggleOpen: () => void;
   mutateFn: () => void;
@@ -18,6 +19,7 @@ interface IConfirmModalProps {
 }
 
 const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
+  variant = 'small',
   isOpen,
   toggleOpen,
   mutateFn,
@@ -35,7 +37,7 @@ const ConfirmModal: React.FunctionComponent<IConfirmModalProps> = ({
 
   return isOpen ? (
     <Modal
-      variant="small"
+      variant={variant}
       title={title}
       isOpen
       onClose={toggleOpen}

--- a/src/app/common/components/ConfirmModal.tsx
+++ b/src/app/common/components/ConfirmModal.tsx
@@ -5,7 +5,7 @@ import { UnknownMutationResult } from '../types';
 
 // TODO lib-ui candidate
 
-interface IConfirmModalProps {
+export interface IConfirmModalProps {
   variant?: ModalProps['variant'];
   isOpen: boolean;
   toggleOpen: () => void;


### PR DESCRIPTION
Closes #624.

This PR:
* Adds a confirmation modal when clicking the Start or Cutover buttons on a plan, or the Restart kebab action.
* Removes the weird `errorContainerRef` we had to use to put errors starting a plan above the plans table, now that they live in the confirm modal.
* Refactors the confirm modal when archiving a plan to use our common `ConfirmModal` so it will report errors in the POST request properly. Note that this only applies to the POST itself, a backend failure to complete the archive process will instead result in a status condition on the plan.

## Confirm modals of various flavors:

Starting a cold plan:
![Screen Shot 2021-09-30 at 3 51 30 PM](https://user-images.githubusercontent.com/811963/135522625-3ef14964-7717-4c34-bf85-e8a3a204103f.png)

Starting a warm plan:
![Screen Shot 2021-10-04 at 3 52 46 PM](https://user-images.githubusercontent.com/811963/135915518-98bb37d9-3bf2-4942-96bb-59d3265fc565.png)

Starting cutover on a warm plan:
![Screen Shot 2021-09-30 at 4 09 25 PM](https://user-images.githubusercontent.com/811963/135523490-5760586a-93ed-4faf-89fe-7ec4bac5ed0e.png)

Restarting a cold plan:
![Screen Shot 2021-09-30 at 3 53 25 PM](https://user-images.githubusercontent.com/811963/135522717-a67201e5-bee7-4a00-973d-e93c140f253c.png)

Restarting a warm plan:
![Screen Shot 2021-09-30 at 3 54 56 PM](https://user-images.githubusercontent.com/811963/135522743-155560e8-540a-4886-bf9c-703440297f4f.png)

## Error reporting in the modal:

![Screen Shot 2021-09-30 at 4 05 34 PM](https://user-images.githubusercontent.com/811963/135523044-e0c14e66-4829-4b6f-9318-f97cdac04ec8.png)


![Screen Shot 2021-09-30 at 4 06 06 PM](https://user-images.githubusercontent.com/811963/135523248-75aca215-7829-4157-81f3-7a8dee74c128.png)


