### PR TITLE
Bug 2059879: Invalidate cached secrets when patching a provider CR

### DIFF
--- a/pkg/web/src/app/queries/providers.ts
+++ b/pkg/web/src/app/queries/providers.ts
@@ -241,6 +241,7 @@ export const usePatchProviderMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries('cluster-providers');
       queryClient.invalidateQueries('inventory-providers');
+      queryClient.invalidateQueries('secrets');
       onSuccess && onSuccess();
     },
   });

--- a/pkg/web/src/app/queries/secrets.ts
+++ b/pkg/web/src/app/queries/secrets.ts
@@ -10,7 +10,7 @@ export const useSecretQuery = (secretName: string | null): UseQueryResult<ISecre
   const client = useAuthorizedK8sClient();
   return useMockableQuery<ISecret>(
     {
-      queryKey: ['secret', secretName],
+      queryKey: ['secrets', secretName],
       queryFn: async () => (await client.get<ISecret>(secretResource, secretName || '')).data,
       refetchInterval: usePollingContext().refetchInterval,
       enabled: !!secretName,


### PR DESCRIPTION
When the user edits a provider, we patch both the Provider CR and the Secret CR which stores its username and password, and in the `onSuccess` callback of that mutation we invalidate the queries with keys `cluster-providers` and `inventory-providers`. But, we failed to invalidate the `secrets` query there. As a result, the copy of that secret first cached when the Edit Provider modal was first opened is retained and reused when opening the modal a second time, rather than using the one that was updated from the first time.

This PR simply invalidates that query along with the provider queries so we'll always be working with a fresh copy of the updated secret.

Note that we pass just the prefix of the queryKey, the string `'secrets'`, and not the specific secret name. This will invalidate all queries containing that as part of their key (see https://react-query.tanstack.com/guides/query-invalidation), just because it's simpler.