### PR TITLE
Bug 2011785: Show Validating instead of Unknown for the first 30 seconds of missing status on a plan CR

### DIFF
--- a/src/app/Plans/components/PlansTable.tsx
+++ b/src/app/Plans/components/PlansTable.tsx
@@ -31,7 +31,7 @@ import { ArchiveIcon } from '@patternfly/react-icons';
 import alignment from '@patternfly/react-styles/css/utilities/Alignment/alignment';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { Link } from 'react-router-dom';
-import { useSelectionState } from '@konveyor/lib-ui';
+import { StatusIcon, useSelectionState } from '@konveyor/lib-ui';
 
 import { archivedPlanLabel } from '@app/common/constants';
 import { PlanActionsDropdown } from './PlanActionsDropdown';
@@ -254,6 +254,8 @@ const PlansTable: React.FunctionComponent<IPlansTableProps> = ({ plans }: IPlans
               <PlanStatusNavLink plan={plan}>
                 Running - preparing for incremental data copies
               </PlanStatusNavLink>
+            ) : planState === 'Unknown' ? (
+              <StatusIcon status="Warning" label="Unknown" />
             ) : planState === 'NotStarted-Ready' || planState === 'NotStarted-NotReady' ? (
               <StatusCondition status={plan.status} />
             ) : planState === 'Copying' || planState === 'Copying-CutoverScheduled' ? (

--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -134,6 +134,15 @@ export const getPlanState = (
   migrationQuery: UseQueryResult<IKubeList<IMigration>>
 ): PlanState | null => {
   if (!plan) return null;
+  // Give the controller 30 seconds to fill in status data before we consider the status to be unknown
+  if (
+    !plan.status &&
+    plan.metadata.creationTimestamp &&
+    new Date(plan.metadata.creationTimestamp).getTime() < new Date().getTime() - 30000
+  ) {
+    return 'Unknown';
+  }
+
   const isWarm = plan.spec.warm;
   const conditions = plan.status?.conditions || [];
 

--- a/src/app/common/components/StatusCondition.tsx
+++ b/src/app/common/components/StatusCondition.tsx
@@ -11,69 +11,66 @@ interface IStatusConditionProps {
 }
 
 const StatusCondition: React.FunctionComponent<IStatusConditionProps> = ({
-  status = {},
+  status,
   unknownFallback = null,
 }: IStatusConditionProps) => {
+  if (!status) return <StatusIcon status="Loading" label="Validating" />;
+
   const getStatusType = (severity: string): StatusType => {
-    if (status) {
-      if (severity === 'Ready' || severity === StatusCategoryType.Required) {
-        return 'Ok';
-      }
-      if (severity === StatusCategoryType.Advisory) {
-        return 'Info';
-      }
-      if (severity === 'Pending') {
-        return 'Loading';
-      }
-      if (severity === StatusCategoryType.Critical || severity === StatusCategoryType.Error) {
-        return 'Error';
-      }
+    if (severity === 'Ready' || severity === StatusCategoryType.Required) {
+      return 'Ok';
+    }
+    if (severity === StatusCategoryType.Advisory) {
+      return 'Info';
+    }
+    if (severity === 'Pending') {
+      return 'Loading';
+    }
+    if (severity === StatusCategoryType.Critical || severity === StatusCategoryType.Error) {
+      return 'Error';
     }
     return 'Warning';
   };
 
-  if (status) {
-    const conditions = status?.conditions || [];
-    const mostSeriousCondition = getMostSeriousCondition(conditions);
+  const conditions = status?.conditions || [];
+  const mostSeriousCondition = getMostSeriousCondition(conditions);
 
-    if (mostSeriousCondition === 'Unknown' && unknownFallback !== null) {
-      return <>{unknownFallback}</>;
-    }
-
-    let label = mostSeriousCondition;
-    if (mostSeriousCondition === StatusCategoryType.Required) {
-      label = 'Not ready';
-    }
-
-    const icon = <StatusIcon status={getStatusType(mostSeriousCondition)} label={label} />;
-
-    if (conditions.length === 0) return icon;
-
-    return (
-      <Popover
-        hasAutoWidth
-        bodyContent={
-          <>
-            {conditions.map((condition) => {
-              const severity = getMostSeriousCondition([condition]);
-              return (
-                <StatusIcon
-                  key={condition.message}
-                  status={getStatusType(severity)}
-                  label={condition.message}
-                />
-              );
-            })}
-          </>
-        }
-      >
-        <Button variant="link" isInline>
-          {icon}
-        </Button>
-      </Popover>
-    );
+  if (mostSeriousCondition === 'Unknown' && unknownFallback !== null) {
+    return <>{unknownFallback}</>;
   }
-  return null;
+
+  let label = mostSeriousCondition;
+  if (mostSeriousCondition === StatusCategoryType.Required) {
+    label = 'Not ready';
+  }
+
+  const icon = <StatusIcon status={getStatusType(mostSeriousCondition)} label={label} />;
+
+  if (conditions.length === 0) return icon;
+
+  return (
+    <Popover
+      hasAutoWidth
+      bodyContent={
+        <>
+          {conditions.map((condition) => {
+            const severity = getMostSeriousCondition([condition]);
+            return (
+              <StatusIcon
+                key={condition.message}
+                status={getStatusType(severity)}
+                label={condition.message}
+              />
+            );
+          })}
+        </>
+      }
+    >
+      <Button variant="link" isInline>
+        {icon}
+      </Button>
+    </Popover>
+  );
 };
 
 export default StatusCondition;

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -59,7 +59,8 @@ export type PlanState =
   | 'Finished-Succeeded' // Has a completed timestamp
   | 'Finished-Failed'
   | 'Finished-Incomplete'
-  | 'Archived';
+  | 'Archived'
+  | 'Unknown'; // No status data is available and the plan is over 30 seconds old (to give the controller time to catch up)
 
 export enum StepType {
   Full = 'Full',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2011785

Currently when the `plan.status` property is missing, we assume there is a problem and show Unknown in the status column on the plans table. It appears that in some circumstances this can be normal, if the controller is taking a few seconds to catch up and validate the newly created plan CR. This PR shows a spinner with "Validating" if there is no status data available for a plan at first.

![Screen Shot 2021-10-07 at 12 19 01 PM](https://user-images.githubusercontent.com/811963/136424867-dac33840-960c-4483-9ac2-b352c102020b.png)

However, the status field can also be empty because of some unknown problem, and I didn't want it to be possible for a plan to get stuck showing "Validating" forever in that case. After 30 seconds of status data continuing to be missing, the message will change to "Unknown" with a warning icon as is displayed today.