### PR TITLE
Bug 2039665: Fix entrypoint CA bundle permission issues

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,15 +4,20 @@
 # If a custom certificate is deployed for ingress, the
 # /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem file
 # exists and should be used. Otherwise, we use the default.
-if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ]; then
-    cp /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /opt/app-root/src/ca.crt
-else
-    cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt /opt/app-root/src/ca.crt
+
+# Add Kube API CA, if it exists
+if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt" ]; then
+   cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt ${NODE_EXTRA_CA_CERTS}
 fi
 
 # Add service serving CA cert to the global CA bundle if it exists
 if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt" ]; then
-    cat /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt >> /opt/app-root/src/ca.crt
+    cat /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt >> ${NODE_EXTRA_CA_CERTS}
+fi
+
+# Add custom ingress CA if it exists
+if [ -f "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem" ]; then
+    cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem >> ${NODE_EXTRA_CA_CERTS}
 fi
 
 exec npm run -s start


### PR DESCRIPTION
This is a fix related to #883 , the base image ubi8/nodejs-16-minimal already contains a /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem which has restrictive permissions, because this was the first CA cert copied, it caused subsequent CA additions to the bundle to fail during entrypoint startup.

This PR addresses this issue and also reorders by priority the creation of the NODE_EXTRA_CA_CERTS bundle. At any given time there are 2 CA certificates needed on this bundle: Kube API CA, Service Serving Signer CA, optionally also Custom Ingress CA can be added.

When a Custom Ingress cert has been detected by operator on the cluster , this will inject the trusted-ca configmap with the ca-bundle.crt and mount it in /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem which will override the nodejs-16-minimal file location.
