### PR TITLE
Revert "Use started/completed timestamps on precopies instead of start/end"

### DIFF
--- a/src/app/Plans/components/VMStatusPrecopyTable.tsx
+++ b/src/app/Plans/components/VMStatusPrecopyTable.tsx
@@ -34,8 +34,8 @@ export const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTable
 
   const sortedPrecopies = (status.warm.precopies || []).sort((a, b) => {
     // Most recent first
-    if (a.started < b.started) return 1;
-    if (a.started > b.started) return -1;
+    if (a.start < b.start) return 1;
+    if (a.start > b.start) return -1;
     return 0;
   });
 
@@ -55,17 +55,12 @@ export const VMStatusPrecopyTable: React.FunctionComponent<IVMStatusPrecopyTable
       cells: [
         sortedPrecopies.length - index,
         {
-          title: (
-            <TickingElapsedTime
-              start={precopy.started}
-              end={precopy.completed || status.completed}
-            />
-          ),
+          title: <TickingElapsedTime start={precopy.start} end={precopy.end || status.completed} />,
         },
         {
           title: isCanceled ? (
             <CanceledIcon />
-          ) : precopy.completed ? (
+          ) : precopy.end ? (
             <StatusIcon status="Ok" label="Complete" />
           ) : status.error && index === 0 ? (
             <StatusIcon status="Error" label="Failed" />

--- a/src/app/Plans/components/VMWarmCopyStatus.tsx
+++ b/src/app/Plans/components/VMWarmCopyStatus.tsx
@@ -34,14 +34,14 @@ export const getWarmVMCopyState = (vmStatus: IVMStatus): IWarmVMCopyState => {
     };
   }
   const { precopies, nextPrecopyAt } = vmStatus.warm;
-  if ((precopies || []).some((copy) => !!copy.started && !copy.completed)) {
+  if ((precopies || []).some((copy) => !!copy.start && !copy.end)) {
     return {
       state: 'Copying',
       status: 'Loading',
       label: 'Performing incremental data copy',
     };
   }
-  if ((precopies || []).every((copy) => !!copy.started && !!copy.completed)) {
+  if ((precopies || []).every((copy) => !!copy.start && !!copy.end)) {
     return {
       state: 'Idle',
       status: 'Paused',

--- a/src/app/queries/mocks/plans.mock.ts
+++ b/src/app/queries/mocks/plans.mock.ts
@@ -623,7 +623,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       failures: 0,
       precopies: [
         {
-          started: '2021-03-16T17:28:48Z',
+          start: '2021-03-16T17:28:48Z',
         },
       ],
       successes: 0,
@@ -647,7 +647,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       failures: 0,
       precopies: [
         {
-          started: '2021-03-16T17:28:48Z',
+          start: '2021-03-16T17:28:48Z',
         },
       ],
       successes: 0,
@@ -662,15 +662,15 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       failures: 0,
       precopies: [
         {
-          started: '2021-03-16T17:28:48Z',
-          completed: '2021-03-16T17:29:42Z',
+          start: '2021-03-16T17:28:48Z',
+          end: '2021-03-16T17:29:42Z',
         },
         {
-          started: '2021-03-16T18:29:20Z',
-          completed: '2021-03-16T18:30:38Z',
+          start: '2021-03-16T18:29:20Z',
+          end: '2021-03-16T18:30:38Z',
         },
         {
-          started: '2021-03-16T18:30:38Z',
+          start: '2021-03-16T18:30:38Z',
         },
       ],
       successes: 0,
@@ -693,16 +693,16 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       nextPrecopyAt: '2021-03-16T18:29:20Z',
       precopies: [
         {
-          started: '2021-03-16T17:28:48Z',
-          completed: '2021-03-16T17:29:42Z',
+          start: '2021-03-16T17:28:48Z',
+          end: '2021-03-16T17:29:42Z',
         },
         {
-          started: '2021-03-16T18:29:20Z',
-          completed: '2021-03-16T18:30:38Z',
+          start: '2021-03-16T18:29:20Z',
+          end: '2021-03-16T18:30:38Z',
         },
         {
-          started: '2021-03-16T18:30:38Z',
-          completed: '2021-03-16T18:31:48Z',
+          start: '2021-03-16T18:30:38Z',
+          end: '2021-03-16T18:31:48Z',
         },
       ],
       successes: 3,

--- a/src/app/queries/types/plans.types.ts
+++ b/src/app/queries/types/plans.types.ts
@@ -41,8 +41,8 @@ export interface IVMStatus {
     successes: number;
     nextPrecopyAt?: string; // ISO timestamp
     precopies?: {
-      started: string;
-      completed?: string;
+      start: string;
+      end?: string;
     }[];
   };
 }


### PR DESCRIPTION
Reverts https://github.com/konveyor/forklift-ui/pull/813.

Goes with https://github.com/konveyor/forklift-operator/pull/182 and https://github.com/konveyor/forklift-controller/pull/390