### PR TITLE
Bug 2012795: feat(edit): allow editing for plans where no individual VM migration succeeded

### DIFF
--- a/pkg/web/src/app/Plans/components/PlansTable.tsx
+++ b/pkg/web/src/app/Plans/components/PlansTable.tsx
@@ -182,7 +182,7 @@ export const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     const statusValue = totalVMs > 0 ? (numVMsDone * 100) / totalVMs : 0;
     const statusMessage = `${numVMsDone} of ${totalVMs} VMs migrated`;
 
-    return { statusValue, statusMessage };
+    return { statusValue, statusMessage, numVMsDone };
   };
 
   const columns: ICell[] = [
@@ -220,7 +220,7 @@ export const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
     const buttonType = getButtonState(planState);
     const { title, variant } = getMigStatusState(planState, isWarmPlan);
 
-    const { statusValue = 0, statusMessage = '' } = ratioVMs(plan);
+    const { statusValue = 0, statusMessage = '', numVMsDone } = ratioVMs(plan);
 
     const { sourceProvider, targetProvider } = findProvidersByRefs(
       plan.spec.provider,
@@ -308,11 +308,21 @@ export const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
                 ) : null}
               </FlexItem>
               <FlexItem>
-                <PlanActionsDropdown canRestart={canRestart} planState={planState} plan={plan} />
+                <PlanActionsDropdown
+                  numVMsDone={numVMsDone}
+                  canRestart={canRestart}
+                  planState={planState}
+                  plan={plan}
+                />
               </FlexItem>
             </Flex>
           ) : !isBeingStarted ? (
-            <PlanActionsDropdown canRestart={canRestart} planState={planState} plan={plan} />
+            <PlanActionsDropdown
+              numVMsDone={numVMsDone}
+              canRestart={canRestart}
+              planState={planState}
+              plan={plan}
+            />
           ) : null,
         },
       ],


### PR DESCRIPTION
This PR updates the logic around the PlansTable and PlanActionsDropdown to allow for editing a plan assuming none of the VMs have been migrated yet. We anticipate there may be some changes needed elsewhere in the UI, so I'm posting this as a draft first to work out any kinks.