### PR TITLE
Use started/completed timestamps on precopies instead of start/end

### DIFF
--- a/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -34,8 +34,8 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
 
   const sortedPrecopies = (status.warm.precopies || []).sort((a, b) => {
     // Most recent first
-    if (a.start < b.start) return 1;
-    if (a.start > b.start) return -1;
+    if (a.started < b.started) return 1;
+    if (a.started > b.started) return -1;
     return 0;
   });
 
@@ -55,12 +55,17 @@ const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTableProps> 
       cells: [
         sortedPrecopies.length - index,
         {
-          title: <TickingElapsedTime start={precopy.start} end={precopy.end || status.completed} />,
+          title: (
+            <TickingElapsedTime
+              start={precopy.started}
+              end={precopy.completed || status.completed}
+            />
+          ),
         },
         {
           title: isCanceled ? (
             <CanceledIcon />
-          ) : precopy.end ? (
+          ) : precopy.completed ? (
             <StatusIcon status="Ok" label="Complete" />
           ) : status.error && index === 0 ? (
             <StatusIcon status="Error" label="Failed" />

--- a/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -34,14 +34,14 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
     };
   }
   const { precopies, nextPrecopyAt } = vmStatus.warm;
-  if ((precopies || []).some((copy) => !!copy.start && !copy.end)) {
+  if ((precopies || []).some((copy) => !!copy.started && !copy.completed)) {
     return {
       state: 'Copying',
       status: 'Loading',
       label: 'Performing incremental data copy',
     };
   }
-  if ((precopies || []).every((copy) => !!copy.start && !!copy.end)) {
+  if ((precopies || []).every((copy) => !!copy.started && !!copy.completed)) {
     return {
       state: 'Idle',
       status: 'Paused',

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -606,7 +606,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       failures: 0,
       precopies: [
         {
-          start: '2021-03-16T17:28:48Z',
+          started: '2021-03-16T17:28:48Z',
         },
       ],
       successes: 0,
@@ -630,7 +630,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       failures: 0,
       precopies: [
         {
-          start: '2021-03-16T17:28:48Z',
+          started: '2021-03-16T17:28:48Z',
         },
       ],
       successes: 0,
@@ -645,15 +645,15 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       failures: 0,
       precopies: [
         {
-          start: '2021-03-16T17:28:48Z',
-          end: '2021-03-16T17:29:42Z',
+          started: '2021-03-16T17:28:48Z',
+          completed: '2021-03-16T17:29:42Z',
         },
         {
-          start: '2021-03-16T18:29:20Z',
-          end: '2021-03-16T18:30:38Z',
+          started: '2021-03-16T18:29:20Z',
+          completed: '2021-03-16T18:30:38Z',
         },
         {
-          start: '2021-03-16T18:30:38Z',
+          started: '2021-03-16T18:30:38Z',
         },
       ],
       successes: 0,
@@ -676,16 +676,16 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       nextPrecopyAt: '2021-03-16T18:29:20Z',
       precopies: [
         {
-          start: '2021-03-16T17:28:48Z',
-          end: '2021-03-16T17:29:42Z',
+          started: '2021-03-16T17:28:48Z',
+          completed: '2021-03-16T17:29:42Z',
         },
         {
-          start: '2021-03-16T18:29:20Z',
-          end: '2021-03-16T18:30:38Z',
+          started: '2021-03-16T18:29:20Z',
+          completed: '2021-03-16T18:30:38Z',
         },
         {
-          start: '2021-03-16T18:30:38Z',
-          end: '2021-03-16T18:31:48Z',
+          started: '2021-03-16T18:30:38Z',
+          completed: '2021-03-16T18:31:48Z',
         },
       ],
       successes: 3,

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -40,8 +40,8 @@ export interface IVMStatus {
     successes: number;
     nextPrecopyAt?: string; // ISO timestamp
     precopies?: {
-      start: string;
-      end?: string;
+      started: string;
+      completed?: string;
     }[];
   };
 }


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=2012732, awaiting a BZ for the UI issue.