### PR TITLE
Upgrade lib-ui to 6.0.0, address breaking changes in useFormState

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hot-loader/react-dom": "^17.0.1",
-        "@konveyor/lib-ui": "^5.0.0",
+        "@konveyor/lib-ui": "^6.0.0",
         "@patternfly/react-core": "^4.181.1",
         "@patternfly/react-icons": "^4.32.1",
         "@patternfly/react-styles": "^4.31.1",
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/@konveyor/lib-ui": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-5.2.0.tgz",
-      "integrity": "sha512-XRGnbCwsgkohM5uai0iYCL0Veo8QRnU7N4ycZ5b4E2H/aBqQAbrehR6JCtYHPeI1x1zoJvRwNqg6y23buhspIw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-6.0.0.tgz",
+      "integrity": "sha512-0Za3WU3vbmTHZozIo9JCu/3b8NFO/xYKzJXKaXulfn+U2/WDvGD0ejOgHSg4DtnzgUiY2sz4Gre6CoU1JaEBBg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "react-query": "^3.26.0",
@@ -17642,9 +17642,9 @@
       }
     },
     "@konveyor/lib-ui": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-5.2.0.tgz",
-      "integrity": "sha512-XRGnbCwsgkohM5uai0iYCL0Veo8QRnU7N4ycZ5b4E2H/aBqQAbrehR6JCtYHPeI1x1zoJvRwNqg6y23buhspIw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@konveyor/lib-ui/-/lib-ui-6.0.0.tgz",
+      "integrity": "sha512-0Za3WU3vbmTHZozIo9JCu/3b8NFO/xYKzJXKaXulfn+U2/WDvGD0ejOgHSg4DtnzgUiY2sz4Gre6CoU1JaEBBg==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "react-query": "^3.26.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "dependencies": {
     "@hot-loader/react-dom": "^17.0.1",
-    "@konveyor/lib-ui": "^5.0.0",
+    "@konveyor/lib-ui": "^6.0.0",
     "@patternfly/react-core": "^4.181.1",
     "@patternfly/react-icons": "^4.32.1",
     "@patternfly/react-styles": "^4.31.1",

--- a/pkg/web/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/PlanAddEditHookModal.tsx
@@ -262,7 +262,7 @@ export const PlanAddEditHookModal: React.FunctionComponent<IPlanAddEditHookModal
                       setPlaybookFilename(filename);
                     }}
                     onBlur={() => instanceForm.fields.playbook.setIsTouched(true)}
-                    validated={instanceForm.fields.playbook.isValid ? 'default' : 'error'}
+                    validated={instanceForm.fields.playbook.shouldShowError ? 'error' : 'default'}
                   />
                 </FormGroup>
               </div>

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -348,7 +348,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                         ref={certificateConfirmButtonRef}
                         aria-label="Verify Certificate"
                         variant="primary"
-                        isDisabled={!fields.hostname?.isTouched || !fields.hostname?.isValid} // TODO we should remove the isTouched case here once we resolve https://github.com/konveyor/lib-ui/issues/82
+                        isDisabled={!fields.hostname?.isValid}
                         onClick={() => {
                           setCertificateQueryEnabled(true);
                         }}
@@ -471,7 +471,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                         fields.caCertFilename?.setValue(filename);
                       }}
                       onBlur={() => fields.caCert?.setIsTouched(true)}
-                      validated={fields.caCert?.isValid ? 'default' : 'error'}
+                      validated={fields.caCert?.shouldShowError ? 'error' : 'default'}
                     />
                   </FormGroup>
                 ) : null}

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/helpers.ts
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/helpers.ts
@@ -40,7 +40,6 @@ export const useEditProviderPrefillEffect = (
       if (providerType === 'vsphere') {
         const vmwareFields = forms.vsphere.fields;
         vmwareFields.hostname.prefill(vmwareUrlToHostname(providerBeingEdited.spec.url || ''));
-        vmwareFields.hostname.setIsTouched(true); // TODO this shouldn't be necessary once we resolve https://github.com/konveyor/lib-ui/issues/82
         vmwareFields.fingerprint.prefill(atob(secret?.data.thumbprint || ''));
       }
       if (providerType === 'ovirt') {

--- a/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
+++ b/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal.tsx
@@ -132,7 +132,7 @@ export const SelectNetworkModal: React.FunctionComponent<ISelectNetworkModalProp
             label="Network"
             isRequired
             fieldId="network"
-            validated={form.fields.selectedNetworkAdapter.isValid ? 'default' : 'error'}
+            validated={form.fields.selectedNetworkAdapter.shouldShowError ? 'error' : 'default'}
             {...getFormGroupProps(form.fields.selectedNetworkAdapter)}
           >
             <SimpleSelect

--- a/pkg/web/src/app/common/components/SelectOpenShiftNetworkModal.tsx
+++ b/pkg/web/src/app/common/components/SelectOpenShiftNetworkModal.tsx
@@ -133,7 +133,7 @@ export const SelectOpenShiftNetworkModal: React.FunctionComponent<
           <FormGroup
             isRequired
             fieldId="network"
-            validated={form.fields.selectedNetworkName.isValid ? 'default' : 'error'}
+            validated={form.fields.selectedNetworkName.shouldShowError ? 'error' : 'default'}
             {...getFormGroupProps(form.fields.selectedNetworkName)}
           >
             <SimpleSelect


### PR DESCRIPTION
Upgrades lib-ui to bring in https://github.com/konveyor/lib-ui/pull/83 and adjusts references to `field.isValid` to account for the breaking change.