### PR TITLE
Treeview: expands only top level

### DIFF
--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -171,6 +171,7 @@ export const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
         emptyStateBody={LONG_LOADING_MESSAGE}
       >
         <TreeView
+          key={form.fields.treeType.value}
           data={treeViewData}
           defaultAllExpanded
           allExpanded={true}

--- a/src/app/Plans/components/Wizard/FilterVMsForm.tsx
+++ b/src/app/Plans/components/Wizard/FilterVMsForm.tsx
@@ -173,8 +173,6 @@ export const FilterVMsForm: React.FunctionComponent<IFilterVMsFormProps> = ({
         <TreeView
           key={form.fields.treeType.value}
           data={treeViewData}
-          defaultAllExpanded
-          allExpanded={true}
           hasChecks
           hasBadges
           hasGuides

--- a/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -110,6 +110,8 @@ describe('<AddEditProviderModal />', () => {
     userEvent.click(nextButton);
 
     expect(screen.getByRole('heading', { name: /Filter by VM location/ })).toBeInTheDocument();
+    const v2vDC = await screen.findByRole('button', { name: /V2V-DC/ });
+    userEvent.click(v2vDC);
     expect(screen.getByRole('checkbox', { name: /Select Cluster V2V_Cluster/ })).toBeChecked();
     expect(nextButton).toBeEnabled();
     userEvent.click(nextButton);

--- a/src/app/Plans/components/Wizard/helpers.tsx
+++ b/src/app/Plans/components/Wizard/helpers.tsx
@@ -170,6 +170,7 @@ const convertInventoryTreeNode = (
       node.kind === 'Cluster' ? <ClusterIcon /> : node.kind === 'Folder' ? <FolderIcon /> : null,
     customBadgeContent: badge,
     hasBadge: !!badge,
+    defaultExpanded: false,
   };
 };
 
@@ -235,6 +236,7 @@ export const filterAndConvertInventoryTree = (
       ),
       customBadgeContent: badge,
       hasBadge: !!badge,
+      defaultExpanded: true,
     },
   ];
 };


### PR DESCRIPTION
- Only first level children are expanded by default
- Added a distinct React `key` to TreeView to avoid tree behavior overlap between Cluster and Folder views. For example (without a key), expend/collapse one tree would also expend/collapse the other one.

Follow up from https://github.com/konveyor/forklift-ui/issues/35 (which becomes obsolete after this one)


