### PR TITLE
Bug 2051508: Add field for VDDK init image to vmware provider form

### DIFF
--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -51,7 +51,7 @@ import {
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import { IProviderObject } from '@app/queries/types';
 import { QuerySpinnerMode, ResolvedQuery } from '@app/common/components/ResolvedQuery';
-import { useEditProviderPrefillEffect } from './helpers';
+import { useAddEditProviderPrefillEffect } from './helpers';
 import { LoadingEmptyState } from '@app/common/components/LoadingEmptyState';
 import { ValidatedPasswordInput } from '@app/common/components/ValidatedPasswordInput';
 
@@ -142,6 +142,7 @@ const useAddProviderFormState = (
       ...sourceProviderFields,
       fingerprint: useFormField('', fingerprintSchema.required()),
       isCertificateValid: useFormField(false, yup.boolean()),
+      vddkInitImage: useFormField('', yup.string().label('VDDK init image').required()),
     }),
     ovirt: useFormState({
       ...sourceProviderFields,
@@ -175,7 +176,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
 
   const forms = useAddProviderFormState(clusterProvidersQuery, providerBeingEdited);
 
-  const { isDonePrefilling } = useEditProviderPrefillEffect(forms, providerBeingEdited);
+  const { isDonePrefilling } = useAddEditProviderPrefillEffect(forms, providerBeingEdited);
 
   const providerTypeField = forms.vsphere.fields.providerType;
   const providerType = providerTypeField.value;
@@ -260,7 +261,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
       }
     >
       <ResolvedQuery result={clusterProvidersQuery} errorTitle="Cannot load providers">
-        {!isDonePrefilling ? (
+        {(providerBeingEdited && !isDonePrefilling) || clusterProvidersQuery.isLoading ? (
           <LoadingEmptyState />
         ) : (
           <Form>
@@ -337,6 +338,40 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                     label={getLabelName('pwd', brandPrefix(providerType))}
                     isRequired
                     fieldId="password"
+                  />
+                ) : null}
+                {fields?.vddkInitImage ? (
+                  <ValidatedTextInput
+                    field={fields.vddkInitImage}
+                    label="VDDK init image"
+                    isRequired
+                    fieldId="vddk-init-image"
+                    formGroupProps={{
+                      labelIcon: (
+                        <Popover
+                          bodyContent={
+                            <>
+                              Path of a VDDK image pushed to an image registry.
+                              <br />
+                              For example: <i>{'<registry_route_or_server_path>/vddk:<tag>'}</i>
+                              <br />
+                              See product documentation for more information.
+                            </>
+                          }
+                          hasAutoWidth
+                        >
+                          <Button
+                            variant="plain"
+                            aria-label="More info for VDDK init image field"
+                            onClick={(e) => e.preventDefault()}
+                            aria-describedby="vddk-init-image-info"
+                            className="pf-c-form__group-label-help"
+                          >
+                            <HelpIcon noVerticalAlign />
+                          </Button>
+                        </Popover>
+                      ),
+                    }}
                   />
                 ) : null}
                 {fields?.fingerprint ? (
@@ -544,15 +579,6 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                     }}
                   />
                 ) : null}
-                {/* TODO re-enable this when we have the API capability
-                providerType ? (
-                  <div>
-                    <Button variant="link" isInline icon={<ConnectedIcon />} onClick={() => alert('TODO')}>
-                      Check connection
-                    </Button>
-                  </div>
-                ) : null
-                */}
               </>
             ) : null}
           </Form>

--- a/pkg/web/src/app/Providers/components/AddEditProviderModal/helpers.ts
+++ b/pkg/web/src/app/Providers/components/AddEditProviderModal/helpers.ts
@@ -1,4 +1,4 @@
-import { useSecretQuery } from '@app/queries';
+import { useClusterProvidersQuery, useSecretQuery } from '@app/queries';
 import * as React from 'react';
 import { IProviderObject } from '@app/queries/types';
 import { AddProviderFormState } from './AddEditProviderModal';
@@ -8,54 +8,84 @@ interface IEditProviderPrefillEffect {
   isDonePrefilling: boolean;
 }
 
-export const useEditProviderPrefillEffect = (
+export const useAddEditProviderPrefillEffect = (
   forms: AddProviderFormState,
   providerBeingEdited: IProviderObject | null
 ): IEditProviderPrefillEffect => {
   const [isStartedPrefilling, setIsStartedPrefilling] = React.useState(false);
-  const [isDonePrefilling, setIsDonePrefilling] = React.useState(!providerBeingEdited);
+  const [isDonePrefilling, setIsDonePrefilling] = React.useState(false);
   const secretQuery = useSecretQuery(providerBeingEdited?.spec.secret?.name || null);
+  const clusterProvidersQuery = useClusterProvidersQuery();
+  const providerType = forms.vsphere.values.providerType || providerBeingEdited?.spec.type;
   React.useEffect(() => {
     if (
       !isStartedPrefilling &&
-      providerBeingEdited &&
-      secretQuery.isSuccess &&
-      providerBeingEdited.spec.type
+      (providerBeingEdited ? secretQuery.isSuccess : true) &&
+      clusterProvidersQuery.isSuccess &&
+      providerType
     ) {
       setIsStartedPrefilling(true);
-      const secret = secretQuery.data;
-      const providerType = providerBeingEdited.spec.type;
-      const { fields } = forms[providerType];
-      fields.providerType.prefill(providerType);
-      fields.name.prefill(providerBeingEdited.metadata.name);
-      if (providerType === 'vsphere' || providerType === 'ovirt') {
-        const sourceFields = fields as typeof forms.vsphere.fields | typeof forms.ovirt.fields;
-        sourceFields.username.prefill(atob(secret?.data.user || ''));
-        sourceFields.password.prefill(atob(secret?.data.password || ''));
-      }
-      if (providerType === 'ovirt') {
-        const sourceFields = fields as typeof forms.ovirt.fields;
-        sourceFields.caCert.prefill(atob(secret?.data.cacert || ''));
-      }
-      if (providerType === 'vsphere') {
-        const vmwareFields = forms.vsphere.fields;
-        vmwareFields.hostname.prefill(vmwareUrlToHostname(providerBeingEdited.spec.url || ''));
-        vmwareFields.fingerprint.prefill(atob(secret?.data.thumbprint || ''));
-      }
-      if (providerType === 'ovirt') {
-        const rhvFields = forms.ovirt.fields;
-        rhvFields.hostname.prefill(ovirtUrlToHostname(providerBeingEdited.spec.url || ''));
-      }
-      if (providerType === 'openshift') {
-        const openshiftFields = forms.openshift.fields;
-        openshiftFields.url.prefill(providerBeingEdited.spec.url || '');
-        openshiftFields.saToken.prefill(atob(secret?.data.token || ''));
+      if (!providerBeingEdited) {
+        if (providerType === 'vsphere') {
+          const vmwareFields = forms.vsphere.fields;
+          const vmwareProviders = (clusterProvidersQuery.data.items || []).filter(
+            (provider) => provider.spec.type === 'vsphere'
+          );
+          if (vmwareProviders.length > 0) {
+            const lastCreatedVmwareProvider = vmwareProviders.sort((a, b) =>
+              (a.metadata.creationTimestamp || '') > (b.metadata.creationTimestamp || '') ? -1 : 1
+            )[0];
+            vmwareFields.vddkInitImage.prefill(
+              lastCreatedVmwareProvider.spec.settings?.vddkInitImage || ''
+            );
+          }
+        }
+      } else {
+        const secret = secretQuery.data;
+        const { fields } = forms[providerType];
+        fields.providerType.prefill(providerType);
+        fields.name.prefill(providerBeingEdited.metadata.name);
+        if (providerType === 'vsphere' || providerType === 'ovirt') {
+          const sourceFields = fields as typeof forms.vsphere.fields | typeof forms.ovirt.fields;
+          sourceFields.username.prefill(atob(secret?.data.user || ''));
+          sourceFields.password.prefill(atob(secret?.data.password || ''));
+        }
+        if (providerType === 'ovirt') {
+          const sourceFields = fields as typeof forms.ovirt.fields;
+          sourceFields.caCert.prefill(atob(secret?.data.cacert || ''));
+        }
+        if (providerType === 'vsphere') {
+          const vmwareFields = forms.vsphere.fields;
+          vmwareFields.hostname.prefill(vmwareUrlToHostname(providerBeingEdited.spec.url || ''));
+          vmwareFields.fingerprint.prefill(atob(secret?.data.thumbprint || ''));
+          vmwareFields.vddkInitImage.prefill(
+            providerBeingEdited.spec.settings?.vddkInitImage || ''
+          );
+        }
+        if (providerType === 'ovirt') {
+          const rhvFields = forms.ovirt.fields;
+          rhvFields.hostname.prefill(ovirtUrlToHostname(providerBeingEdited.spec.url || ''));
+        }
+        if (providerType === 'openshift') {
+          const openshiftFields = forms.openshift.fields;
+          openshiftFields.url.prefill(providerBeingEdited.spec.url || '');
+          openshiftFields.saToken.prefill(atob(secret?.data.token || ''));
+        }
       }
       // Wait for effects to run based on field changes first
       window.setTimeout(() => {
         setIsDonePrefilling(true);
       }, 0);
     }
-  }, [isStartedPrefilling, providerBeingEdited, secretQuery.data, secretQuery.isSuccess, forms]);
+  }, [
+    isStartedPrefilling,
+    providerBeingEdited,
+    secretQuery.data,
+    secretQuery.isSuccess,
+    clusterProvidersQuery.data,
+    clusterProvidersQuery.isSuccess,
+    forms,
+    providerType,
+  ]);
   return { isDonePrefilling };
 };

--- a/pkg/web/src/app/client/helpers.ts
+++ b/pkg/web/src/app/client/helpers.ts
@@ -128,8 +128,10 @@ export const convertFormValuesToProvider = (
 ): IProviderObject => {
   const name = values.name;
   let url = '';
+  const specSettings: IProviderObject['spec']['settings'] = {};
   if (providerType === 'vsphere') {
     url = vmwareHostnameToUrl((values as VMwareProviderFormValues).hostname);
+    specSettings.vddkInitImage = (values as VMwareProviderFormValues).vddkInitImage;
   }
   if (providerType === 'ovirt') {
     url = ovirtHostnameToUrl((values as RHVProviderFormValues).hostname);
@@ -147,6 +149,7 @@ export const convertFormValuesToProvider = (
     spec: {
       type: values.providerType,
       url,
+      ...(Object.keys(specSettings).length > 0 ? { settings: specSettings } : {}),
     },
   };
 };

--- a/pkg/web/src/app/queries/mocks/providers.mock.ts
+++ b/pkg/web/src/app/queries/mocks/providers.mock.ts
@@ -38,6 +38,9 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
           namespace: 'openshift-migration',
           name: 'boston',
         },
+        settings: {
+          vddkInitImage: 'quay.io/username/vddk',
+        },
       },
       status: {
         conditions: [
@@ -93,6 +96,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         ...vmwareProvider1.object.metadata,
         name: 'vcenter-2',
         uid: 'mock-uid-vcenter-2',
+        creationTimestamp: '2020-08-22T18:36:41.468Z',
       },
       status: {
         conditions: [
@@ -120,6 +124,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         ...vmwareProvider1.object.metadata,
         name: 'vcenter-3',
         uid: 'mock-uid-vcenter-3',
+        creationTimestamp: '2020-08-23T18:36:41.468Z',
       },
       status: {
         conditions: [

--- a/pkg/web/src/app/queries/types/providers.types.ts
+++ b/pkg/web/src/app/queries/types/providers.types.ts
@@ -14,6 +14,9 @@ export interface IProviderObject extends ICR {
     type: ProviderType | null;
     url?: string; // No url = host provider
     secret?: INameNamespaceRef;
+    settings?: {
+      vddkInitImage?: string; // VMware only
+    };
   };
   status?: {
     conditions: IStatusCondition[];


### PR DESCRIPTION
Adds a required form field "VDDK init image" when creating or editing a VMware provider. This value is initially blank for the first VMware provider being created, but will prefill itself from the last used value if another VMware provider is present.

Had to modify the prefill hook logic so it will run both in create and edit modes, since this initial value depends on a query.

![Screen Shot 2022-02-07 at 12 24 55 PM](https://user-images.githubusercontent.com/811963/152839758-e6e95470-e200-443f-a110-4fa77afd52c9.png)

