### PR TITLE
Bug 2032805: Restore the 'select all' checkbox for canceling VMs

### DIFF
--- a/pkg/web/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/pkg/web/src/app/Plans/components/VMMigrationDetails.tsx
@@ -404,7 +404,7 @@ export const VMMigrationDetails: React.FunctionComponent = () => {
                       toggleItemSelected(rowData.meta.vmStatus, isSelected);
                     }
                   }}
-                  canSelectAll={false}
+                  canSelectAll={cancelableVMs.length > 0}
                 >
                   <TableHeader />
                   <TableBody />


### PR DESCRIPTION
Reverts [this change](https://github.com/konveyor/forklift-ui/pull/663/files#diff-88742f21dfead4628c8230611451d713c8d9b0de1683ac4239edfa4d24ab840eL383) from #663, which made it into v2.1.0. That PR was intended to focus on the Select VMs step of the wizard and involved some refactoring of shared components also used on the migration details table. As part of disabling the built-in select all checkbox on that Select VMs table to replace it with a bulk-select control in the toolbar, we apparently also disabled it on the migration details table without adding a bulk-select control.

![Screen Shot 2022-01-24 at 1 34 56 PM](https://user-images.githubusercontent.com/811963/150843169-9574ee2b-1036-4040-b103-33d6b290c56e.png)

@vconzola to quickly resolve the BZ, I've reverted that change so we get this original Select All checkbox back, but if you like I can go in later and replace it with a bulk-select dropdown like we have in the wizard (see screenshot in #663).

