### PR TITLE
Add npm run install:ws script

### DIFF
--- a/.github/workflows/tests-ci.yaml
+++ b/.github/workflows/tests-ci.yaml
@@ -18,6 +18,6 @@ jobs:
         with:
           node-version: 16
       - name: Install dependencies
-        run: npm install -ws --legacy-peer-deps && npm install
+        run: npm run install:ws
       - name: Run tests
         run: npm run ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM registry.access.redhat.com/ubi8/nodejs-16 as builder
 COPY . .
 USER root
-RUN npm install -ws --legacy-peer-deps && npm install && npm run build
+RUN npm run install:ws && npm run build
 
 # Runner image
 FROM registry.access.redhat.com/ubi8/nodejs-16-minimal

--- a/README.md
+++ b/README.md
@@ -15,17 +15,12 @@ Clone and install dependencies:
 ```bash
 git clone https://github.com/konveyor/forklift-ui
 cd forklift-ui
-npm install -ws --legacy-peer-deps && npm install
+npm run install:ws # Installs all workspaces packages and the top level packages
 ```
 
 Create a meta.dev.json file in the config directory using [`config/meta.dev.example.json`](./config/meta.dev.example.json) as a template. Set the `inventoryApi` property to the root URL of your forklift-controller inventory API, and set the `clusterApi` property to the root URL of your host OpenShift cluster API. And also to be able to use VMware provider data to be analysed by Migration Analytics set the `inventoryPayloadApi` property to the root URL of your forklift-controller inventory Payload API.
 
-### Environment variables:
-
-To install all workspaces packages and the top level packages run:
-```sh
-$ npm install -ws --legacy-peer-deps && npm install
-```
+### Environment variables
 
 - `DATA_SOURCE` - either `mock` or `remote`
   (unnecessary if you use `npm run [start:dev|build]:[mock|remote]` scripts)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "pkg/api/src/server.js",
   "private": true,
   "scripts": {
+    "install:ws": "npm install -ws --legacy-peer-deps && npm install",
     "dr:surge": "node dr-surge.js",
     "setup:dev:remote": "node ./pkg/api/scripts/remote-dev.js",
     "build": "npm run clean && NODE_ENV=production $(npm bin)/webpack --config ./config/webpack.prod.js",


### PR DESCRIPTION
Adds the `npm run install:ws` script to more easily run our necessary `npm install -ws --legacy-peer-deps && npm install` commands. Updates the README, dockerfile and CI config to use this.