### PR TITLE
[QE] Fixes for warm migration automation

### DIFF
--- a/pkg/qe-tests/cypress/integration/models/plan.ts
+++ b/pkg/qe-tests/cypress/integration/models/plan.ts
@@ -348,7 +348,8 @@ export class Plan {
       cy.get(`[aria-label="Select row ${i}"]`, { timeout: 30 * SEC })
         .closest(trTag)
         .within(() => {
-          cy.get('[data-label="Status"]', { timeout: 3600 * SEC }).should(
+          //VM's completes the 1 precopy
+          cy.get('[data-label="Status"]', { timeout: 6000 * SEC }).should(
             'contain.text',
             'Idle - Next incremental copy will begin in less than 1 minute'
           );
@@ -440,7 +441,6 @@ export class Plan {
     applyAction(name, restartButton);
     confirm(); //Added Confirm Button
     if (warmMigration) {
-      Plan.openList();
       this.waitForIncrementalCopies(planData);
       this.schedule_cutover(planData);
     }

--- a/pkg/qe-tests/cypress/integration/tests/Rhv/config_separate_mapping_rhv.ts
+++ b/pkg/qe-tests/cypress/integration/tests/Rhv/config_separate_mapping_rhv.ts
@@ -6,6 +6,7 @@ import {
   TestData,
   RhvProviderData,
   HookData,
+  CutoverData,
 } from '../../types/types';
 import { providerType, storageType } from '../../types/constants';
 const url = Cypress.env('url');
@@ -19,6 +20,8 @@ const v2v_rhv_clustername = Cypress.env('v2v_rhv_clustername');
 const v2v_rhv_cert = Cypress.env('v2v_rhv_cert');
 const preAnsiblePlaybook = Cypress.env('preAnsiblePlaybook');
 const postAnsiblePlaybook = Cypress.env('postAnsiblePlaybook');
+const scheduled_date = Cypress.env('scheduled_date');
+const scheduled_time = Cypress.env('scheduled_time');
 
 export const loginData: LoginData = {
   username: user_login,
@@ -72,6 +75,11 @@ export const preHookData: HookData = {
 
 export const postHookData: HookData = {
   ansiblePlaybook: postAnsiblePlaybook,
+};
+
+export const cutoverData: CutoverData = {
+  date: scheduled_date,
+  time: scheduled_time,
 };
 
 export const originalPlanData: PlanData = {

--- a/pkg/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts
+++ b/pkg/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts
@@ -7,6 +7,7 @@ import {
   VmwareProviderData,
   HookData,
   esxiHostList,
+  CutoverData,
 } from '../../types/types';
 import { providerType, storageType } from '../../types/constants';
 const url = Cypress.env('url');
@@ -26,6 +27,8 @@ const target_network = Cypress.env('v2v_vmwareTargetNetwork');
 const hostListArray = Cypress.env('host_list');
 const esxi_username = Cypress.env('v2v_vmwareEsxiUsername');
 const esxi_password = Cypress.env('v2v_vmwareEsxiPassword');
+const scheduled_date = Cypress.env('scheduled_date');
+const scheduled_time = Cypress.env('scheduled_time');
 
 export const loginData: LoginData = {
   username: user_login,
@@ -90,6 +93,11 @@ export const postHookData: HookData = {
   ansiblePlaybook: postAnsiblePlaybook,
 };
 
+export const cutoverData: CutoverData = {
+  date: scheduled_date,
+  time: scheduled_time,
+};
+
 export const originalPlanData: PlanData = {
   name: `testplan-${providerData.name}separate-mapping-cold`,
   sProvider: providerData.name,
@@ -105,6 +113,7 @@ export const originalPlanData: PlanData = {
   warmMigration: false,
   preHook: preHookData,
   postHook: postHookData,
+  scheduledCutover: cutoverData,
 };
 
 export const duplicatePlanData: PlanData = {


### PR DESCRIPTION
1. Removed time-period as an assertion from the text of incremental copy status 
2. In config files added scheduled date and time parameters for both vmware and rhv providers. 
3. Remove "Plan.openList();" extra line from the restart method

modified:   pkg/qe-tests/cypress/integration/models/plan.ts
	modified:   pkg/qe-tests/cypress/integration/tests/Rhv/config_separate_mapping_rhv.ts
	modified:   pkg/qe-tests/cypress/integration/tests/vmware/config_separate_mapping.ts