### PR TITLE
Fix Cannot read property 'createEvent' of null

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,7 @@
       "version": "^16.11.0"
     }
   },
-  "plugins": ["prettier", "@typescript-eslint", "react-hooks", "eslint-plugin-react-hooks"],
+  "plugins": ["prettier", "@typescript-eslint", "react-hooks", "eslint-plugin-react-hooks", "testing-library"],
   "rules": {
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
@@ -48,7 +48,11 @@
         "singleQuote": true,
         "semi": true
       }
-    ]  
+    ],
+    "testing-library/await-async-query": "error",
+    "testing-library/no-await-sync-query": "error",
+    "testing-library/no-debugging-utils": "warn",
+    "testing-library/no-dom-import": "off"
   },
   "env": {
     "browser": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0",
+        "eslint-plugin-testing-library": "^5.0.3",
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.3.1",
         "imagemin": "^8.0.0",
@@ -2113,6 +2114,113 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
+      "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/typescript-estree": "5.9.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+      "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/visitor-keys": "5.9.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+      "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+      "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/visitor-keys": "5.9.1",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+      "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.9.1",
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -5753,6 +5861,22 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.3.tgz",
+      "integrity": "sha512-tKZ9G+HnIOnYAhXeoBCiAT8LOdU3m1VquBTKsBW/5zAaB30vq7gC60DIayPfMJt8EZBlqPVzGqSN57sIFmTunQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.9.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": "^7.5.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -18373,6 +18497,69 @@
         }
       }
     },
+    "@typescript-eslint/experimental-utils": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
+      "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/typescript-estree": "5.9.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+          "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/visitor-keys": "5.9.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+          "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+          "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "@typescript-eslint/visitor-keys": "5.9.1",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.9.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+          "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.9.1",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+          "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+          "dev": true
+        }
+      }
+    },
     "@typescript-eslint/parser": {
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.0.tgz",
@@ -21213,6 +21400,15 @@
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-testing-library": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.3.tgz",
+      "integrity": "sha512-tKZ9G+HnIOnYAhXeoBCiAT8LOdU3m1VquBTKsBW/5zAaB30vq7gC60DIayPfMJt8EZBlqPVzGqSN57sIFmTunQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.9.0"
+      }
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
       "devDependencies": {
         "@axe-core/react": "^4.2.1",
         "@testing-library/cypress": "^8.0.2",
-        "@testing-library/jest-dom": "^5.13.0",
-        "@testing-library/react": "^11.2.7",
-        "@testing-library/user-event": "^13.1.9",
+        "@testing-library/jest-dom": "^5.16.1",
+        "@testing-library/react": "^12.1.2",
+        "@testing-library/user-event": "^13.5.0",
         "@types/ejs": "^3.0.6",
         "@types/express": "^4.17.12",
         "@types/file-saver": "^2.0.3",
@@ -664,19 +664,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
       "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.3.tgz",
-      "integrity": "sha512-IAdDC7T0+wEB4y2gbIL0uOXEYpiZEeuFUTVbdGq+UwCcF35T/tS8KrmMomEwEc5wBbyfH3PJVpTSUqrhPDXFcQ==",
-      "dev": true,
-      "dependencies": {
-        "core-js-pure": "^3.19.0",
         "regenerator-runtime": "^0.13.4"
       },
       "engines": {
@@ -1390,7 +1377,7 @@
         "cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
       }
     },
-    "node_modules/@testing-library/cypress/node_modules/@testing-library/dom": {
+    "node_modules/@testing-library/dom": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
       "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
@@ -1409,7 +1396,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/@testing-library/cypress/node_modules/ansi-styles": {
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
@@ -1421,22 +1408,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@testing-library/cypress/node_modules/aria-query": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
-      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/@testing-library/cypress/node_modules/pretty-format": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
-      "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.4.6",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
+      "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.4.2",
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
@@ -1445,34 +1422,15 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "7.31.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^4.2.2",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.6",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^26.6.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.15.1.tgz",
-      "integrity": "sha512-kmj8opVDRE1E4GXyLlESsQthCXK7An28dFWxhiMwD7ZUI7ZxA6sjdJRxLerD9Jd8cHX4BDc1jzXaaZKqzlUkvg==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.1.tgz",
+      "integrity": "sha512-ajUJdfDIuTCadB79ukO+0l8O+QwN0LiSxDaYUTI4LndbbUsGi6rWU1SCexXzBA2NSjlVB9/vbkasQIL3tmPBjw==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2",
         "@types/testing-library__jest-dom": "^5.9.1",
-        "aria-query": "^4.2.2",
+        "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
         "css": "^3.0.0",
         "css.escape": "^1.5.1",
@@ -1500,16 +1458,16 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
-      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
+        "@testing-library/dom": "^8.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "peerDependencies": {
         "react": "*",
@@ -2936,14 +2894,10 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
       "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
-      },
       "engines": {
         "node": ">=6.0"
       }
@@ -4307,17 +4261,6 @@
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
       "hasInstallScript": true
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.19.2.tgz",
-      "integrity": "sha512-5LkcgQEy8pFeVnd/zomkUBSwnmIxuF1C8E9KrMAbOc8f34IBT9RGvTYeNDdp1PnvMJrrVhvk1hg/yVV5h/znlg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -17263,16 +17206,6 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "@babel/runtime-corejs3": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.3.tgz",
-      "integrity": "sha512-IAdDC7T0+wEB4y2gbIL0uOXEYpiZEeuFUTVbdGq+UwCcF35T/tS8KrmMomEwEc5wBbyfH3PJVpTSUqrhPDXFcQ==",
-      "dev": true,
-      "requires": {
-        "core-js-pure": "^3.19.0",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/template": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
@@ -17855,43 +17788,36 @@
       "requires": {
         "@babel/runtime": "^7.14.6",
         "@testing-library/dom": "^8.1.0"
+      }
+    },
+    "@testing-library/dom": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
+      "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
       },
       "dependencies": {
-        "@testing-library/dom": {
-          "version": "8.11.1",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.1.tgz",
-          "integrity": "sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^4.2.0",
-            "aria-query": "^5.0.0",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.9",
-            "lz-string": "^1.4.4",
-            "pretty-format": "^27.0.2"
-          }
-        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
         },
-        "aria-query": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
-          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
-          "dev": true
-        },
         "pretty-format": {
-          "version": "27.4.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
-          "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
+          "version": "27.4.6",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
+          "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.4.2",
             "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
@@ -17899,31 +17825,15 @@
         }
       }
     },
-    "@testing-library/dom": {
-      "version": "7.31.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-      "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^4.2.2",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.6",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^26.6.2"
-      }
-    },
     "@testing-library/jest-dom": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.15.1.tgz",
-      "integrity": "sha512-kmj8opVDRE1E4GXyLlESsQthCXK7An28dFWxhiMwD7ZUI7ZxA6sjdJRxLerD9Jd8cHX4BDc1jzXaaZKqzlUkvg==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.1.tgz",
+      "integrity": "sha512-ajUJdfDIuTCadB79ukO+0l8O+QwN0LiSxDaYUTI4LndbbUsGi6rWU1SCexXzBA2NSjlVB9/vbkasQIL3tmPBjw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
         "@types/testing-library__jest-dom": "^5.9.1",
-        "aria-query": "^4.2.2",
+        "aria-query": "^5.0.0",
         "chalk": "^3.0.0",
         "css": "^3.0.0",
         "css.escape": "^1.5.1",
@@ -17945,13 +17855,13 @@
       }
     },
     "@testing-library/react": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
-      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^7.28.1"
+        "@testing-library/dom": "^8.0.0"
       }
     },
     "@testing-library/user-event": {
@@ -19101,14 +19011,10 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+      "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -20182,12 +20088,6 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-    },
-    "core-js-pure": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.19.2.tgz",
-      "integrity": "sha512-5LkcgQEy8pFeVnd/zomkUBSwnmIxuF1C8E9KrMAbOc8f34IBT9RGvTYeNDdp1PnvMJrrVhvk1hg/yVV5h/znlg==",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "eslint-plugin-testing-library": "^5.0.3",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.1",
     "imagemin": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "devDependencies": {
     "@axe-core/react": "^4.2.1",
     "@testing-library/cypress": "^8.0.2",
-    "@testing-library/jest-dom": "^5.13.0",
-    "@testing-library/react": "^11.2.7",
-    "@testing-library/user-event": "^13.1.9",
+    "@testing-library/jest-dom": "^5.16.1",
+    "@testing-library/react": "^12.1.2",
+    "@testing-library/user-event": "^13.5.0",
     "@types/ejs": "^3.0.6",
     "@types/express": "^4.17.12",
     "@types/file-saver": "^2.0.3",

--- a/pkg/web/src/app/Mappings/Mappings.test.tsx
+++ b/pkg/web/src/app/Mappings/Mappings.test.tsx
@@ -19,7 +19,7 @@ describe('Mappings', () => {
       </QueryClientProvider>
     );
 
-    const result = await screen.getByText('Loading...');
+    const result = screen.getByText('Loading...');
     expect(result).toBeDefined();
   });
 });

--- a/pkg/web/src/app/Mappings/MappingsPage.test.tsx
+++ b/pkg/web/src/app/Mappings/MappingsPage.test.tsx
@@ -12,7 +12,7 @@ describe('MappingsPage', () => {
         <MappingsPage />
       </QueryClientProvider>
     );
-    const heading = await screen.getByText('Mappings');
+    const heading = screen.getByText('Mappings');
     expect(heading).toBeDefined();
 
     screen.getByRole('button', {

--- a/pkg/web/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/__tests__/PlanWizard.test.tsx
@@ -48,7 +48,10 @@ describe('<AddEditProviderModal />', () => {
     userEvent.type(name, 'planname');
     userEvent.type(description, 'plan description');
 
-    userEvent.click(providers[0]);
+    await waitFor(() => {
+      userEvent.click(providers[0]);
+    });
+
     await screen.findByRole('option', {
       name: /vcenter-1/i,
       hidden: true,
@@ -61,7 +64,11 @@ describe('<AddEditProviderModal />', () => {
     });
 
     expect(namespace).toHaveAttribute('disabled', '');
-    userEvent.click(namespace);
+
+    await waitFor(() => {
+      userEvent.click(namespace);
+    });
+
     userEvent.type(namespace, 'openshift-migration');
 
     const nextButton = await screen.findByRole('button', { name: /Next/ });
@@ -69,7 +76,9 @@ describe('<AddEditProviderModal />', () => {
     const cancelButton = await screen.findByRole('button', { name: /Cancel/ });
     expect(cancelButton).toBeEnabled();
 
-    userEvent.click(nextButton);
+    await waitFor(() => {
+      userEvent.click(nextButton);
+    });
 
     // TODO: Continue to VMs selection
   });
@@ -107,20 +116,28 @@ describe('<AddEditProviderModal />', () => {
 
     const nextButton = await screen.findByRole('button', { name: /Next/ });
     expect(nextButton).toBeEnabled();
-    userEvent.click(nextButton);
+    await waitFor(() => {
+      userEvent.click(nextButton);
+    });
 
     expect(screen.getByRole('heading', { name: /Filter by VM location/ })).toBeInTheDocument();
     const v2vDC = await screen.findByRole('button', { name: /V2V-DC/ });
-    userEvent.click(v2vDC);
+    await waitFor(() => {
+      userEvent.click(v2vDC);
+    });
     expect(screen.getByRole('checkbox', { name: /Select Cluster V2V_Cluster/ })).toBeChecked();
     expect(nextButton).toBeEnabled();
-    userEvent.click(nextButton);
+    await waitFor(() => {
+      userEvent.click(nextButton);
+    });
 
     expect(screen.getByRole('heading', { name: /Select VMs/ })).toBeInTheDocument();
     await waitFor(() => expect(screen.getByLabelText('VMware VMs table')).toBeInTheDocument());
     expect(screen.getByRole('checkbox', { name: /Select row 0/ })).toBeChecked();
     expect(nextButton).toBeEnabled();
-    userEvent.click(nextButton);
+    await waitFor(() => {
+      userEvent.click(nextButton);
+    });
 
     expect(screen.getByRole('heading', { name: /Network mapping/ })).toBeInTheDocument();
     expect(screen.getByText(/vmware-network-1/i)).toBeInTheDocument();
@@ -128,7 +145,9 @@ describe('<AddEditProviderModal />', () => {
     expect(networkTarget).toHaveValue('openshift-migration / ocp-network-1');
     expect(screen.getByRole('checkbox', { name: /save mapping checkbox/ })).not.toBeChecked();
     await waitFor(() => expect(nextButton).toBeEnabled());
-    userEvent.click(nextButton);
+    await waitFor(() => {
+      userEvent.click(nextButton);
+    });
 
     expect(screen.getByRole('heading', { name: /Storage mapping/ })).toBeInTheDocument();
     expect(screen.getByText(/vmware-datastore-1/i)).toBeInTheDocument();
@@ -136,18 +155,24 @@ describe('<AddEditProviderModal />', () => {
     expect(storageTarget).toHaveValue('large');
     expect(screen.getByRole('checkbox', { name: /save mapping checkbox/ })).not.toBeChecked();
     await waitFor(() => expect(nextButton).toBeEnabled());
-    userEvent.click(nextButton);
+    await waitFor(() => {
+      userEvent.click(nextButton);
+    });
 
     expect(screen.getByRole('heading', { name: /Migration type/ })).toBeInTheDocument();
     expect(screen.getByLabelText(/Cold migration/)).toHaveAttribute('checked');
     await waitFor(() => expect(nextButton).toBeEnabled());
-    userEvent.click(nextButton);
+    await waitFor(() => {
+      userEvent.click(nextButton);
+    });
 
     expect(
       screen.getByRole('heading', { name: /Add hooks to the plan \(optional\)/ })
     ).toBeInTheDocument();
     await waitFor(() => expect(nextButton).toBeEnabled());
-    userEvent.click(nextButton);
+    await waitFor(() => {
+      userEvent.click(nextButton);
+    });
 
     // Review step
     expect(screen.getByRole('heading', { name: /Review the migration plan/ })).toBeInTheDocument();

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -213,6 +213,11 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
     isCertificateQueryEnabled
   );
 
+  const certificateConfirmButtonRef = React.useRef<HTMLElement>(null);
+
+  const scrollVerifyButtonIntoView = () =>
+    certificateConfirmButtonRef.current?.scrollIntoView({ behavior: 'smooth' });
+
   return (
     <Modal
       className="AddEditProviderModal"
@@ -317,6 +322,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                       placeholder: isVmWare(providerType)
                         ? 'Example, administrator@vsphere.local'
                         : undefined,
+                      onFocus: scrollVerifyButtonIntoView,
                     }}
                     field={fields.username}
                     label={getLabelName('username', brandPrefix(providerType))}
@@ -326,6 +332,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                 ) : null}
                 {fields?.password ? (
                   <ValidatedPasswordInput
+                    inputProps={{ onFocus: scrollVerifyButtonIntoView }}
                     field={fields.password}
                     label={getLabelName('pwd', brandPrefix(providerType))}
                     isRequired
@@ -338,6 +345,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                       <Button
                         id="certificate-confirm-button"
                         key="confirm"
+                        ref={certificateConfirmButtonRef}
                         aria-label="Verify Certificate"
                         variant="primary"
                         isDisabled={!fields.hostname?.isTouched || !fields.hostname?.isValid} // TODO we should remove the isTouched case here once we resolve https://github.com/konveyor/lib-ui/issues/82

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -213,11 +213,6 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
     isCertificateQueryEnabled
   );
 
-  const certificateConfirmButtonRef = React.useRef<HTMLElement>(null);
-
-  const scrollVerifyButtonIntoView = () =>
-    certificateConfirmButtonRef.current?.scrollIntoView({ behavior: 'smooth' });
-
   return (
     <Modal
       className="AddEditProviderModal"
@@ -322,7 +317,6 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                       placeholder: isVmWare(providerType)
                         ? 'Example, administrator@vsphere.local'
                         : undefined,
-                      onFocus: scrollVerifyButtonIntoView,
                     }}
                     field={fields.username}
                     label={getLabelName('username', brandPrefix(providerType))}
@@ -332,7 +326,6 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                 ) : null}
                 {fields?.password ? (
                   <ValidatedPasswordInput
-                    inputProps={{ onFocus: scrollVerifyButtonIntoView }}
                     field={fields.password}
                     label={getLabelName('pwd', brandPrefix(providerType))}
                     isRequired
@@ -345,7 +338,6 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                       <Button
                         id="certificate-confirm-button"
                         key="confirm"
-                        ref={certificateConfirmButtonRef}
                         aria-label="Verify Certificate"
                         variant="primary"
                         isDisabled={!fields.hostname?.isTouched || !fields.hostname?.isValid} // TODO we should remove the isTouched case here once we resolve https://github.com/konveyor/lib-ui/issues/82

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -11,6 +11,8 @@ import { NetworkContextProvider } from '@app/common/context';
 import { AddEditProviderModal } from '../AddEditProviderModal';
 import { MOCK_CLUSTER_PROVIDERS } from '@app/queries/mocks/providers.mock';
 
+beforeAll(() => (window.HTMLElement.prototype.scrollIntoView = jest.fn()));
+
 describe('<AddEditProviderModal />', () => {
   const toggleModalAndResetEdit = () => {
     return;

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -21,7 +21,7 @@ describe('<AddEditProviderModal />', () => {
     onClose: toggleModalAndResetEdit,
   };
 
-  it('allows to cancel addition/edition of a provider', async () => {
+  it.skip('allows to cancel addition/edition of a provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -51,8 +51,14 @@ describe('<AddEditProviderModal />', () => {
 
     const typeButton = await screen.findByLabelText(/provider type/i);
     userEvent.click(typeButton);
+    await waitFor(() => {
+      null;
+    });
     const oVirtButton = await screen.findByRole('option', { name: /ovirt/i, hidden: true });
     userEvent.click(oVirtButton);
+    await waitFor(() => {
+      null;
+    });
     const caCertField = screen.getByLabelText(/^File upload/);
     const name = screen.getByRole('textbox', { name: /Name/ });
     const hostname = screen.getByRole('textbox', {
@@ -60,22 +66,23 @@ describe('<AddEditProviderModal />', () => {
     });
     const username = screen.getByRole('textbox', { name: /oVirt Engine user name/i });
     const password = screen.getByLabelText(/^oVirt Engine password/);
-
-    userEvent.type(name, 'providername');
-    userEvent.type(hostname, 'host.example.com');
-    userEvent.type(username, 'username');
-    userEvent.type(password, 'password');
-    userEvent.type(caCertField, '-----BEGIN CERTIFICATE-----abc-----END CERTIFICATE-----');
+    await waitFor(() => {
+      userEvent.type(name, 'providername');
+      userEvent.type(hostname, 'host.example.com');
+      userEvent.type(username, 'username');
+      userEvent.type(password, 'password');
+      userEvent.type(caCertField, '-----BEGIN CERTIFICATE-----abc-----END CERTIFICATE-----');
+    });
 
     const addButton = await screen.findByRole('dialog', { name: /Add provider/ });
-    expect(addButton).toBeEnabled();
+    await waitFor(() => expect(addButton).toBeEnabled());
     const cancelButton = await screen.findByRole('button', { name: /Cancel/ });
-    expect(cancelButton).toBeEnabled();
+    await waitFor(() => expect(cancelButton).toBeEnabled());
   });
 
   // Vsphere Provider
 
-  it('allows adding a vsphere provider', async () => {
+  it.skip('allows adding a vsphere provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -126,7 +133,7 @@ describe('<AddEditProviderModal />', () => {
     expect(cancelButton).toBeEnabled();
   });
 
-  it('fails to add a vsphere provider with wrong values', async () => {
+  it.skip('fails to add a vsphere provider with wrong values', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -160,7 +167,7 @@ describe('<AddEditProviderModal />', () => {
     expect(cancelButton).toBeEnabled();
   });
 
-  it('allows editing a vsphere provider', async () => {
+  it.skip('allows editing a vsphere provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -179,7 +186,7 @@ describe('<AddEditProviderModal />', () => {
 
   // OpenShift Provider
 
-  it('allows to add an openshift provider', async () => {
+  it.skip('allows to add an openshift provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -209,7 +216,7 @@ describe('<AddEditProviderModal />', () => {
     expect(cancelButton).toBeEnabled();
   });
 
-  it('fails to add an openshift provider with wrong values', async () => {
+  it.skip('fails to add an openshift provider with wrong values', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -239,7 +246,7 @@ describe('<AddEditProviderModal />', () => {
     expect(cancelButton).toBeEnabled();
   });
 
-  it('allows editing an openshift provider', async () => {
+  it.skip('allows editing an openshift provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -112,16 +112,14 @@ describe('<AddEditProviderModal />', () => {
 
     userEvent.type(name, 'providername');
     userEvent.type(hostname, 'host.example.com');
-    await waitFor(() => {
-      userEvent.click(username);
-    });
     userEvent.type(username, 'username');
     userEvent.type(password, 'password');
 
     const verifyButton = await screen.findByLabelText(/verify certificate/i);
+    expect(verifyButton).toBeEnabled();
+
     await waitFor(() => {
       userEvent.click(verifyButton);
-      expect(verifyButton).toBeEnabled();
     });
 
     expect(

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -11,8 +11,6 @@ import { NetworkContextProvider } from '@app/common/context';
 import { AddEditProviderModal } from '../AddEditProviderModal';
 import { MOCK_CLUSTER_PROVIDERS } from '@app/queries/mocks/providers.mock';
 
-beforeAll(() => (window.HTMLElement.prototype.scrollIntoView = jest.fn()));
-
 describe('<AddEditProviderModal />', () => {
   const toggleModalAndResetEdit = () => {
     return;

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -11,9 +11,9 @@ import { NetworkContextProvider } from '@app/common/context';
 import { AddEditProviderModal } from '../AddEditProviderModal';
 import { MOCK_CLUSTER_PROVIDERS } from '@app/queries/mocks/providers.mock';
 
-beforeAll(() => (window.HTMLElement.prototype.scrollIntoView = jest.fn()));
-
 describe('<AddEditProviderModal />', () => {
+  beforeAll(() => (window.HTMLElement.prototype.scrollIntoView = jest.fn()));
+
   const toggleModalAndResetEdit = () => {
     return;
   };
@@ -23,7 +23,7 @@ describe('<AddEditProviderModal />', () => {
     onClose: toggleModalAndResetEdit,
   };
 
-  it.skip('allows to cancel addition/edition of a provider', async () => {
+  it('allows to cancel addition/edition of a provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -52,14 +52,12 @@ describe('<AddEditProviderModal />', () => {
     );
 
     const typeButton = await screen.findByLabelText(/provider type/i);
-    userEvent.click(typeButton);
     await waitFor(() => {
-      null;
+      userEvent.click(typeButton);
     });
     const oVirtButton = await screen.findByRole('option', { name: /ovirt/i, hidden: true });
-    userEvent.click(oVirtButton);
     await waitFor(() => {
-      null;
+      userEvent.click(oVirtButton);
     });
     const caCertField = screen.getByLabelText(/^File upload/);
     const name = screen.getByRole('textbox', { name: /Name/ });
@@ -77,14 +75,14 @@ describe('<AddEditProviderModal />', () => {
     });
 
     const addButton = await screen.findByRole('dialog', { name: /Add provider/ });
-    await waitFor(() => expect(addButton).toBeEnabled());
+    expect(addButton).toBeEnabled();
     const cancelButton = await screen.findByRole('button', { name: /Cancel/ });
-    await waitFor(() => expect(cancelButton).toBeEnabled());
+    expect(cancelButton).toBeEnabled();
   });
 
   // Vsphere Provider
 
-  it.skip('allows adding a vsphere provider', async () => {
+  it('allows adding a vsphere provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -96,9 +94,14 @@ describe('<AddEditProviderModal />', () => {
     );
 
     const typeButton = await screen.findByLabelText(/provider type/i);
-    userEvent.click(typeButton);
+    await waitFor(() => {
+      userEvent.click(typeButton);
+    });
+
     const vsphereButton = await screen.findByRole('option', { name: /vmware/i, hidden: true });
-    userEvent.click(vsphereButton);
+    await waitFor(() => {
+      userEvent.click(vsphereButton);
+    });
 
     const name = screen.getByRole('textbox', { name: /Name/ });
     const hostname = screen.getByRole('textbox', {
@@ -109,16 +112,18 @@ describe('<AddEditProviderModal />', () => {
 
     userEvent.type(name, 'providername');
     userEvent.type(hostname, 'host.example.com');
-    userEvent.click(username);
+    await waitFor(() => {
+      userEvent.click(username);
+    });
     userEvent.type(username, 'username');
     userEvent.type(password, 'password');
 
     const verifyButton = await screen.findByLabelText(/verify certificate/i);
     await waitFor(() => {
       userEvent.click(verifyButton);
+      expect(verifyButton).toBeEnabled();
     });
 
-    expect(verifyButton).toBeEnabled();
     expect(
       screen.getByText('39:5C:6A:2D:36:38:B2:52:2B:21:EA:74:11:59:89:5E:20:D5:D9:A2')
     ).toBeInTheDocument();
@@ -126,7 +131,9 @@ describe('<AddEditProviderModal />', () => {
       name: /validate certificate/i,
     });
 
-    userEvent.click(validateCertificationCheckbox);
+    await waitFor(() => {
+      userEvent.click(validateCertificationCheckbox);
+    });
 
     expect(validateCertificationCheckbox).toBeChecked();
     const addButton = await screen.findByRole('dialog', { name: /Add provider/ });
@@ -135,7 +142,7 @@ describe('<AddEditProviderModal />', () => {
     expect(cancelButton).toBeEnabled();
   });
 
-  it.skip('fails to add a vsphere provider with wrong values', async () => {
+  it('fails to add a vsphere provider with wrong values', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -147,9 +154,14 @@ describe('<AddEditProviderModal />', () => {
     );
 
     const typeButton = await screen.findByLabelText(/provider type/i);
-    userEvent.click(typeButton);
+    await waitFor(() => {
+      userEvent.click(typeButton);
+    });
+
     const vsphereButton = await screen.findByRole('option', { name: /vmware/i, hidden: true });
-    userEvent.click(vsphereButton);
+    await waitFor(() => {
+      userEvent.click(vsphereButton);
+    });
 
     const name = screen.getByRole('textbox', { name: /Name/ });
     const hostname = screen.getByRole('textbox', {
@@ -158,10 +170,12 @@ describe('<AddEditProviderModal />', () => {
     const username = screen.getByRole('textbox', { name: /vCenter user name/i });
     const password = screen.getByLabelText(/^vCenter password/);
 
-    userEvent.type(name, 'providername');
-    userEvent.type(hostname, 'hostname');
-    userEvent.type(username, 'username');
-    userEvent.type(password, 'password');
+    await waitFor(() => {
+      userEvent.type(name, 'providername');
+      userEvent.type(hostname, 'hostname');
+      userEvent.type(username, 'username');
+      userEvent.type(password, 'password');
+    });
 
     const addButton = await screen.findByRole('button', { name: /Add/ });
     expect(addButton).toBeDisabled();
@@ -169,7 +183,7 @@ describe('<AddEditProviderModal />', () => {
     expect(cancelButton).toBeEnabled();
   });
 
-  it.skip('allows editing a vsphere provider', async () => {
+  it('allows editing a vsphere provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -188,7 +202,7 @@ describe('<AddEditProviderModal />', () => {
 
   // OpenShift Provider
 
-  it.skip('allows to add an openshift provider', async () => {
+  it('allows to add an openshift provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -200,17 +214,24 @@ describe('<AddEditProviderModal />', () => {
     );
 
     const typeButton = await screen.findByLabelText(/provider type/i);
-    userEvent.click(typeButton);
+    await waitFor(() => {
+      userEvent.click(typeButton);
+    });
+
     const openshiftButton = await screen.findByRole('option', { name: /kubevirt/i, hidden: true });
-    userEvent.click(openshiftButton);
+    await waitFor(() => {
+      userEvent.click(openshiftButton);
+    });
 
     const name = screen.getByRole('textbox', { name: /name/i });
     const url = screen.getByRole('textbox', { name: /url/i });
     const saToken = screen.getByLabelText(/^Service account token/);
 
-    userEvent.type(name, 'providername');
-    userEvent.type(url, 'http://host.example.com');
-    userEvent.type(saToken, 'saToken');
+    await waitFor(() => {
+      userEvent.type(name, 'providername');
+      userEvent.type(url, 'http://host.example.com');
+      userEvent.type(saToken, 'saToken');
+    });
 
     const addButton = await screen.findByRole('dialog', { name: /Add provider/ });
     expect(addButton).toBeEnabled();
@@ -218,7 +239,7 @@ describe('<AddEditProviderModal />', () => {
     expect(cancelButton).toBeEnabled();
   });
 
-  it.skip('fails to add an openshift provider with wrong values', async () => {
+  it('fails to add an openshift provider with wrong values', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>
@@ -230,25 +251,32 @@ describe('<AddEditProviderModal />', () => {
     );
 
     const typeButton = await screen.findByLabelText(/provider type/i);
-    userEvent.click(typeButton);
+    await waitFor(() => {
+      userEvent.click(typeButton);
+    });
+
     const openshiftButton = await screen.findByRole('option', { name: /kubevirt/i, hidden: true });
-    userEvent.click(openshiftButton);
+    await waitFor(() => {
+      userEvent.click(openshiftButton);
+    });
 
     const name = screen.getByRole('textbox', { name: /name/i });
     const url = screen.getByRole('textbox', { name: /url/i });
     const saToken = screen.getByLabelText(/^Service account token/);
 
-    userEvent.type(name, 'providername');
-    userEvent.type(url, 'host');
-    userEvent.type(saToken, 'saToken');
+    await waitFor(() => {
+      userEvent.type(name, 'providername');
+      userEvent.type(url, 'host');
+      userEvent.type(saToken, 'saToken');
+    });
 
-    const addButton = await screen.getByRole('button', { name: /Add/ });
+    const addButton = screen.getByRole('button', { name: /Add/ });
     expect(addButton).toBeDisabled();
     const cancelButton = await screen.findByRole('button', { name: /Cancel/ });
     expect(cancelButton).toBeEnabled();
   });
 
-  it.skip('allows editing an openshift provider', async () => {
+  it('allows editing an openshift provider', async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <NetworkContextProvider>


### PR DESCRIPTION
Initially we thought using `scrollIntoView` wasn't playing nicely with our testing libraries and we had to find a solution and in the meantime we remove the feature.

It turned out that it was an async/await issue with userEvent() from react-testing-library (it's community channel helped: https://stackoverflow.com/questions/60504720/jest-cannot-read-property-createevent-of-null).

So finally we don't have to remove `scrollIntoView` and the random error has disappeared where the only way to make sure of it is to run the tests in a loop.

AddEditProviderModal.test.tsx and PlanWizard.test.tsx are the two files involved.

This also:
- adds "eslint-plugin-testing-library" library to help with developments.
- Bump testing libraries to latest