### PR TITLE
Bug 2034810: Add ids and aria-labels for ESXi host configuration status, and other missing ids

### DIFF
--- a/pkg/web/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/pkg/web/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -83,7 +83,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
         <Text component="p">{instructionText}</Text>
       </TextContent>
       {builderItems.map((item, itemIndex) => {
-        const key = item.source ? `${item.source.id}` : `empty-${itemIndex}`;
+        const key = item.source ? `${item.source.name}` : 'empty';
         return (
           <Grid key={key}>
             {itemIndex === 0 ? (
@@ -113,7 +113,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                 </Bullseye>
               ) : (
                 <MappingSourceSelect
-                  id={`mapping-sources-for-${key}`}
+                  id={`mapping-source-for-${key}`}
                   builderItems={builderItems}
                   itemIndex={itemIndex}
                   setBuilderItems={setBuilderItems}

--- a/pkg/web/src/app/Mappings/components/MappingBuilder/MappingSourceSelect.tsx
+++ b/pkg/web/src/app/Mappings/components/MappingBuilder/MappingSourceSelect.tsx
@@ -53,6 +53,7 @@ export const MappingSourceSelect: React.FunctionComponent<IMappingSourceSelectPr
   return (
     <SimpleSelect
       id={id}
+      toggleId={id}
       aria-label="Select source"
       className="mapping-item-select"
       variant="typeahead"

--- a/pkg/web/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
+++ b/pkg/web/src/app/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
@@ -90,6 +90,7 @@ export const MappingTargetSelect: React.FunctionComponent<IMappingTargetSelectPr
   return (
     <SimpleSelect
       id={id}
+      toggleId={id}
       aria-label="Select target"
       className="mapping-item-select"
       variant="typeahead"

--- a/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -58,19 +58,33 @@ export const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHo
                   <Popover
                     hasAutoWidth
                     bodyContent={
-                      <StatusIcon status="Ok" label="Not configured, using default network" />
+                      <div id={`host-status-popover-${host.name}`}>
+                        <StatusIcon status="Ok" label="Not configured, using default network" />
+                      </div>
                     }
                   >
-                    <Button variant="link" isInline>
+                    <Button
+                      variant="link"
+                      isInline
+                      id={`host-status-icon-${host.name}`}
+                      aria-label="Ok"
+                    >
                       <StatusIcon status="Ok" />
                     </Button>
                   </Popover>
                 ) : !hostConfig.status ? (
                   <Tooltip content="Configuring">
-                    <StatusIcon status="Loading" />
+                    <span id={`host-status-icon-${host.name}`} aria-label="Loading">
+                      <StatusIcon status="Loading" />
+                    </span>
                   </Tooltip>
                 ) : (
-                  <StatusCondition status={hostConfig.status} hideLabel />
+                  <StatusCondition
+                    status={hostConfig.status}
+                    hideLabel
+                    buttonId={`host-status-icon-${host.name}`}
+                    popoverBodyId={`host-status-popover-${host.name}`}
+                  />
                 )}
                 <span className={spacing.mlSm}>{formatHostNetworkAdapter(networkAdapter)}</span>
               </>

--- a/pkg/web/src/app/common/components/MustGatherModal.tsx
+++ b/pkg/web/src/app/common/components/MustGatherModal.tsx
@@ -61,6 +61,7 @@ export const MustGatherModal: React.FunctionComponent = () => {
       }}
       actions={[
         <Button
+          id="modal-confirm-button"
           key="confirm"
           variant="primary"
           onClick={() => {
@@ -70,6 +71,7 @@ export const MustGatherModal: React.FunctionComponent = () => {
           Get logs
         </Button>,
         <Button
+          id="modal-cancel-button"
           key="cancel"
           variant="link"
           onClick={() => {

--- a/pkg/web/src/app/common/components/StatusCondition.tsx
+++ b/pkg/web/src/app/common/components/StatusCondition.tsx
@@ -9,12 +9,16 @@ interface IStatusConditionProps {
   status?: { conditions?: IStatusCondition[] };
   unknownFallback?: React.ReactNode;
   hideLabel?: boolean;
+  buttonId?: string;
+  popoverBodyId?: string;
 }
 
 export const StatusCondition: React.FunctionComponent<IStatusConditionProps> = ({
   status,
   unknownFallback = null,
   hideLabel = false,
+  buttonId,
+  popoverBodyId,
 }: IStatusConditionProps) => {
   if (!status) return <StatusIcon status="Loading" label="Validating" />;
 
@@ -56,7 +60,7 @@ export const StatusCondition: React.FunctionComponent<IStatusConditionProps> = (
     <Popover
       hasAutoWidth
       bodyContent={
-        <>
+        <div {...(popoverBodyId ? { id: popoverBodyId } : {})}>
           {conditions.map((condition) => {
             const severity = getMostSeriousCondition([condition]);
             return (
@@ -67,10 +71,10 @@ export const StatusCondition: React.FunctionComponent<IStatusConditionProps> = (
               />
             );
           })}
-        </>
+        </div>
       }
     >
-      <Button variant="link" isInline>
+      <Button variant="link" isInline {...(buttonId ? { id: buttonId } : {})} aria-label={label}>
         {icon}
       </Button>
     </Popover>


### PR DESCRIPTION
Adds `id` and `aria-label` attributes for QE to use for test automation. This addresses https://bugzilla.redhat.com/show_bug.cgi?id=2034810 and also adds some unrelated ids @ibragins has asked for.

For ESXi host status:
* The icon in each host's row now has either a button or a span around it with an `id` of the format `host-status-icon-${host.name}`, where `${host.name}` is the host's name as displayed in the Name column. For example, for the host "esx12.v2v.bos.redhat.com" the id will be `host-status-icon-esx12.v2v.bos.redhat.com`. This element will be a span if the status is loading, or a button otherwise.
* The element with that id will also have an `aria-label` attribute reflecting what icon is displayed, which will be one of `Loading`, `Ok`, `Info`, `Warning` or `Error` depending on the conditions of the Host CR. Most likely it will only ever be `Loading`, `Ok` or `Error`.
* For any of these icons which are clickable to display a popover with specific status details, the button identified by the above id can be clicked to reveal a popover with an id of a similar format `host-status-popover-${host.name}`, which will contain the specific error/info text.

For the mapping builder (both on the Mappings page and in the Plan wizard):
* The `<button>` elements that toggle each select dropdown for selecting source or target resources in the mapping now have `id`s of the format `mapping-${sourceOrTarget}-for-${sourceName}`, where `${sourceOrTarget}` is either `source` or `target`, and `${sourceName}` is either the name of the source resource or the string `empty`. For example:
  * If you're selecting a source resource to map (not applicable to the wizard), the id will be `mapping-source-for-empty`. If you then select "rhv-network-1", the id will change to `mapping-source-for-rhv-network-1`. Only one empty source dropdown can be present at a time, so the ids will remain unique.
  * If you're selecting the target for the source network called "rhv-network-1", the id for that button will be `mapping-target-for-rhv-network-1`.
* The text filter `<input>` just before each of those buttons has the same id with the suffix `-select-typeahead`.
  * For example, the text field in the dropdown mentioned above is `mapping-target-for-rhv-network-1-select-typeahead`.

For the "Get logs" confirmation modal:
* The confirm and cancel buttons now have the ids `modal-confirm-button` and `modal-cancel-button`, like all our other confirm modals already had.