### PR TITLE
Use css-minimizer-webpack-plugin for optimizing bundle

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -4,20 +4,11 @@ const common = require('./webpack.common.js');
 const { stylePaths } = require('./stylePaths');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserJSPlugin = require('terser-webpack-plugin');
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 
 module.exports = merge(common('production'), {
   mode: 'production',
   devtool: 'nosources-source-map',
-  optimization: {
-    minimizer: [new TerserJSPlugin({})],
-    sideEffects: true,
-  },
-  plugins: [
-    new MiniCssExtractPlugin({
-      filename: '[name].css',
-      chunkFilename: '[name].bundle.css',
-    }),
-  ],
   module: {
     rules: [
       {
@@ -27,4 +18,19 @@ module.exports = merge(common('production'), {
       },
     ],
   },
+  optimization: {
+    minimizer: [new TerserJSPlugin({}), `...`, new CssMinimizerPlugin()],
+    sideEffects: true,
+  },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: '[name].css',
+      chunkFilename: '[name].bundle.css',
+    }),
+    new CssMinimizerPlugin({
+      minimizerOptions: {
+        preset: ['default', { mergeLonghand: false }],
+      },
+    }),
+  ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3742,9 +3742,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001236",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
-      "integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==",
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
       "dev": true
     },
     "caseless": {


### PR DESCRIPTION
This is a follow up from https://github.com/konveyor/forklift-ui/pull/847.

This reduces the bundle to 7.2 MB (from 7.4).

I believe we can keep using `css-minimizer-webpack-plugin` instead of restoring `optimize-css-assets-webpack-plugin` to bundle css for production. Effectively the former is more accurate and works by default since Webpack 5. 

The original issue (see https://github.com/konveyor/forklift-ui/pull/646) is related to https://github.com/cssnano/cssnano/issues/675 and the work around for either plugin is to set `mergeLonghand: false` to `cssnano` processing (The flag to be  removed once addressed).
