### PR TITLE
Bug 2018983: Ensure k8s names will not be longer than 63 characters when configuring hosts

### DIFF
--- a/pkg/web/src/app/queries/helpers.ts
+++ b/pkg/web/src/app/queries/helpers.ts
@@ -168,3 +168,8 @@ export const areAssociatedProvidersReady = (
     );
   return areProvidersReady;
 };
+
+export const truncateK8sString = (prefix: string, suffix = '', generateName = false) => {
+  const targetPrefixLength = 63 - (generateName ? 5 : 0) - suffix.length;
+  return `${prefix.slice(0, targetPrefixLength)}${suffix}`;
+};

--- a/pkg/web/src/app/queries/hosts.ts
+++ b/pkg/web/src/app/queries/hosts.ts
@@ -9,6 +9,7 @@ import {
   nameAndNamespace,
   mockKubeList,
   sortByName,
+  truncateK8sString,
 } from './helpers';
 import { MOCK_HOSTS, MOCK_HOST_CONFIGS } from './mocks/hosts.mock';
 import { IHost, IHostConfig, INameNamespaceRef, ISecret, IVMwareProvider } from './types';
@@ -65,7 +66,7 @@ export const getExistingHostConfigs = (
   );
 
 const getHostConfigRef = (provider: IVMwareProvider, host: IHost) => ({
-  name: `${provider.name}-${host.id}-config`,
+  name: truncateK8sString(provider.name, `-${host.id}-config`),
   namespace: META.namespace,
 });
 
@@ -84,7 +85,7 @@ const generateSecret = (
   kind: 'Secret',
   metadata: {
     ...(secretBeingReusedRef || {
-      generateName: `${provider.name}-${host.id}-`,
+      generateName: truncateK8sString(provider.name, `-${host.id}-`, true),
       namespace: META.namespace,
     }),
     labels: {


### PR DESCRIPTION
When we configure the migration network for vsphere hosts, we create Secret and Host CRs with names based on the provider name and the host id. If the provider name is very long, as in the BZ example of `vsphere-6.5-rhev-node-05.rdu2.scalelab.redhat.com`, the additional characters of the host id and the `generateName` suffix can put the Secret and/or Host CR name over the 63 character limit for k8s resource names.

This PR adds a `truncateK8sString` helper function which can be used to limit these names to 63 characters while preserving the desired suffix, by truncating the prefix (provider name, in this case). In the case where it is used for a `generateName` field, an additional 5 characters are shaved off to leave room for the generated suffix.