### PR TITLE
[Backport] Bug 2059879: Invalidate cached secrets when patching a provider CR

### DIFF
--- a/pkg/web/src/app/queries/providers.ts
+++ b/pkg/web/src/app/queries/providers.ts
@@ -241,6 +241,7 @@ export const usePatchProviderMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries('cluster-providers');
       queryClient.invalidateQueries('inventory-providers');
+      queryClient.invalidateQueries('secrets');
       onSuccess && onSuccess();
     },
   });

--- a/pkg/web/src/app/queries/secrets.ts
+++ b/pkg/web/src/app/queries/secrets.ts
@@ -10,7 +10,7 @@ export const useSecretQuery = (secretName: string | null): UseQueryResult<ISecre
   const client = useAuthorizedK8sClient();
   return useMockableQuery<ISecret>(
     {
-      queryKey: ['secret', secretName],
+      queryKey: ['secrets', secretName],
       queryFn: async () => (await client.get<ISecret>(secretResource, secretName || '')).data,
       refetchInterval: usePollingContext().refetchInterval,
       enabled: !!secretName,


### PR DESCRIPTION
Backports #933