### PR TITLE
Bug 2057617: Show path under source datastores/networks in read-only mapping views

### DIFF
--- a/pkg/web/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/pkg/web/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Grid, GridItem, Text } from '@patternfly/react-core';
+import { Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 
@@ -51,33 +51,48 @@ export const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps>
               {getMappingSourceTitle(mappingType, sourceProviderType)}
             </Text>
           </GridItem>
-          <GridItem span={2}></GridItem>
+          <GridItem span={2} />
           <GridItem span={5} className={spacing.pbSm}>
             <Text className={text.fontWeightBold}>{getMappingTargetTitle(mappingType)}</Text>
           </GridItem>
         </Grid>
-        {mappingItemGroups.map((items, index) => {
+        {mappingItemGroups.map((items, itemGroupIndex) => {
           const targetName = getMappingItemTargetName(
             items[0],
             mappingType,
             mappingResourceQueries.availableTargets
           );
-          const isLastGroup = index === mappingItemGroups.length - 1;
+          const isLastGroup = itemGroupIndex === mappingItemGroups.length - 1;
           return (
             <Grid key={targetName} className={!isLastGroup ? spacing.mbLg : ''}>
               <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
                 <ul>
-                  {items.map((item) => {
+                  {items.map((item, itemIndex) => {
                     const source = getMappingSourceById(
                       mappingResourceQueries.availableSources,
                       item.source.id
                     );
                     const sourceName = source ? source.name : '';
                     return (
-                      <li key={sourceName}>
-                        <TruncatedText>
-                          {sourceName || <span className="missing-item">Not available</span>}
-                        </TruncatedText>
+                      <li
+                        key={`${sourceName}-${source?.path || ''}`}
+                        className={itemIndex !== items.length - 1 ? spacing.mbSm : ''}
+                      >
+                        <TextContent>
+                          <TruncatedText>
+                            {sourceName || <span className="missing-item">Not available</span>}
+                          </TruncatedText>
+                          {source?.path ? (
+                            <TruncatedText>
+                              <Text
+                                component="small"
+                                style={{ fontSize: 'var(--pf-global--FontSize--xs)' }}
+                              >
+                                {source.path}
+                              </Text>
+                            </TruncatedText>
+                          ) : null}
+                        </TextContent>
                       </li>
                     );
                   })}

--- a/pkg/web/src/app/Mappings/components/helpers.ts
+++ b/pkg/web/src/app/Mappings/components/helpers.ts
@@ -48,10 +48,10 @@ export const getMappingSourceTitle = (
   providerType: ProviderType
 ): string => {
   if (mappingType === MappingType.Network) {
-    return 'Source datacenters / networks';
+    return 'Source networks';
   }
   if (mappingType === MappingType.Storage) {
-    return `Source datacenters / ${getStorageTitle(providerType)}`;
+    return `Source ${getStorageTitle(providerType)}`;
   }
   return '';
 };

--- a/pkg/web/src/app/queries/mocks/mappings.mock.ts
+++ b/pkg/web/src/app/queries/mocks/mappings.mock.ts
@@ -181,6 +181,15 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             type: 'multus',
           },
         },
+        {
+          source: {
+            id: MOCK_VMWARE_NETWORKS[2].id,
+          },
+          destination: {
+            ...nameAndNamespace(MOCK_OPENSHIFT_NETWORKS[1]),
+            type: 'multus',
+          },
+        },
       ],
     },
   };


### PR DESCRIPTION
When viewing a mapping on either the mappings page (expanded content in the table rows) or the plan details modal (reachable from the kebab menu on a plan in the plans page), we'll now show the `path` property from the datastore/network in the inventory as small grey text underneath the name of the datastore/network.

![Screen Shot 2022-02-24 at 5 04 28 PM](https://user-images.githubusercontent.com/811963/155616182-363ec1b6-0b77-4e93-9a33-dfbeafa582d8.png)

![Screen Shot 2022-02-24 at 5 04 59 PM](https://user-images.githubusercontent.com/811963/155616192-9c39a1fe-815f-4d93-bbf3-7c91056278e9.png)

