### PR TITLE
[QE] Added VDDK Image field in VMware Provider

### DIFF
--- a/pkg/qe-tests/cypress/integration/models/providerVmware.ts
+++ b/pkg/qe-tests/cypress/integration/models/providerVmware.ts
@@ -28,6 +28,7 @@ import {
   certificateCheck,
   networkField,
   SelectMigrationNetworkButton,
+  vddkImage,
 } from '../views/providerVmware.view';
 import { providerMenu } from '../views/provider.view';
 import { VmwareProviderData } from '../types/types';
@@ -47,6 +48,11 @@ export class ProviderVmware extends Provider {
 
   protected fillPassword(password: string): void {
     inputText(instancePassword, password);
+  }
+
+  //Fill the VDDK Image Field
+  protected fillVddkImage(image: string): void {
+    inputText(vddkImage, image);
   }
 
   //Now we have verify Certificate option in place of fingerprint
@@ -88,24 +94,16 @@ export class ProviderVmware extends Provider {
   }
 
   protected runWizard(providerData: VmwareProviderData): void {
-    const { name, hostname, username, password } = providerData;
+    const { name, hostname, username, password, image } = providerData;
     super.runWizard(providerData);
     this.fillName(name);
     this.fillHostname(hostname);
     this.fillUsername(username);
     this.fillPassword(password);
+    this.fillVddkImage(image);
     this.verifyCertificate();
     click(addButtonModal);
     cy.wait(2 * SEC);
-    // Temporary fix for VMWare provider VDDK init image
-    const vddkImage = 'cnv-qe-server.rhevdev.lab.eng.rdu2.redhat.com:5000/vddk-images/vddk:v702';
-    cy.exec(
-      `oc -nopenshift-mtv  patch provider/${name} --type json -p '[{ "op": "add", "path": "/spec/settings", "value": {} }]'`
-    );
-    cy.exec(
-      `oc -nopenshift-mtv patch provider/${name} --type json -p '[{ "op": "add", "path": "/spec/settings/vddkInitImage", "value": ${vddkImage} }]'`
-    );
-    // End of fix
   }
 
   protected populate(providerData: VmwareProviderData): void {

--- a/pkg/qe-tests/cypress/integration/tests/ocpvirt/ocpVirtConfig.ts
+++ b/pkg/qe-tests/cypress/integration/tests/ocpvirt/ocpVirtConfig.ts
@@ -5,7 +5,6 @@ import {
   TestData,
   OcpVirtData,
   MappingPeer,
-  HookData,
 } from '../../types/types';
 import { storageType } from '../../types/constants';
 

--- a/pkg/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts
+++ b/pkg/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts
@@ -16,6 +16,7 @@ const v2v_vmware_providername = Cypress.env('v2v_vmware_providername');
 const v2v_vmware_username = Cypress.env('v2v_vmware_username');
 const v2v_vmware_password = Cypress.env('v2v_vmware_password');
 const v2v_vmware_hostname = Cypress.env('v2v_vmware_hostname');
+const v2v_vmware_vddkImage = Cypress.env('v2v_vmware_vddkImage');
 const vmwareClusterName = Cypress.env('v2v_vmwareClusterName');
 const sourceProviderStorage = Cypress.env('v2v_vmwareStorageSource');
 const vmListArray = Cypress.env('vm_list');
@@ -45,6 +46,7 @@ export const providerData: VmwareProviderData = {
   hostname: v2v_vmware_hostname,
   username: v2v_vmware_username,
   password: v2v_vmware_password,
+  image: v2v_vmware_vddkImage,
   esxiHostList: hostList,
 };
 

--- a/pkg/qe-tests/cypress/integration/types/types.ts
+++ b/pkg/qe-tests/cypress/integration/types/types.ts
@@ -28,6 +28,7 @@ export type VmwareProviderData = {
   hostname?: string;
   username?: string;
   password?: string;
+  image?: string;
   esxiHostList?: esxiHostList;
 };
 

--- a/pkg/qe-tests/cypress/integration/views/providerVmware.view.ts
+++ b/pkg/qe-tests/cypress/integration/views/providerVmware.view.ts
@@ -2,11 +2,11 @@ export const instanceName = '#name';
 export const instanceHostname = '#hostname';
 export const instanceUsername = '#username';
 export const instancePassword = '#password';
-export const instanceFingerprint = '#fingerprint';
 export const addButtonModal = '#modal-confirm-button';
 export const verifyCertificateButton = '#certificate-confirm-button';
 export const certificateCheck = '#certificate-check';
 export const SelectMigrationNetworkButton = 'button.pf-c-button.pf-m-secondary';
+export const vddkImage = '#vddk-init-image';
 
 export enum dataLabel {
   name = '[data-label=Name]',

--- a/pkg/qe-tests/cypress/utils/utils.ts
+++ b/pkg/qe-tests/cypress/utils/utils.ts
@@ -1,4 +1,4 @@
-import { LoginData, TestData } from '../integration/types/types';
+import { LoginData } from '../integration/types/types';
 import * as loginView from '../integration/views/login.view';
 import {
   button,


### PR DESCRIPTION
@ibragins Please Review the PR! This contains the additional field in vmware provider test which adds the Vddk Image and which can be provided as an external string.
        modified:   pkg/qe-tests/cypress/integration/models/providerVmware.ts
	modified:   pkg/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts
	modified:   pkg/qe-tests/cypress/integration/types/types.ts
	modified:   pkg/qe-tests/cypress/integration/views/providerVmware.view.ts