### PR TITLE
Bug 2067708: Fix invalid-mapping check to allow mapping items by name or id

### DIFF
--- a/pkg/web/src/app/Mappings/components/helpers.ts
+++ b/pkg/web/src/app/Mappings/components/helpers.ts
@@ -124,6 +124,9 @@ export const useEditingMappingPrefillEffect = (
   return { isDonePrefilling };
 };
 
+export const doesSourceExist = (availableSources: MappingSource[], mappingItem: MappingItem) =>
+  !!getMappingSourceByRef(availableSources, mappingItem.source);
+
 export const doesTargetExist = (
   mappingType: MappingType,
   availableTargets: MappingTarget[],
@@ -148,6 +151,6 @@ export const isMappingValid = (
 ): boolean =>
   (mapping.spec.map as MappingItem[]).every(
     (mappingItem) =>
-      availableSources.some((source) => source.id === mappingItem.source.id) &&
+      doesSourceExist(availableSources, mappingItem) &&
       doesTargetExist(mappingType, availableTargets, mappingItem)
   );


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2067708.

This PR fixes a case I missed in https://github.com/konveyor/forklift-ui/pull/948 (that fix was [backported](https://github.com/konveyor/forklift-ui/pull/951) for 2.3.1 and then [reverted](https://github.com/konveyor/forklift-ui/pull/952) because it failed QE).

With the fix from #948, the UI can correctly identify mapping items no matter whether they are mapped by name or id (you'll notice that the source networks/datastore names appear in the expanded view of the mapping correctly) but that logic was not applied to the boolean check for whether the mapping "is valid" (all of its source and target resources can be identified in the inventory). So the UI reported an error in the Status column even though the data is present.

This PR fixes this by reusing that PR's `getMappingSourceByRef` in a new `doesSourceExist` helper to complement the `doesTargetExist` helper also used in `isMappingValid`. Now all logic for finding mapping sources should tolerate mapping items that use either name or id, or both.