### PR TITLE
Fix fallback path for meta.dev.json file when META_FILE environment var is undefined

### DIFF
--- a/pkg/api/src/helpers.ts
+++ b/pkg/api/src/helpers.ts
@@ -8,7 +8,7 @@ const sanitizeMeta = (meta) => {
 
 export const getDevMeta = () => {
   if (process.env['DATA_SOURCE'] === 'mock') return { oauth: {} };
-  const configPath = process.env['META_FILE'] || './meta.dev.json';
+  const configPath = process.env['META_FILE'] || './config/meta.dev.json';
   if (!existsSync(configPath)) {
     console.error(`ERROR: ${configPath} is missing`);
     console.error(


### PR DESCRIPTION
Currently when running remote dev mode without an explicit `META_FILE` in your environment, the script attempts to look for a `meta.dev.json` in the repo root rather than in the config directory.