### PR TITLE
Update CODEOWNERS with new location of qe-tests directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 * @konveyor/migration-engineering-ui-committers
-/qe-tests/ @konveyor/migration-engineering-qe-committers
+/pkg/qe-tests/ @konveyor/migration-engineering-qe-committers


### PR DESCRIPTION
I'm hoping this restores @ibragins ' ability to approve/merge qe-tests PRs.