### PR TITLE
Bug 2059108: Fix canceled icon that was accidentally swapped to FA baby-icon :)

### DIFF
--- a/pkg/web/src/app/common/components/CanceledIcon.tsx
+++ b/pkg/web/src/app/common/components/CanceledIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
-import BanIcon from '@patternfly/react-icons/dist/esm/icons/baby-icon';
+import BanIcon from '@patternfly/react-icons/dist/esm/icons/ban-icon';
 import { global_disabled_color_100 as canceledColor } from '@patternfly/react-tokens';
 
 // TODO add a custom icon prop to StatusIcon so repeating these flex props isn't necessary. Also maybe a built-in canceled type.


### PR DESCRIPTION
In this line: https://github.com/konveyor/forklift-ui/pull/847/files#diff-c3deb2bfe974bc28c9d8169bf135a13d98e1f504a073e376cfd55d653bb93a6eR3, when refactoring our icon imports, the `ban-icon` used as our Canceled icon was replaced with `baby-icon` (due to autocorrect?) which indeed exists in font-awesome, resulting in a cute little baby in our UI instead of the desired icon:

![Screen Shot 2022-02-28 at 1 30 19 PM](https://user-images.githubusercontent.com/811963/156038462-e5940a1d-dad5-445e-a64d-dc31b7b37bf4.png)

This PR corrects the typo and restores the original icon:

![Screen Shot 2022-02-28 at 1 31 10 PM](https://user-images.githubusercontent.com/811963/156038557-5e07f408-b37c-4bc8-ab3b-82dbf21de277.png)

