### PR TITLE
Enable minikube: Add AUTH_REQUIRED

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -167,6 +167,7 @@ module.exports = (env) => {
         DATA_SOURCE: 'remote',
         BRAND_TYPE: 'Konveyor',
         NODE_ENV: 'production',
+        NO_AUTH: 'false',
       }),
     ],
     resolve: {

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -167,7 +167,6 @@ module.exports = (env) => {
         DATA_SOURCE: 'remote',
         BRAND_TYPE: 'Konveyor',
         NODE_ENV: 'production',
-        NO_AUTH: 'false',
       }),
     ],
     resolve: {

--- a/pkg/api/scripts/remote-dev.js
+++ b/pkg/api/scripts/remote-dev.js
@@ -3,7 +3,7 @@ const execSync = require('child_process').execSync;
 const helpers = require('../src/helpers');
 
 try {
-  if(process.env['NO_AUTH'] === 'true'){
+  if (process.env['NO_AUTH'] === 'true') {
     process.exit(0);
   }
   execSync('hash oc');

--- a/pkg/api/scripts/remote-dev.js
+++ b/pkg/api/scripts/remote-dev.js
@@ -3,6 +3,9 @@ const execSync = require('child_process').execSync;
 const helpers = require('../src/helpers');
 
 try {
+  if(process.env['NO_AUTH'] === 'true'){
+    process.exit(0);
+  }
   execSync('hash oc');
 } catch (error) {
   console.error(error.stdout.toString());

--- a/pkg/api/scripts/remote-dev.js
+++ b/pkg/api/scripts/remote-dev.js
@@ -3,7 +3,7 @@ const execSync = require('child_process').execSync;
 const helpers = require('../src/helpers');
 
 try {
-  if (process.env['NO_AUTH'] === 'true') {
+  if (process.env['AUTH_REQUIRED'] === 'false') {
     process.exit(0);
   }
   execSync('hash oc');

--- a/pkg/api/src/helpers.js
+++ b/pkg/api/src/helpers.js
@@ -34,6 +34,7 @@ const getAppTitle = () =>
   process.env['BRAND_TYPE'] === 'RedHat' ? 'Migration Toolkit for Virtualization' : 'Forklift';
 
 const FORKLIFT_ENV = [
+  'NO_AUTH',
   'NODE_ENV',
   'DATA_SOURCE',
   'BRAND_TYPE',

--- a/pkg/api/src/helpers.js
+++ b/pkg/api/src/helpers.js
@@ -34,7 +34,7 @@ const getAppTitle = () =>
   process.env['BRAND_TYPE'] === 'RedHat' ? 'Migration Toolkit for Virtualization' : 'Forklift';
 
 const FORKLIFT_ENV = [
-  'NO_AUTH',
+  'AUTH_REQUIRED',
   'NODE_ENV',
   'DATA_SOURCE',
   'BRAND_TYPE',

--- a/pkg/web/src/app/common/types.ts
+++ b/pkg/web/src/app/common/types.ts
@@ -17,6 +17,7 @@ export interface IMetaVars {
 }
 
 export interface IEnvVars {
+  NO_AUTH: string;
   NODE_ENV: string;
   DATA_SOURCE: string;
   BRAND_TYPE: BrandType;

--- a/pkg/web/src/app/common/types.ts
+++ b/pkg/web/src/app/common/types.ts
@@ -17,7 +17,7 @@ export interface IMetaVars {
 }
 
 export interface IEnvVars {
-  NO_AUTH: string;
+  AUTH_REQUIRED: string;
   NODE_ENV: string;
   DATA_SOURCE: string;
   BRAND_TYPE: BrandType;

--- a/pkg/web/src/app/queries/fetchHelpers.ts
+++ b/pkg/web/src/app/queries/fetchHelpers.ts
@@ -29,7 +29,7 @@ export const authorizedFetch = async <TResponse, TData = unknown>(
 ): Promise<TResponse> => {
   const { history, checkExpiry } = fetchContext;
 
-  if (ENV.NO_AUTH !== 'true') {
+  if (ENV.AUTH_REQUIRED !== 'false') {
     extraHeaders['Authorization'] = `Bearer ${fetchContext.currentUser.access_token}`;
   }
 

--- a/pkg/web/src/app/queries/fetchHelpers.ts
+++ b/pkg/web/src/app/queries/fetchHelpers.ts
@@ -5,6 +5,7 @@ import { History, LocationState } from 'history';
 import { useClientInstance } from '@app/client/helpers';
 import { KubeResource } from '@konveyor/lib-ui';
 import { IKubeResponse, IKubeStatus } from '@app/client/types';
+import { ENV } from '@app/common/constants';
 
 interface IFetchContext {
   history: History<LocationState>;
@@ -27,14 +28,14 @@ export const authorizedFetch = async <TResponse, TData = unknown>(
   data?: TData
 ): Promise<TResponse> => {
   const { history, checkExpiry } = fetchContext;
-  const headersObj = {
-    Authorization: `Bearer ${fetchContext.currentUser.access_token}`,
-    ...extraHeaders,
-  };
+
+  if (ENV.NO_AUTH !== 'true') {
+    extraHeaders['Authorization'] = `Bearer ${fetchContext.currentUser.access_token}`;
+  }
 
   try {
     const response = await fetch(url, {
-      headers: headersObj,
+      headers: extraHeaders,
       method,
       ...(data &&
         method !== 'get' && {

--- a/pkg/web/src/app/routes.tsx
+++ b/pkg/web/src/app/routes.tsx
@@ -4,7 +4,7 @@ import { accessibleRouteChangeHandler } from '@app/utils/utils';
 import { useDocumentTitle } from '@app/utils/useDocumentTitle';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
 import { useLocalStorageContext, LocalStorageKey } from './common/context/LocalStorageContext';
-import { APP_TITLE } from '@app/common/constants';
+import { APP_TITLE, ENV } from '@app/common/constants';
 import { WelcomePage } from '@app/Welcome/WelcomePage';
 import { ProvidersPage } from '@app/Providers/ProvidersPage';
 import { PlansPage } from '@app/Plans/PlansPage';
@@ -15,7 +15,6 @@ import { VMMigrationDetails } from '@app/Plans/components/VMMigrationDetails';
 import { LoginHandlerComponent } from './common/LoginHandlerComponent';
 import { RedirectToLogin } from './common/RedirectToLogin';
 import { NotFound } from './NotFound';
-import { ENV } from '@app/common/constants';
 
 let routeFocusTimer: number;
 

--- a/pkg/web/src/app/routes.tsx
+++ b/pkg/web/src/app/routes.tsx
@@ -15,6 +15,9 @@ import { VMMigrationDetails } from '@app/Plans/components/VMMigrationDetails';
 import { LoginHandlerComponent } from './common/LoginHandlerComponent';
 import { RedirectToLogin } from './common/RedirectToLogin';
 import { NotFound } from './NotFound';
+import { IEnvVars } from './common/types';
+
+export const ENV: IEnvVars = window['_env'] || {};
 
 let routeFocusTimer: number;
 
@@ -152,7 +155,7 @@ const RouteWithTitleUpdates = ({
   useDocumentTitle(title);
 
   function routeWithTitle(routeProps: RouteComponentProps) {
-    if (isProtected) {
+    if (isProtected && ENV.NO_AUTH !== 'true') {
       return isLoggedIn ? <Component {...rest} {...routeProps} /> : <RedirectToLogin />;
     } else {
       return <Component {...rest} {...routeProps} />;
@@ -184,7 +187,7 @@ export const AppRoutes = (): React.ReactElement => {
         {flattenedRoutes.map(({ path, exact, component, title, isAsync, isProtected }, idx) => (
           <RouteWithTitleUpdates
             isProtected={isProtected}
-            isLoggedIn={!!currentUser || process.env['DATA_SOURCE'] === 'mock'}
+            isLoggedIn={!!currentUser || ENV.DATA_SOURCE === 'mock'}
             path={path}
             exact={exact}
             component={component}

--- a/pkg/web/src/app/routes.tsx
+++ b/pkg/web/src/app/routes.tsx
@@ -15,9 +15,7 @@ import { VMMigrationDetails } from '@app/Plans/components/VMMigrationDetails';
 import { LoginHandlerComponent } from './common/LoginHandlerComponent';
 import { RedirectToLogin } from './common/RedirectToLogin';
 import { NotFound } from './NotFound';
-import { IEnvVars } from './common/types';
-
-export const ENV: IEnvVars = window['_env'] || {};
+import { ENV } from '@app/common/constants';
 
 let routeFocusTimer: number;
 

--- a/pkg/web/src/app/routes.tsx
+++ b/pkg/web/src/app/routes.tsx
@@ -152,7 +152,7 @@ const RouteWithTitleUpdates = ({
   useDocumentTitle(title);
 
   function routeWithTitle(routeProps: RouteComponentProps) {
-    if (isProtected && ENV.NO_AUTH !== 'true') {
+    if (isProtected && ENV.AUTH_REQUIRED !== 'false') {
       return isLoggedIn ? <Component {...rest} {...routeProps} /> : <RedirectToLogin />;
     } else {
       return <Component {...rest} {...routeProps} />;


### PR DESCRIPTION
Issue: Currently we always log in to the okd, which can be a problem for devs as not everybody has HW for okd.
This patch adds env var `AUTH_REQUIRED` which disables the login.
I have also removed the `Authorization` when communicating with the controller as it's no longer needed because we would be sending empty bearer token.

Example: `NO_AUTH=true DATA_SOURCE=remote npm run start:dev`