### PR TITLE
Bug 1994479: fix(status): ensure status helper checks for starting state before not started

### DIFF
--- a/src/app/Plans/components/helpers.ts
+++ b/src/app/Plans/components/helpers.ts
@@ -154,12 +154,13 @@ export const getPlanState = (
     return 'Archiving';
   }
 
+  if (isPlanBeingStarted(plan, migration, migrationQuery) && !hasCondition(conditions, 'Succeeded'))
+    return 'Starting';
+
   if (!migration || !plan.status?.migration?.started) {
     if (hasCondition(conditions, 'Ready')) return 'NotStarted-Ready';
     return 'NotStarted-NotReady';
   }
-  if (isPlanBeingStarted(plan, migration, migrationQuery) && !hasCondition(conditions, 'Succeeded'))
-    return 'Starting';
 
   if (isWarm && !migration.spec.cutover) {
     if (hasCondition(conditions, 'Canceled')) {


### PR DESCRIPTION
This PR makes a small adjustment to the helper that determines a plan state (which drives status of various elements within the UI). It seems like the conditions we're checking for are correct, just that we need to check for the starting state before we check for the case of NotStarted-NotReady/NotStarted-Ready. Seems almost too good to be true, am I missing something @mturley ?

![Screen Shot 2021-10-18 at 4 28 51 PM](https://user-images.githubusercontent.com/5942899/137802338-368133a7-8165-46b4-8946-f6a235dea91b.png)

Should help close [1994479](https://bugzilla.redhat.com/show_bug.cgi?id=1994479)