### PR TITLE
[QE] Few Fixes for Tier0 Tests

### DIFF
--- a/pkg/qe-tests/cypress/integration/models/plan.ts
+++ b/pkg/qe-tests/cypress/integration/models/plan.ts
@@ -278,9 +278,7 @@ export class Plan {
       .contains(name)
       .closest(trTag)
       .within(() => {
-        cy.get(dataLabel.status).contains(planSuccessMessage, {
-          timeout: 3600 * SEC,
-        });
+        cy.get(dataLabel.status).contains(planSuccessMessage, { timeout: 3600 * SEC });
       });
   }
 

--- a/pkg/qe-tests/cypress/integration/tests/Rhv/config_separate_mapping_rhv.ts
+++ b/pkg/qe-tests/cypress/integration/tests/Rhv/config_separate_mapping_rhv.ts
@@ -48,7 +48,7 @@ export const networkMappingPeer: MappingPeer[] = [
 export const storageMappingPeer: MappingPeer[] = [
   {
     sProvider: 'v2v-fc',
-    dProvider: storageType.cephRbd,
+    dProvider: storageType.nfs,
   },
 ];
 

--- a/pkg/qe-tests/cypress/integration/tests/tier0/tier0_tests_vmware.ts
+++ b/pkg/qe-tests/cypress/integration/tests/tier0/tier0_tests_vmware.ts
@@ -64,7 +64,6 @@ describe('Automate cancel and restart of cold migration test', () => {
     networkMapping.create(testData.planData.networkMappingData);
     storageMapping.create(testData.planData.storageMappingData);
     plan.create(testData.planData);
-    plan.execute(testData.planData);
   });
 
   it('Cancel and restart migration', () => {

--- a/pkg/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts
+++ b/pkg/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts
@@ -64,7 +64,7 @@ export const networkMappingPeer: MappingPeer[] = [
 export const storageMappingPeer: MappingPeer[] = [
   {
     sProvider: sourceProviderStorage,
-    dProvider: storageType.cephRbd,
+    dProvider: storageType.nfs,
   },
 ];
 


### PR DESCRIPTION
1. Set dProvider storageType to nfs instead of ceph
2. From tier0_vmware cancel_restart tests removed execute method
3. Minor change fixing the spacing in " waitForSuccess" method
modified:   pkg/qe-tests/cypress/integration/test/Rhv/config_separate_mapping.ts
modified:   pkg/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts