### PR TITLE
Temporarily remove workspace links from package-lock.json to fix Cachito

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6563,18 +6563,6 @@
         "node": "*"
       }
     },
-    "node_modules/forklift-ui-api": {
-      "resolved": "pkg/api",
-      "link": true
-    },
-    "node_modules/forklift-ui-qe-tests": {
-      "resolved": "pkg/qe-tests",
-      "link": true
-    },
-    "node_modules/forklift-ui-web": {
-      "resolved": "pkg/web",
-      "link": true
-    },
     "node_modules/form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",


### PR DESCRIPTION
#871 didn't resolve the entire issue, which seems to be happening at lockfile parse time. Trying this as a temporary workaround.