### PR TITLE
Bug 1994179: Add support for custom ingress CA chain in OpenShift

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 
-# Add service serving CA cert to the global CA bundle
-if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" ]; then
+# Copy the main CA bundle to /opt/app-root/src/ca.crt
+# If a custom certificate is deployed for ingress, the
+# /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem file
+# exists and should be used. Otherwise, we use the default.
+if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ]; then
+    cp /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /opt/app-root/src/ca.crt
+else
     cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt /opt/app-root/src/ca.crt
+fi
+
+# Add service serving CA cert to the global CA bundle if it exists
+if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" ]; then
     cat /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt >> /opt/app-root/src/ca.crt
 fi
 


### PR DESCRIPTION
In OpenShift, it is possible to configure a custom certificate for the ingress routes. The full CA chain is provided to allow certificate verification. By default, the custom CA chain is not exposed in `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, so pods cannot reach services on their external URL.

The UI uses a callback link with the external URL of the UI, since it will then be passed to the user's browser that can only access external URLs. This forbids the access to the UI when using custom CA.

With konveyor/forklift-operator#201, we ensure that the custom CA is merged into the main CA bundle and mounted in `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`. This change checks
the existence of this file and uses it as the main CA bundle to build the final CA bundle used by NodeJS.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>