### PR TITLE
Bug 2047467: Show source mapping resource path when editing mappings in wizard to distinguish duplicate names

### DIFF
--- a/pkg/web/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/pkg/web/src/app/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -14,6 +14,7 @@ import { ConditionalTooltip } from '@app/common/components/ConditionalTooltip';
 import './MappingBuilder.css';
 import { ProviderType } from '@app/common/constants';
 import { getStorageTitle } from '@app/common/helpers';
+import { TruncatedText } from '@app/common/components/TruncatedText';
 
 export interface IMappingBuilderItem {
   source: MappingSource | null;
@@ -83,7 +84,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
         <Text component="p">{instructionText}</Text>
       </TextContent>
       {builderItems.map((item, itemIndex) => {
-        const key = item.source ? `${item.source.name}` : 'empty';
+        const key = item.source ? item.source.path : 'empty';
         return (
           <Grid key={key}>
             {itemIndex === 0 ? (
@@ -109,7 +110,19 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
             <GridItem span={5} className={`mapping-builder-box ${spacing.pSm}`}>
               {isWizardMode && item.source ? (
                 <Bullseye style={{ justifyContent: 'left' }} className={spacing.plSm}>
-                  {item.source.name}
+                  <TextContent>
+                    <TruncatedText>{item.source.name}</TruncatedText>
+                    {item.source.path ? (
+                      <TruncatedText>
+                        <Text
+                          component="small"
+                          style={{ fontSize: 'var(--pf-global--FontSize--xs)' }}
+                        >
+                          {item.source.path}
+                        </Text>
+                      </TruncatedText>
+                    ) : null}
+                  </TextContent>
                 </Bullseye>
               ) : (
                 <MappingSourceSelect
@@ -130,17 +143,19 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
               </Bullseye>
             </GridItem>
             <GridItem span={5} className={`mapping-builder-box ${spacing.pSm}`}>
-              <MappingTargetSelect
-                id={`mapping-target-for-${key}`}
-                builderItems={builderItems}
-                itemIndex={itemIndex}
-                setBuilderItems={setBuilderItems}
-                availableTargets={availableTargets}
-                mappingType={mappingType}
-                // Maybe use these instead of extraSelectMargin if we can get it to be dynamic to always fit the screen
-                //menuAppendTo="parent"
-                //maxHeight="200px"
-              />
+              <Bullseye style={{ justifyContent: 'left' }} className={spacing.plSm}>
+                <MappingTargetSelect
+                  id={`mapping-target-for-${key}`}
+                  builderItems={builderItems}
+                  itemIndex={itemIndex}
+                  setBuilderItems={setBuilderItems}
+                  availableTargets={availableTargets}
+                  mappingType={mappingType}
+                  // Maybe use these instead of extraSelectMargin if we can get it to be dynamic to always fit the screen
+                  //menuAppendTo="parent"
+                  //maxHeight="200px"
+                />
+              </Bullseye>
             </GridItem>
             {isWizardMode ? null : (
               <GridItem span={1}>


### PR DESCRIPTION
The observed behavior in https://bugzilla.redhat.com/show_bug.cgi?id=2047467 is misleading. In the example given, the mapping of the `ovirtmgmt` network to the default pod network appears twice. However, due to the same issue fixed elsewhere in the UI by https://github.com/konveyor/forklift-ui/pull/922 (http://bugzilla.redhat.com/show_bug.cgi?id=2057617), these source networks were not displaying their full paths and it was unclear that it is in fact two different networks.

The reason this was only happening when selecting an existing mapping is that the selected mapping includes source networks that do not match the selected VMs for the plan (they are from a different datacenter). The ones that are not associated with the VMs being migrated are not included when creating a new mapping in the wizard, but when you select an existing mapping we show all the contents of that mapping (even though some may be irrelevant), to alleviate confusion we saw in the past where users didn't know why their whole mapping wasn't showing up.

This PR simply repeats the fix from #922 in the one remaining place where we display mapping sources: the mapping builder in the wizard. This was left out of #922 because the assumption was that all items in this view would come from the same datacenter, but we overlooked this case of existing mappings including things from other datacenters, so it applies here as well.

Now you can tell the difference between the two networks being mapped, and see that the lines are not in fact duplicates after all:

![Screen Shot 2022-02-28 at 1 06 24 PM](https://user-images.githubusercontent.com/811963/156036842-9e16aeff-f741-4d9d-87d5-6ac80cd58a66.png)

