### PR TITLE
[qe-tests] Upgrade `cypress` to 9.x and `@testing-library/cypress` to 7.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1167,9 +1167,9 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.0.tgz",
-      "integrity": "sha512-jIsLdASXMf8GS7P7oGFGwobNse/6Ewq3GBPHoo0i6XRmja+NrUoDqJm4a1ffF2bHGleKJizxokcp1sCqSktP3g==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1355,20 +1355,75 @@
       }
     },
     "node_modules/@testing-library/cypress": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-7.0.7.tgz",
-      "integrity": "sha512-4yavolmN9o4Lmtrff6sbOTNFW9VqRRqDrP6gS2hkqLri4+lKURRYblg8kjOlcni/5h/qctFych+gkUOkpgypxw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.2.tgz",
+      "integrity": "sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.29.6"
+        "@babel/runtime": "^7.14.6",
+        "@testing-library/dom": "^8.1.0"
       },
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
-        "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+        "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@testing-library/cypress/node_modules/@testing-library/dom": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
+      "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@testing-library/cypress/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/cypress/node_modules/aria-query": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@testing-library/cypress/node_modules/pretty-format": {
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
+      "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.4.2",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4453,20 +4508,20 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.7.0.tgz",
-      "integrity": "sha512-uYBYXNoI5ym0UxROwhQXWTi8JbUEjpC6l/bzoGZNxoKGsLrC1SDPgIDJMgLX/MeEdPL0UInXLDUWN/rSyZUCjQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.1.1.tgz",
+      "integrity": "sha512-yWcYD8SEQ8F3okFbRPqSDj5V0xhrZBT5QRIH+P1J2vYvtEmZ4KGciHE7LCcZZLILOrs7pg4WNCqkj/XRvReQlQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.5",
+        "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "^6.0.2",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
-        "bluebird": "^3.7.2",
+        "bluebird": "3.7.2",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -4493,7 +4548,7 @@
         "minimist": "^1.2.5",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
-        "ramda": "~0.27.1",
+        "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
@@ -12070,6 +12125,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -12172,12 +12233,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -16702,8 +16757,8 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@testing-library/cypress": "^7.0.6",
-        "cypress": "^7.5.0"
+        "@testing-library/cypress": "^8.0.2",
+        "cypress": "^9.1.1"
       }
     },
     "pkg/web": {
@@ -17636,9 +17691,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.0.tgz",
-      "integrity": "sha512-jIsLdASXMf8GS7P7oGFGwobNse/6Ewq3GBPHoo0i6XRmja+NrUoDqJm4a1ffF2bHGleKJizxokcp1sCqSktP3g==",
+      "version": "27.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
+      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -17788,13 +17843,55 @@
       }
     },
     "@testing-library/cypress": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-7.0.7.tgz",
-      "integrity": "sha512-4yavolmN9o4Lmtrff6sbOTNFW9VqRRqDrP6gS2hkqLri4+lKURRYblg8kjOlcni/5h/qctFych+gkUOkpgypxw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.2.tgz",
+      "integrity": "sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.29.6"
+        "@babel/runtime": "^7.14.6",
+        "@testing-library/dom": "^8.1.0"
+      },
+      "dependencies": {
+        "@testing-library/dom": {
+          "version": "8.11.1",
+          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
+          "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/runtime": "^7.12.5",
+            "@types/aria-query": "^4.2.0",
+            "aria-query": "^5.0.0",
+            "chalk": "^4.1.0",
+            "dom-accessibility-api": "^0.5.9",
+            "lz-string": "^1.4.4",
+            "pretty-format": "^27.0.2"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "aria-query": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "27.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
+          "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^27.4.2",
+            "ansi-regex": "^5.0.1",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
       }
     },
     "@testing-library/dom": {
@@ -20255,19 +20352,19 @@
       "dev": true
     },
     "cypress": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.7.0.tgz",
-      "integrity": "sha512-uYBYXNoI5ym0UxROwhQXWTi8JbUEjpC6l/bzoGZNxoKGsLrC1SDPgIDJMgLX/MeEdPL0UInXLDUWN/rSyZUCjQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.1.1.tgz",
+      "integrity": "sha512-yWcYD8SEQ8F3okFbRPqSDj5V0xhrZBT5QRIH+P1J2vYvtEmZ4KGciHE7LCcZZLILOrs7pg4WNCqkj/XRvReQlQ==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.5",
+        "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "^6.0.2",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
-        "bluebird": "^3.7.2",
+        "bluebird": "3.7.2",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
@@ -20294,7 +20391,7 @@
         "minimist": "^1.2.5",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
-        "ramda": "~0.27.1",
+        "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
@@ -21879,8 +21976,8 @@
     "forklift-ui-qe-tests": {
       "version": "file:pkg/qe-tests",
       "requires": {
-        "@testing-library/cypress": "^7.0.6",
-        "cypress": "^7.5.0"
+        "@testing-library/cypress": "^8.0.2",
+        "cypress": "^9.1.1"
       }
     },
     "forklift-ui-web": {
@@ -26084,6 +26181,12 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -26154,12 +26257,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
-    },
-    "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
       "dev": true
     },
     "randombytes": {

--- a/pkg/qe-tests/package.json
+++ b/pkg/qe-tests/package.json
@@ -12,7 +12,7 @@
     "tsc": "tsc --project ./tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@testing-library/cypress": "^7.0.6",
-    "cypress": "^7.5.0"
+    "@testing-library/cypress": "^8.0.2",
+    "cypress": "^9.1.1"
   }
 }


### PR DESCRIPTION
As requested by @ibragins. After updating your local main branch, run `npm install` again.

```diff
diff --git a/pkg/qe-tests/package.json b/pkg/qe-tests/package.json
index ee10b87..4255de5 100644
--- a/pkg/qe-tests/package.json
+++ b/pkg/qe-tests/package.json
@@ -12,7 +12,7 @@
     "tsc": "tsc --project ./tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@testing-library/cypress": "^7.0.6",
-    "cypress": "^7.5.0"
+    "@testing-library/cypress": "^8.0.2",
+    "cypress": "^9.1.1"
   }
 }
```