### PR TITLE
Bug 2022651: Add explanation of leftover resources when deleting a non-archived plan, don't allow deleting while a plan is being archived

### DIFF
--- a/src/app/Plans/components/PlanActionsDropdown.tsx
+++ b/src/app/Plans/components/PlanActionsDropdown.tsx
@@ -152,7 +152,8 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
             isTooltipEnabled={
               hasCondition(conditions, 'Executing') ||
               deletePlanMutation.isLoading ||
-              isPlanGathering
+              isPlanGathering ||
+              planState === 'Archiving'
             }
             content={
               hasCondition(conditions, 'Executing')
@@ -161,6 +162,8 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
                 ? 'This plan cannot be deleted because it is deleting'
                 : isPlanGathering
                 ? 'This plan cannot be deleted because it is running must gather service'
+                : planState === 'Archiving'
+                ? 'This plan cannot be deleted because it is being archived'
                 : ''
             }
           >
@@ -168,7 +171,8 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
               isAriaDisabled={
                 hasCondition(conditions, 'Executing') ||
                 deletePlanMutation.isLoading ||
-                isPlanGathering
+                isPlanGathering ||
+                planState === 'Archiving'
               }
               onClick={() => {
                 setKebabIsOpen(false);
@@ -229,7 +233,20 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
         mutateResult={deletePlanMutation}
         title="Permanently delete migration plan?"
         confirmButtonText="Delete"
-        body={`All data for migration plan "${plan.metadata.name}" will be lost.`}
+        body={
+          isPlanStarted && !isPlanArchived ? (
+            <TextContent>
+              <Text>
+                Migration plan &quot;{plan.metadata.name}&quot; will be deleted. However, some
+                temporary resources created during migration will not be cleaned up. These include
+                failed VMs and datavolumes, conversion pods, importer pods, secrets, and configmaps.
+              </Text>
+              <Text>To clean up these resources, archive the plan before deleting it.</Text>
+            </TextContent>
+          ) : (
+            <>All data for migration plan &quot;{plan.metadata.name}&quot; will be lost.</>
+          )
+        }
         errorText="Cannot delete migration plan"
       />
       {isRestartModalOpen ? (


### PR DESCRIPTION
This is the confirm modal we currently show when deleting a plan:
![Screen Shot 2021-11-11 at 3 19 53 PM](https://user-images.githubusercontent.com/811963/141364393-8d427cda-e8a1-4261-aaaf-6e6c9e5fe66b.png)

With this PR, that text is still used for deleting any plans that have never been started or are fully archived. Otherwise (for plans that are done running but have not yet been archived), this is the new confirm modal:

![Screen Shot 2021-11-11 at 3 20 12 PM](https://user-images.githubusercontent.com/811963/141364513-1b505397-a929-43de-a218-69b744e79d1f.png)

This PR also prevents triggering the delete action (even opening the modal) if the plan is currently in the process of being archived.
