### PR TITLE
Bug 2013687: fix(must-gather): ensure mg calls do not end in infinite redirect loop

### DIFF
--- a/qe-tests/cypress/integration/tests/Rhv/config_separate_mapping_rhv.ts
+++ b/qe-tests/cypress/integration/tests/Rhv/config_separate_mapping_rhv.ts
@@ -6,7 +6,7 @@ import {
   TestData,
   RhvProviderData,
 } from '../../types/types';
-import { providerType, storageType, CreateNewStorageMapping } from '../../types/constants';
+import { providerType, storageType } from '../../types/constants';
 const url = Cypress.env('url');
 const user_login = 'kubeadmin';
 const user_password = Cypress.env('pass');

--- a/src/app/queries/fetchHelpers.ts
+++ b/src/app/queries/fetchHelpers.ts
@@ -23,6 +23,7 @@ export const authorizedFetch = async <TResponse, TData = unknown>(
   extraHeaders: RequestInit['headers'] = {},
   method: 'get' | 'post' = 'get',
   returnMode: 'json' | 'blob' = 'json',
+  bypassRedirect = false,
   data?: TData
 ): Promise<TResponse> => {
   const { history, checkExpiry } = fetchContext;
@@ -46,14 +47,14 @@ export const authorizedFetch = async <TResponse, TData = unknown>(
       throw response;
     }
   } catch (error: unknown) {
-    checkExpiry(error, history);
+    !bypassRedirect && checkExpiry(error, history);
     throw error;
   }
 };
 
-export const useAuthorizedFetch = <T>(url: string): QueryFunction<T> => {
+export const useAuthorizedFetch = <T>(url: string, bypassRedirect?: boolean): QueryFunction<T> => {
   const fetchContext = useFetchContext();
-  return () => authorizedFetch(url, fetchContext);
+  return () => authorizedFetch(url, fetchContext, {}, 'get', 'json', bypassRedirect);
 };
 
 export const authorizedK8sRequest = async <T>(

--- a/src/app/queries/mustGather.ts
+++ b/src/app/queries/mustGather.ts
@@ -23,6 +23,7 @@ export const useMustGatherMutation = (
           { 'Content-Type': 'application/json' },
           'post',
           'json',
+          true,
           options
         )
           .then((mustGatherData) => {
@@ -59,7 +60,7 @@ export const useMustGathersQuery = (
   const result = useMockableQuery<IMustGatherResponse[], Response>(
     {
       queryKey: ['must-gather-list'],
-      queryFn: useAuthorizedFetch(getMustGatherApiUrl(url)),
+      queryFn: useAuthorizedFetch(getMustGatherApiUrl(url), true),
       enabled: isReady,
       refetchInterval: usePollingContext().refetchInterval,
       onError: (error) => {
@@ -86,7 +87,7 @@ export const useMustGatherQuery = (
   const result = useMockableQuery<IMustGatherResponse, Response>(
     {
       queryKey: ['must-gather-entity', customName],
-      queryFn: useAuthorizedFetch(getMustGatherApiUrl(`must-gather/${customName}`)),
+      queryFn: useAuthorizedFetch(getMustGatherApiUrl(`must-gather/${customName}`), true),
       enabled: shouldPoll,
       refetchInterval: usePollingContext().refetchInterval,
       onError: () => {


### PR DESCRIPTION
This PR adds a flag which can be used to bypass the auto redirect if a fetch fails. It's defaulted to false so all requests should function as they have previously without change, but for the must gather requests which are still being ironed out, we take advantage of this new flag and let them fail silently.