### PR TITLE
Remove unnecessary console.log

### DIFF
--- a/pkg/web/src/app/queries/tree.ts
+++ b/pkg/web/src/app/queries/tree.ts
@@ -68,7 +68,7 @@ export const indexTree = <T extends InventoryTree>(tree: T): IndexedTree<T> => {
       : node.children?.flatMap((child: InventoryTree) => getDescendants(child, true)) || [];
     return includeSelf ? [node, ...descendants] : descendants;
   };
-  const ret = {
+  return {
     tree: sortedTree,
     flattenedNodes: walk(sortedTree),
     vmSelfLinks,
@@ -77,8 +77,6 @@ export const indexTree = <T extends InventoryTree>(tree: T): IndexedTree<T> => {
     vmDescendantsBySelfLink,
     getDescendants,
   };
-  console.log(ret);
-  return ret;
 };
 
 export const useInventoryTreeQuery = <T extends InventoryTree>(


### PR DESCRIPTION
Removes a log statement accidentally left behind by an earlier PR.