### PR TITLE
[QE] Checkbox to Cancel Multiple VMs

### DIFF
--- a/pkg/qe-tests/cypress/integration/models/plan.ts
+++ b/pkg/qe-tests/cypress/integration/models/plan.ts
@@ -294,25 +294,20 @@ export class Plan {
   //Method for different Migaration plan step
   protected waitForState(planStep: string): void {
     click(arrowDropDown); //click on dropdown arrow to see the plan steps box
-    cy.get(dataLabel.step, { timeout: 20 * SEC })
+    cy.get(dataLabel.step, { timeout: 200 * SEC })
       .contains(planStep)
       .closest(trTag)
       .within(() => {
-        cy.get(dataLabel.elapsedTime, { timeout: 20 * SEC })
+        cy.get(dataLabel.elapsedTime, { timeout: 3600 * SEC })
           .should('not.be.empty')
           .should('not.contain.text', '1');
       });
   }
-  protected cancel(planData: PlanData): void {
-    const { vmList } = planData; // Getting list of VMs from plan Data
-    const rowAmount = vmList.length; // Getting size of VM list
-    let i;
-    // Iterating through the list of VMs to put a checkbox on each line
-    for (i = 0; i < rowAmount; i++) {
-      cy.get(`[aria-label="Select row ${i}"]`, { timeout: 30 * SEC })
-        .should('be.enabled')
-        .check();
-    }
+  protected cancel(): void {
+    //Checkbox to cancel all Vms which appears near a "Name" data-label only when expected
+    cy.get(`[aria-label="Select all rows"]`, { timeout: 300 * SEC })
+      .should('be.enabled')
+      .check();
   }
 
   protected selectMigrationTypeStep(planData: PlanData): void {
@@ -413,7 +408,7 @@ export class Plan {
     this.run(name, start);
     confirm();
     cy.wait(10000);
-    this.cancel(planData);
+    this.cancel();
     clickOnCancel();
     this.waitForCanceled(name);
     this.restart(planData);
@@ -435,7 +430,7 @@ export class Plan {
       confirm();
       cy.get(tdTag).contains(name).click();
     }
-    this.cancel(planData);
+    this.cancel();
     this.waitForState(planStep.transferDisk);
     clickOnCancel();
     this.waitForCanceled(name);
@@ -458,7 +453,7 @@ export class Plan {
       confirm();
       cy.get(tdTag).contains(name).click();
     }
-    this.cancel(planData);
+    this.cancel();
     this.waitForState(planStep.convtImage);
     clickOnCancel();
     this.waitForCanceled(name);
@@ -476,7 +471,7 @@ export class Plan {
     this.run(name, start);
     confirm();
     cy.wait(10000);
-    this.cancel(planData);
+    this.cancel();
     this.waitForCanceled(name);
   }
   //Method to click on Get Logs and Download logs

--- a/pkg/qe-tests/cypress/integration/tests/Rhv/Cancel_Restart_Test.ts
+++ b/pkg/qe-tests/cypress/integration/tests/Rhv/Cancel_Restart_Test.ts
@@ -11,7 +11,7 @@ describe('Automate cancel and restart of cold migration test', () => {
   const storageMapping = new MappingStorage();
   const plan = new Plan();
 
-  before(() => {
+  beforeEach(() => {
     login(testData.loginData);
     source.create(testData.planData.providerData);
     networkMapping.create(testData.planData.networkMappingData);
@@ -23,7 +23,15 @@ describe('Automate cancel and restart of cold migration test', () => {
     plan.cancel_and_restart(testData.planData);
   });
 
-  after(() => {
+  it.skip('cancel and Restart at Transfer Disk Step', () => {
+    plan.cancelRestartAtTransferDisks(testData.planData);
+  });
+
+  it.skip('cancel and Restart at Convert to Image Step', () => {
+    plan.cancelRestartAtKubevirt(testData.planData);
+  });
+
+  afterEach(() => {
     plan.delete(testData.planData);
     networkMapping.delete(testData.planData.networkMappingData);
     storageMapping.delete(testData.planData.storageMappingData);


### PR DESCRIPTION
	modified:   pkg/qe-tests/cypress/integration/models/plan.ts
	modified:   pkg/qe-tests/cypress/integration/tests/Rhv/Cancel_Restart_Test.ts
@ibragins Please review this PR. It contains following changes
1. Added the code for Checkbox to Cancel Multiple VMs instead removed the for loop Iterating through the list of VMs to put a checkbox on each line
2. Increased timeout in waitForState and made required changes in plan.ts
3. Added in Rhv cancel restart test cases for transferDisk and  Convert to Image Step