### PR TITLE
Bug 2049638: Add tooltip explanation on 'Select migration network' button

### DIFF
--- a/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
+++ b/pkg/web/src/app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.tsx
@@ -16,7 +16,6 @@ import { IHost, IVMwareProvider } from '@app/queries/types';
 import { SelectNetworkModal } from './SelectNetworkModal';
 import { useHostConfigsQuery } from '@app/queries';
 import { findHostConfig, findSelectedNetworkAdapter, formatHostNetworkAdapter } from './helpers';
-import { ConditionalTooltip } from '@app/common/components/ConditionalTooltip';
 import { ResolvedQuery } from '@app/common/components/ResolvedQuery';
 import { StatusCondition } from '@app/common/components/StatusCondition';
 import '@app/Providers/components/VMwareProviderHostsTable/VMwareProviderHostsTable.css';
@@ -136,12 +135,13 @@ export const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHo
     <ResolvedQuery result={hostConfigsQuery} errorTitle="Cannot load host configurations">
       <Level>
         <LevelItem>
-          <ConditionalTooltip
-            isTooltipEnabled={commonNetworkAdapters.length === 0}
+          <Tooltip
             content={
               selectedItems.length === 0
                 ? 'Select at least one host'
-                : 'Selected hosts have no networks in common'
+                : commonNetworkAdapters.length === 0
+                ? 'Selected hosts have no networks in common'
+                : 'Select a network for migration data transfer for the selected hosts'
             }
           >
             <div>
@@ -153,7 +153,7 @@ export const VMwareProviderHostsTable: React.FunctionComponent<IVMwareProviderHo
                 Select migration network
               </Button>
             </div>
-          </ConditionalTooltip>
+          </Tooltip>
         </LevelItem>
         <LevelItem>
           <Pagination {...paginationProps} widgetId="providers-table-pagination-top" />


### PR DESCRIPTION
On the VMware Hosts table, when no other tooltip needs to be displayed on the "Select migration network" button (other tooltips are "Select at least one host" or "Selected hosts have no networks in common"), the following tooltip will be shown:

![Screen Shot 2022-02-28 at 3 32 39 PM](https://user-images.githubusercontent.com/811963/156054596-a97a6fa4-ef70-41f5-9d89-9709cbf3b749.png)
 