### PR TITLE
Github workflow: bump plateform and actions versions

### DIFF
--- a/.github/workflows/deploy-main-preview.yaml
+++ b/.github/workflows/deploy-main-preview.yaml
@@ -9,12 +9,12 @@ jobs:
   test-and-release:
     name: Deploy preview to Surge
     if: ${{ github.repository == 'konveyor/forklift-ui' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16
       - name: Install dependencies

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -4,16 +4,16 @@ on: pull_request
 jobs:
   deploy-pr-preview:
     name: Deploy to Surge
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up token
         id: token
         # This is a base64-encoded OAuth token for the "konveyor-preview-bot" GitHub account, which has no secure access.
         run: echo "::set-output name=GH_TOKEN::`echo 'ODk3MzkyNzJlMDQwZjQ3YThhODJjYjYwZmFhM2RlOWQ3ZTk2YWM3OQo=' | base64 -d`"
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16
       - name: Install dependencies

--- a/.github/workflows/tests-ci.yaml
+++ b/.github/workflows/tests-ci.yaml
@@ -9,12 +9,12 @@ on:
 jobs:
   tests:
     name: Continuous Integration
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16
       - name: Install dependencies


### PR DESCRIPTION
The initial reason for updating github actions version and the Linux platform version is a mismatch discovered in CI for  https://github.com/konveyor/forklift-ui/pull/845 which is not happening when testing locally (at least with Fedora 35).

While investigating it came that using action version for setup-node @v2 guarantee an LTS version for node.js.
Bumping actions/checkout to v2 comes along and while doing let's use latest Ubuntu LTS version with 20.04.