### PR TITLE
fix(must-gather): ensure MG command uses plan/vm name, ensure access_token exist

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -23,7 +23,6 @@ import './AppLayout.css';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import HelpDropdown from './HelpDropdown';
 import { Notifications } from '@app/common/components/Notifications';
-import { MustGatherModal } from '@app/common/components/MustGatherModal';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -150,7 +149,6 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
     >
       <>
         {children}
-        <MustGatherModal />
         <Notifications />
       </>
     </Page>

--- a/src/app/Plans/PlansPage.tsx
+++ b/src/app/Plans/PlansPage.tsx
@@ -10,7 +10,8 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-
+import { MustGatherModal } from '@app/common/components/MustGatherModal';
+// import { MustGatherContextProvider } from '@app/common/context';
 import {
   useHasSufficientProvidersQuery,
   usePlansQuery,
@@ -77,6 +78,7 @@ const PlansPage: React.FunctionComponent = () => {
           </Card>
         </ResolvedQueries>
       </PageSection>
+      <MustGatherModal />
     </>
   );
 };

--- a/src/app/Plans/PlansPage.tsx
+++ b/src/app/Plans/PlansPage.tsx
@@ -11,7 +11,7 @@ import {
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { MustGatherModal } from '@app/common/components/MustGatherModal';
-// import { MustGatherContextProvider } from '@app/common/context';
+
 import {
   useHasSufficientProvidersQuery,
   usePlansQuery,

--- a/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/src/app/Plans/components/VMMigrationDetails.tsx
@@ -35,6 +35,7 @@ import { useSelectionState } from '@konveyor/lib-ui';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignment';
 
+import { MustGatherModal } from '@app/common/components/MustGatherModal';
 import { useSortState, usePaginationState, useFilterState } from '@app/common/hooks';
 import VMStatusPipelineTable from './VMStatusPipelineTable';
 import PipelineSummary, { getPipelineSummaryTitle } from '@app/common/components/PipelineSummary';
@@ -399,6 +400,7 @@ const VMMigrationDetails: React.FunctionComponent = () => {
           </Card>
         </ResolvedQueries>
       </PageSection>
+      <MustGatherModal />
       <ConfirmModal
         isOpen={isCancelModalOpen}
         toggleOpen={toggleCancelModal}

--- a/src/app/common/components/MustGatherModal.tsx
+++ b/src/app/common/components/MustGatherModal.tsx
@@ -45,8 +45,8 @@ export const MustGatherModal: React.FunctionComponent = () => {
       'custom-name': namespacedName,
       command:
         type === 'plan'
-          ? `PLAN=${namespacedName} /usr/bin/targeted`
-          : `VM=${namespacedName} /usr/bin/targeted`,
+          ? `PLAN=${displayName} /usr/bin/targeted`
+          : `VM=${displayName} /usr/bin/targeted`,
     });
     setMustGatherModalOpen(false);
   };

--- a/src/app/queries/fetchHelpers.ts
+++ b/src/app/queries/fetchHelpers.ts
@@ -25,12 +25,14 @@ export const authorizedFetch = async <TResponse, TData = unknown>(
   data?: TData
 ): Promise<TResponse> => {
   const { history, checkExpiry } = fetchContext;
+  const headersObj = {
+    Authorization: `Bearer ${fetchContext.currentUser.access_token}`,
+    ...extraHeaders,
+  };
+
   try {
     const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${fetchContext.currentUser.access_token}`,
-        ...extraHeaders,
-      },
+      headers: headersObj,
       method,
       ...(data &&
         method !== 'get' && {

--- a/src/app/queries/mustGather.ts
+++ b/src/app/queries/mustGather.ts
@@ -9,7 +9,7 @@ import { MOCK_MUST_GATHERS } from '@app/queries/mocks/mustGather.mock';
 export const useMustGatherMutation = (
   url: string,
   onSuccess?: (data: IMustGatherResponse) => void,
-  onError?: () => void
+  onError?: (error: unknown) => void
 ) => {
   const queryClient = useQueryClient();
   const fetchContext = useFetchContext();
@@ -40,8 +40,8 @@ export const useMustGatherMutation = (
         queryClient.invalidateQueries(['must-gather-list']);
         onSuccess && onSuccess(data);
       },
-      onError: () => {
-        onError && onError();
+      onError: (error) => {
+        onError && onError(error);
       },
     }
   );
@@ -51,17 +51,18 @@ export const useMustGatherMutation = (
 // get all must gathers
 export const useMustGathersQuery = (
   url: string,
+  isReady: boolean,
   onSuccess?: (data: IMustGatherResponse[]) => void,
-  onError?: () => void
+  onError?: (error: Response) => void
 ) => {
   const result = useMockableQuery<IMustGatherResponse[], Response>(
     {
       queryKey: ['must-gather-list'],
       queryFn: useAuthorizedFetch(getMustGatherApiUrl(url)),
-      enabled: true,
+      enabled: isReady,
       refetchInterval: usePollingContext().refetchInterval,
-      onError: () => {
-        onError && onError();
+      onError: (error) => {
+        onError && onError(error);
       },
       onSuccess: (data) => {
         onSuccess && onSuccess(data);


### PR DESCRIPTION
This PR makes two notable changes.

The first change is that we add a check to ensure the relevant access token exists before attempting to hit the must gather service endpoint.

The second change is to make sure that the `command` property for must gather references the actual plan/vm name and not one with any namespace prefix.

Steps toward closing https://github.com/konveyor/forklift-ui/issues/782