### PR TITLE
Use microdnf with nodejs14-minimal image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM registry.access.redhat.com/ubi8/nodejs-14-minimal
 
 # Add tar package to allow copying files with kubectl scp
 USER root
-RUN dnf -y install tar && dnf clean all
+RUN microdnf -y install tar && microdnf clean all
 USER 1001
 
 LABEL name="konveyor/forklift-ui" \


### PR DESCRIPTION
The nodejs14-minimal image is based on ubi8-minimal and doesn't have the `dnf` command. Instead it has `microdnf`.
This pull request updates the Dockerfile to use `microdnf` to install `tar`.