### PR TITLE
Fix express staticDir after moving server.js into pkg/api/src

### DIFF
--- a/pkg/api/src/server.js
+++ b/pkg/api/src/server.js
@@ -28,7 +28,7 @@ console.log('\nValues from meta.json:', meta);
 const app = express();
 const port =
   process.env['EXPRESS_PORT'] || (process.env['UI_TLS_ENABLED'] !== 'false' ? 8443 : 8080);
-const staticDir = process.env['STATIC_DIR'] || path.join(__dirname, '../dist');
+const staticDir = process.env['STATIC_DIR'] || path.join(__dirname, '../../../dist');
 
 app.engine('ejs', require('ejs').renderFile);
 app.use(express.static(staticDir));


### PR DESCRIPTION
We missed this in https://github.com/konveyor/forklift-ui/pull/849. Because the `server.js` file was moved from `deploy/` to `pkg/api/src/` but the `dist` still gets built at the repo root, the `../dist` path was no longer matching anything and so Express was failing to find any files we tried to serve from that path (app.bundle.js, the CSS and favicons, etc). Instead it was hitting the fallback `*` controller which renders the HTML. The result is that an HTML response was attempting to be parsed as JS, resulting in `Uncaught SyntaxError: Unexpected token '<'`. We didn't catch this because we didn't test a full prod build until now and this path is not used in dev mode.

This fixes the relative `staticDir` path to be `../../../dist` so it can properly host the files in the root dist directory from the server's new path.