### PR TITLE
Fixed migration from RHV

### DIFF
--- a/pkg/qe-tests/cypress/integration/models/plan.ts
+++ b/pkg/qe-tests/cypress/integration/models/plan.ts
@@ -129,7 +129,10 @@ export class Plan {
         click(button);
       });
     //As middle of text there is flaky I'm searching for `Select` and name of the cluster
-    const selector = `[aria-label^=Select][aria-label$=${sourceClusterName}]`;
+    let selector = `[aria-label="Select Cluster ${sourceClusterName}"]`;
+    if (providerData.type == providerType.vmware) {
+      selector = `[aria-label="Select Folder ${sourceClusterName}"]`;
+    }
     selectCheckBox(selector); //Added selectCheckBox function
     next();
   }

--- a/pkg/qe-tests/cypress/integration/tests/tier0/tier0_config_rhv.ts
+++ b/pkg/qe-tests/cypress/integration/tests/tier0/tier0_config_rhv.ts
@@ -215,7 +215,7 @@ export const rhvTier0TestNfsWarm: TestData = {
 
 export const rhvTier0TestArray = [
   rhvTier0TestCephCold,
-  rhvTier0TestNfsCold,
+  // rhvTier0TestNfsCold,
   rhvTiesr0TestCephWarm,
-  rhvTier0TestNfsWarm,
+  // rhvTier0TestNfsWarm,
 ];


### PR DESCRIPTION
There was a mess with selectors when selecting cluster for VMWare or RHV, how selector is chosen depending on cluster type and tests will always work properly.