### PR TITLE
[Backport - 2.3.2] Bug 2067708: Support source VMs, networks and datastores referenced either by id or name in plan and mapping objects + Fix invalid-mapping check to allow mapping items by name or id (#961)

### DIFF
--- a/.github/workflows/deploy-main-preview.yaml
+++ b/.github/workflows/deploy-main-preview.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 16
       - name: Install dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
       - name: Run tests
         run: npm run ci
       - name: Build in mock mode

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 16
       - name: Install dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
       - name: Build in mock mode
         run: npm run build:mock
       - name: Generate Surge URL

--- a/.github/workflows/tests-ci.yaml
+++ b/.github/workflows/tests-ci.yaml
@@ -18,6 +18,6 @@ jobs:
         with:
           node-version: 16
       - name: Install dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
       - name: Run tests
         run: npm run ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hot-loader/react-dom": "^17.0.1",
         "@konveyor/lib-ui": "^6.0.0",
         "@patternfly/react-core": "^4.181.1",
         "@patternfly/react-icons": "^4.32.1",
@@ -39,6 +38,7 @@
       },
       "devDependencies": {
         "@axe-core/react": "^4.2.1",
+        "@hot-loader/react-dom": "^17.0.2",
         "@testing-library/cypress": "^8.0.2",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
@@ -865,16 +865,17 @@
       }
     },
     "node_modules/@hot-loader/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-QttzEibkIFkl/WV1dsLXg73YIweNo9ySbB0/26068RqFGWyv7pKyictWsaQXqSj1y66/BDn3kglCHgroGrv3vA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-G2RZrFhsQClS+bdDh/Ojpk3SgocLPUGnvnJDTQYnmKSSwXtU+Yh+8QMs+Ia3zaAvBiOSpIIDSUxuN69cvKqrWg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "17.0.1"
+        "react": "17.0.2"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -18319,13 +18320,14 @@
       }
     },
     "@hot-loader/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-QttzEibkIFkl/WV1dsLXg73YIweNo9ySbB0/26068RqFGWyv7pKyictWsaQXqSj1y66/BDn3kglCHgroGrv3vA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-G2RZrFhsQClS+bdDh/Ojpk3SgocLPUGnvnJDTQYnmKSSwXtU+Yh+8QMs+Ia3zaAvBiOSpIIDSUxuN69cvKqrWg==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       }
     },
     "@humanwhocodes/config-array": {
@@ -18671,8 +18673,7 @@
     "@patternfly/react-icons": {
       "version": "4.32.1",
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.32.1.tgz",
-      "integrity": "sha512-E7Fpnvax37e2ow8Xc2GngQBM7IuOpRyphZXCIUAk/NGsqpvFX27YhIVZiOUIAuBXAI5VXQBwueW/tmhmlXP7+w==",
-      "requires": {}
+      "integrity": "sha512-E7Fpnvax37e2ow8Xc2GngQBM7IuOpRyphZXCIUAk/NGsqpvFX27YhIVZiOUIAuBXAI5VXQBwueW/tmhmlXP7+w=="
     },
     "@patternfly/react-styles": {
       "version": "4.31.1",
@@ -19664,8 +19665,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
       "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.4.0",
@@ -19680,8 +19680,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
       "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-contrib/schema-utils": {
       "version": "1.0.0-beta.0",
@@ -19823,15 +19822,13 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -19874,8 +19871,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -19910,8 +19906,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -21301,8 +21296,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
       "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -22278,8 +22272,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "4.0.0",
@@ -22333,8 +22326,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-testing-library": {
       "version": "5.0.3",
@@ -23637,8 +23629,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -24796,8 +24787,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.4.0",
@@ -27222,29 +27212,25 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
       "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
       "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
       "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
       "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-merge-longhand": {
       "version": "5.0.4",
@@ -27314,8 +27300,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -27350,8 +27335,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
       "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -27816,8 +27800,7 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.22.0.tgz",
       "integrity": "sha512-MPLbF8vzRwAG3GcjdL+OHQlhgtWsLTXs+7uJiHfEeT3Ur7IsZaNYqRTLQ9sj2nB6M6jylcPCeCmH7qbszJmecg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-docgen-typescript-loader": {
       "version": "3.7.2",
@@ -27993,8 +27976,7 @@
     "react-router-last-location": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/react-router-last-location/-/react-router-last-location-2.0.1.tgz",
-      "integrity": "sha512-3FbFIWwUr2qN28vN9DNdFp6RhUH/yif6ILVff1zT+hLdyGmlNPh3GuPhveb7bHQLgB744QW8L0qtWjX58ESuZQ==",
-      "requires": {}
+      "integrity": "sha512-3FbFIWwUr2qN28vN9DNdFp6RhUH/yif6ILVff1zT+hLdyGmlNPh3GuPhveb7bHQLgB744QW8L0qtWjX58ESuZQ=="
     },
     "react-syntax-highlighter": {
       "version": "15.4.5",
@@ -31123,8 +31105,7 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@axe-core/react": "^4.2.1",
+    "@hot-loader/react-dom": "^17.0.2",
     "@testing-library/cypress": "^8.0.2",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
@@ -102,7 +103,6 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@hot-loader/react-dom": "^17.0.1",
     "@konveyor/lib-ui": "^6.0.0",
     "@patternfly/react-core": "^4.181.1",
     "@patternfly/react-icons": "^4.32.1",

--- a/pkg/web/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/pkg/web/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -15,7 +15,7 @@ import {
   SourceInventoryProvider,
 } from '@app/queries/types';
 import { IMappingBuilderItem } from './MappingBuilder';
-import { getMappingSourceById, getMappingTargetByRef } from '../helpers';
+import { getMappingSourceByRef, getMappingTargetByRef } from '../helpers';
 import { CLUSTER_API_VERSION, META, ProviderType } from '@app/common/constants';
 import { nameAndNamespace } from '@app/queries/helpers';
 import { filterSourcesBySelectedVMs } from '@app/Plans/components/Wizard/helpers';
@@ -31,7 +31,7 @@ export const getBuilderItemsFromMappingItems = (
   items
     ? (items
         .map((item: MappingItem): IMappingBuilderItem | null => {
-          const source = getMappingSourceById(allSources, item.source.id);
+          const source = getMappingSourceByRef(allSources, item.source);
           const target = getMappingTargetByRef(allTargets, item.destination, mappingType);
           if (source) {
             return { source, target };

--- a/pkg/web/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/pkg/web/src/app/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -8,7 +8,7 @@ import { LineArrow } from '@app/common/components/LineArrow';
 import { useResourceQueriesForMapping } from '@app/queries';
 import { TruncatedText } from '@app/common/components/TruncatedText';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
-import { getMappingSourceById, getMappingSourceTitle, getMappingTargetTitle } from '../helpers';
+import { getMappingSourceByRef, getMappingSourceTitle, getMappingTargetTitle } from '../helpers';
 import { getMappingItemTargetName, groupMappingItemsByTarget } from './helpers';
 
 import './MappingDetailView.css';
@@ -68,9 +68,9 @@ export const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps>
               <GridItem span={5} className={`mapping-view-box ${spacing.pSm}`}>
                 <ul>
                   {items.map((item, itemIndex) => {
-                    const source = getMappingSourceById(
+                    const source = getMappingSourceByRef(
                       mappingResourceQueries.availableSources,
-                      item.source.id
+                      item.source
                     );
                     const sourceName = source ? source.name : '';
                     return (

--- a/pkg/web/src/app/Mappings/components/helpers.ts
+++ b/pkg/web/src/app/Mappings/components/helpers.ts
@@ -124,6 +124,9 @@ export const useEditingMappingPrefillEffect = (
   return { isDonePrefilling };
 };
 
+export const doesSourceExist = (availableSources: MappingSource[], mappingItem: MappingItem) =>
+  !!getMappingSourceByRef(availableSources, mappingItem.source);
+
 export const doesTargetExist = (
   mappingType: MappingType,
   availableTargets: MappingTarget[],
@@ -148,6 +151,6 @@ export const isMappingValid = (
 ): boolean =>
   (mapping.spec.map as MappingItem[]).every(
     (mappingItem) =>
-      availableSources.some((source) => source.id === mappingItem.source.id) &&
+      doesSourceExist(availableSources, mappingItem) &&
       doesTargetExist(mappingType, availableTargets, mappingItem)
   );

--- a/pkg/web/src/app/Mappings/components/helpers.ts
+++ b/pkg/web/src/app/Mappings/components/helpers.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { isSameResource } from '@app/queries/helpers';
 import {
+  IdOrNameRef,
   IMetaObjectMeta,
   INetworkMappingItem,
   IOpenShiftProvider,
@@ -20,8 +21,11 @@ import { getBuilderItemsFromMapping } from './MappingBuilder/helpers';
 import { ProviderType } from '@app/common/constants';
 import { getStorageTitle } from '@app/common/helpers';
 
-export const getMappingSourceById = (sources: MappingSource[], id: string): MappingSource | null =>
-  sources.find((source) => source.id === id) || null;
+export const getMappingSourceByRef = (
+  sources: MappingSource[],
+  ref: IdOrNameRef
+): MappingSource | null =>
+  sources.find((source) => (ref.id ? source.id === ref.id : source.name === ref.name)) || null;
 
 export const getMappingTargetByRef = (
   targets: MappingTarget[],

--- a/pkg/web/src/app/Plans/components/PlanDetailsModal.tsx
+++ b/pkg/web/src/app/Plans/components/PlanDetailsModal.tsx
@@ -51,7 +51,7 @@ export const PlanDetailsModal: React.FunctionComponent<IPlanDetailsModalProps> =
     allProviders.find((provider) => isSameResource(provider, plan.spec.provider.source)) || null;
 
   const vmsQuery = useSourceVMsQuery(provider);
-  const selectedVMs = vmsQuery.data?.findVMsByIds(plan.spec.vms.map(({ id }) => id)) || [];
+  const selectedVMs = vmsQuery.data?.findVMsByRefs(plan.spec.vms) || [];
 
   const hooksQuery = useHooksQuery();
   const selectedHooks =

--- a/pkg/web/src/app/Plans/components/VMMigrationDetails.tsx
+++ b/pkg/web/src/app/Plans/components/VMMigrationDetails.tsx
@@ -95,7 +95,7 @@ export const VMMigrationDetails: React.FunctionComponent = () => {
 
   const vmsQuery = useSourceVMsQuery(sourceProvider);
   const getVMName = (vmStatus: IVMStatus) => {
-    const nameFromInventory = vmsQuery.data?.vmsById[vmStatus.id]?.name || null;
+    const nameFromInventory = vmsQuery.data?.findVMByRef(vmStatus)?.name || null;
     return nameFromInventory || vmStatus.name;
   };
 
@@ -112,9 +112,9 @@ export const VMMigrationDetails: React.FunctionComponent = () => {
 
   const vmStatuses: IVMStatus[] = planStarted
     ? plan?.status?.migration?.vms || []
-    : plan?.spec.vms.map(({ id }) => ({
-        id,
-        name: vmsQuery.data?.vmsById[id]?.name || '',
+    : plan?.spec.vms.map((vm) => ({
+        id: vmsQuery.data?.findVMByRef(vm)?.id || '',
+        name: vmsQuery.data?.findVMByRef(vm)?.name || '',
         pipeline: [],
         phase: '',
       })) || [];
@@ -280,7 +280,7 @@ export const VMMigrationDetails: React.FunctionComponent = () => {
     const isExpanded = isVMExpanded(vmStatus);
     const ratio = getTotalCopiedRatio(vmStatus);
     const isCanceled = isVMCanceled(vmStatus);
-    const vm = vmsQuery.data?.vmsById[vmStatus.id];
+    const vm = vmsQuery.data?.findVMByRef(vmStatus);
     rows.push({
       meta: { vmStatus },
       selected: isItemSelected(vmStatus),
@@ -429,7 +429,7 @@ export const VMMigrationDetails: React.FunctionComponent = () => {
         isOpen={isCancelModalOpen}
         toggleOpen={toggleCancelModal}
         mutateFn={() => {
-          const vmsToCancel = vmsQuery.data?.findVMsByIds(selectedItems.map(({ id }) => id)) || [];
+          const vmsToCancel = vmsQuery.data?.findVMsByRefs(selectedItems) || [];
           cancelVMsMutation.mutate(vmsToCancel);
         }}
         mutateResult={cancelVMsMutation}

--- a/pkg/web/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -251,7 +251,8 @@ export const PlanWizard: React.FunctionComponent = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mutationStatus]);
 
-  const selectedVMs = vmsQuery.data?.findVMsByIds(forms.selectVMs.values.selectedVMIds) || [];
+  const selectedVMs =
+    vmsQuery.data?.findVMsByRefs(forms.selectVMs.values.selectedVMIds.map((id) => ({ id }))) || [];
 
   const clusterTreeQuery = useInventoryTreeQuery(
     forms.general.values.sourceProvider,

--- a/pkg/web/src/app/Plans/components/Wizard/helpers.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/helpers.tsx
@@ -553,7 +553,7 @@ export const getSelectedVMsFromPlan = (
   indexedVMs: IndexedSourceVMs | undefined
 ): SourceVM[] => {
   if (!planBeingPrefilled || !indexedVMs) return [];
-  return indexedVMs.findVMsByIds(planBeingPrefilled?.spec.vms.map(({ id }) => id));
+  return indexedVMs.findVMsByRefs(planBeingPrefilled?.spec.vms);
 };
 
 interface IPlanWizardPrefillResults {

--- a/pkg/web/src/app/queries/__tests__/vms.test.ts
+++ b/pkg/web/src/app/queries/__tests__/vms.test.ts
@@ -14,15 +14,6 @@ describe('indexVMs', () => {
     ]);
   });
 
-  it('indexes VMs by id', () => {
-    const { vmsById } = indexedVMs;
-    expect(vmsById['vm-1630']?.name).toEqual('fdupont-test-migration');
-    expect(vmsById['vm-2844']?.name).toEqual('fdupont-test');
-    expect(vmsById['vm-1008']?.name).toEqual('fdupont-test-migration-centos');
-    expect(vmsById['vm-2685']?.name).toEqual('pemcg-discovery01');
-    expect(vmsById['vm-431']?.name).toEqual('pemcg-iscsi-target');
-  });
-
   it('indexes VMs by selfLink', () => {
     const { vmsBySelfLink } = indexedVMs;
     expect(vmsBySelfLink['/providers/vsphere/test/vms/vm-1630']?.name).toEqual(
@@ -37,7 +28,20 @@ describe('indexVMs', () => {
   });
 
   it('finds multiple VMs by ids correctly, ignoring invalid ids', () => {
-    const foundVMs = indexedVMs.findVMsByIds(['vm-2844', 'vm-something-invalid', 'vm-1630']);
+    const foundVMs = indexedVMs.findVMsByRefs([
+      { id: 'vm-2844' },
+      { id: 'vm-something-invalid' },
+      { id: 'vm-1630' },
+    ]);
+    expect(foundVMs.map((vm) => vm.name)).toEqual(['fdupont-test', 'fdupont-test-migration']);
+  });
+
+  it('finds multiple VMs by names correctly, ignoring invalid names', () => {
+    const foundVMs = indexedVMs.findVMsByRefs([
+      { name: 'fdupont-test' },
+      { name: 'vm-something-invalid' },
+      { name: 'fdupont-test-migration' },
+    ]);
     expect(foundVMs.map((vm) => vm.name)).toEqual(['fdupont-test', 'fdupont-test-migration']);
   });
 

--- a/pkg/web/src/app/queries/mocks/mappings.mock.ts
+++ b/pkg/web/src/app/queries/mocks/mappings.mock.ts
@@ -70,7 +70,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       map: [
         {
           source: {
-            id: MOCK_VMWARE_DATASTORES[1].id,
+            name: MOCK_VMWARE_DATASTORES[1].name,
           },
           destination: {
             storageClass: MOCK_STORAGE_CLASSES_BY_PROVIDER['ocpv-1'][1].name,
@@ -174,7 +174,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       map: [
         {
           source: {
-            id: MOCK_VMWARE_NETWORKS[1].id,
+            name: MOCK_VMWARE_NETWORKS[1].name,
           },
           destination: {
             ...nameAndNamespace(MOCK_OPENSHIFT_NETWORKS[1]),

--- a/pkg/web/src/app/queries/mocks/plans.mock.ts
+++ b/pkg/web/src/app/queries/mocks/plans.mock.ts
@@ -1,4 +1,4 @@
-import { IPlan, IPlanVM, IVMStatus } from '../types';
+import { IPlan, IVMStatus } from '../types';
 import { MOCK_INVENTORY_PROVIDERS } from '@app/queries/mocks/providers.mock';
 import { CLUSTER_API_VERSION, META } from '@app/common/constants';
 import { nameAndNamespace } from '../helpers';
@@ -9,20 +9,21 @@ import { MOCK_HOOKS } from './hooks.mock';
 export let MOCK_PLANS: IPlan[];
 
 if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
-  const vm1: IPlanVM = {
+  const vm1 = {
     id: 'vm-1630', // fdupont-test-migration
   };
 
-  const vm2: IPlanVM = {
+  const vm2 = {
     id: 'vm-2844', // fdupont-test
   };
 
-  const vm3: IPlanVM = {
+  const vm3 = {
     id: 'vm-1008', // fdupont-test-migration-centos
   };
 
-  const vm4: IPlanVM = {
-    id: 'vm-2685', // pemcg-discovery01
+  const vm4 = {
+    // id: 'vm-2685'
+    name: 'pemcg-discovery01',
   };
 
   const vmStatus1: IVMStatus = {
@@ -113,8 +114,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
   };
 
   const vmStatus4: IVMStatus = {
-    id: vm4.id,
-    name: 'pemcg-discovery01',
+    id: 'vm-2685',
+    name: vm4.name,
     pipeline: [
       {
         name: 'DiskTransfer',

--- a/pkg/web/src/app/queries/types/common.types.ts
+++ b/pkg/web/src/app/queries/types/common.types.ts
@@ -56,3 +56,8 @@ export interface INameNamespaceRef {
   name: string;
   namespace: string;
 }
+
+export interface IdOrNameRef {
+  id?: string;
+  name?: string;
+}

--- a/pkg/web/src/app/queries/types/mappings.types.ts
+++ b/pkg/web/src/app/queries/types/mappings.types.ts
@@ -1,7 +1,12 @@
 import { ISourceNetwork, IOpenShiftNetwork } from './networks.types';
 import { ISourceStorage } from './storages.types';
 import { IAnnotatedStorageClass } from './storages.types';
-import { IMetaObjectGenerateName, IMetaObjectMeta, IMetaTypeMeta } from './common.types';
+import {
+  IdOrNameRef,
+  IMetaObjectGenerateName,
+  IMetaObjectMeta,
+  IMetaTypeMeta,
+} from './common.types';
 import { ISrcDestRefs } from './providers.types';
 
 export enum MappingType {
@@ -10,9 +15,7 @@ export enum MappingType {
 }
 
 export interface INetworkMappingItem {
-  source: {
-    id: string;
-  };
+  source: IdOrNameRef;
   destination:
     | {
         name: string;
@@ -23,9 +26,7 @@ export interface INetworkMappingItem {
 }
 
 export interface IStorageMappingItem {
-  source: {
-    id: string;
-  };
+  source: IdOrNameRef;
   destination: {
     storageClass: string;
   };

--- a/pkg/web/src/app/queries/types/plans.types.ts
+++ b/pkg/web/src/app/queries/types/plans.types.ts
@@ -1,4 +1,10 @@
-import { ICR, IMetaObjectMeta, INameNamespaceRef, IStatusCondition } from '../types/common.types';
+import {
+  ICR,
+  IdOrNameRef,
+  IMetaObjectMeta,
+  INameNamespaceRef,
+  IStatusCondition,
+} from '../types/common.types';
 import { ISrcDestRefs } from './providers.types';
 
 export interface IProgress {
@@ -55,8 +61,7 @@ export interface IPlanVMHook {
   step: HookStep;
 }
 
-export interface IPlanVM {
-  id: string;
+export interface IPlanVM extends IdOrNameRef {
   hooks?: IPlanVMHook[];
 }
 


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2067708, correctly this time...

Re-backports #951 (reverting the revert done in #952)
Backports #961 to address the issues with the original #951
Backports #962 to fix CI