### PR TITLE
Add a fetch action for oVirt CA certs in provider add/edit modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ config/meta.dev.json
 **/RHV*.json
 **/screenshots/*
 **/reports/*
+/.vscode

--- a/pkg/api/scripts/start-dev.sh
+++ b/pkg/api/scripts/start-dev.sh
@@ -7,7 +7,8 @@ export NODE_ENV=development
 export DEBUG=1
 export EXPRESS_PORT=9001
 export NODE_TLS_REJECT_UNAUTHORIZED="0"
-./node_modules/concurrently/bin/concurrently.js --names "EXPRESS,WEBPACK" -c "green.bold.inverse,blue.bold.inverse" \
+./node_modules/concurrently/bin/concurrently.js \
+  --names "EXPRESS,WEBPACK" \
+  -c "green.bold.inverse,blue.bold.inverse" \
   "$_dir/run-local-express.sh --auto-reload" \
-  "./node_modules/webpack/bin/webpack.js serve \
-    --hot --color --config=./config/webpack.dev.js"
+  "./node_modules/webpack/bin/webpack.js serve --hot --color --config=./config/webpack.dev.js"

--- a/pkg/api/src/server-routes.js
+++ b/pkg/api/src/server-routes.js
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const sslCertificate = require('get-ssl-certificate');
+const fetch = require('node-fetch');
+const { X509Certificate } = require('crypto');
+
+function splitSubject(subject) {
+  return subject.split('\n').reduce((subject, part) => {
+    const [term, value] = part.split('=', 2);
+    if (term in subject) {
+      subject[term] = Array.isArray(subject[term])
+        ? [...subject[term], value]
+        : [subject[term], value];
+    } else {
+      subject[term] = value;
+    }
+    return subject;
+  }, {});
+}
+
+/**
+ * Take a standard X509Certificate object and convert to a JSON object following the
+ * formatting of `sslCertificate.get()` and `tlsSocket.getPeerCertificate()`.
+ *
+ * See: https://nodejs.org/dist/latest-v16.x/docs/api/tls.html#certificate-object
+ */
+function certificateToJson(cert) {
+  const json = cert.toLegacyObject();
+  json.subject = splitSubject(json.subject);
+  json.issuer = splitSubject(json.issuer);
+  json.pemEncoded = cert.toString();
+  return json;
+}
+
+async function getCertificate(req, res) {
+  const { providerType, hostname } = req.query;
+
+  if (providerType === 'vsphere') {
+    // get the certificate used on the SSL connection to the host
+    try {
+      const certificate = await sslCertificate.get(hostname, 250, 443, 'https:');
+      console.info(`Fetched certificate: ${hostname}`);
+      return res.status(200).json(certificate);
+    } catch (error) {
+      console.error(`Error: Fetch certificate`, error.message);
+      if (error.code === 'ENOTFOUND') {
+        return res.status(404).json('URL not found');
+      }
+      return res.status(500).json('Fetch certificate failed');
+    }
+  } else if (providerType === 'ovirt') {
+    // get the CA certificate from the ovirt provided endpoint
+    const url = `https://${hostname}/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA`;
+    try {
+      const response = await fetch(url);
+      const certX509 = await response.text();
+      const cert = certificateToJson(new X509Certificate(certX509));
+      console.info(
+        `Fetched CA certificate from: ${hostname}, Subject: ${JSON.stringify(cert.subject)}`
+      );
+      return res.status(200).json(cert);
+    } catch (error) {
+      console.error(`Error: Fetch certificate`, error.message);
+      if (error.code === 'ENOTFOUND') {
+        return res.status(404).json('URL not found');
+      }
+      return res.status(500).json('Fetch certificate failed');
+    }
+  } else {
+    return res.status(500).json('Unknown providerType');
+  }
+}
+
+module.exports = {
+  apply(expressApp) {
+    expressApp.get('/get-certificate', getCertificate);
+  },
+};

--- a/pkg/api/src/server.js
+++ b/pkg/api/src/server.js
@@ -7,6 +7,7 @@ const dayjs = require('dayjs');
 
 const helpers = require('./helpers');
 const { getClusterAuth } = require('./oAuthHelpers');
+const serverRoutes = require('./server-routes');
 
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
@@ -76,22 +77,7 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
     }
   });
 
-  app.get('/get-certificate', async (req, res) => {
-    const sslCertificate = require('get-ssl-certificate');
-    sslCertificate
-      .get(req.query.url, 250, 443, 'https:')
-      .then((certificate) => {
-        console.info(`Fetched certificate: ${req.query.url}`);
-        return res.status(200).json(certificate);
-      })
-      .catch((error) => {
-        console.error(`Error: Fetch certificate`, error.message);
-        if (error.code === 'ENOTFOUND') {
-          return res.status(404).json('URL not found');
-        }
-        return res.status(500).json('Fetch certificate failed');
-      });
-  });
+  serverRoutes.apply(app);
 
   let clusterApiProxyOptions = {
     target: meta.clusterApi,

--- a/pkg/web/src/app/queries/providers.ts
+++ b/pkg/web/src/app/queries/providers.ts
@@ -386,8 +386,17 @@ function assertIsCertificate(certificate: ITLSCertificate): asserts certificate 
     throw new Error('Not certificate');
   }
 }
-const getCertificate = async (hostname: string) => {
-  const response = await fetch(`get-certificate?url=${hostname}`);
+const getCertificate = async (providerType: ProviderType | null, hostname: string) => {
+  const params = {
+    providerType,
+    hostname,
+  };
+  const response = await fetch(
+    `get-certificate?` +
+      Object.entries(params)
+        .map(([key, value]) => `${key}=${encodeURIComponent(value ?? '')}`)
+        .join('&')
+  );
   if (!response.ok) {
     throw new Error('Problem fetching data');
   }
@@ -398,13 +407,14 @@ const getCertificate = async (hostname: string) => {
 };
 
 export const useCertificateQuery = (
+  providerType: ProviderType | null,
   hostname: string,
   enabled: boolean
 ): UseQueryResult<ITLSCertificate> => {
   const result = useMockableQuery<ITLSCertificate>(
     {
       queryKey: ['certificate', hostname],
-      queryFn: () => getCertificate(hostname),
+      queryFn: () => getCertificate(providerType, hostname),
       enabled: enabled,
     },
     MOCK_TLS_CERTIFICATE


### PR DESCRIPTION
### What is new?
Add a new "fetch the engine CA certificate" link to the Add/Edit provider modal.  Using an enhanced `/get-certificate` server route, the CA cert is fetched and populated to the form field.

![ca cert link](https://user-images.githubusercontent.com/3985964/182887437-6f27e263-7c2b-4d09-9066-c7a01234aeb1.png)

The `/get-certificate` server route is enhanced to be able to fetch the CA certificate from an oVirt engine host.  Response data will match the response of the `vsphere` request, and is used to populate the certificate upload form field.  The `useCertificateQuery()` hook has been updated to match the server side enhancements.

None of the existing field or query functionality was changed.  A new query was added for the ovirt CA cert fetching.

Manual upload of the CA certificate is still possible.

### What is missing?
The mock data for the `useCertificateQuery()` hook probably needs to be updated.

### Questions

1. Is the way the CA cert fetch done in the label button click "the right way" for working with the react-query / useQuery libraries? Other suggestions for how to handle the fetch then update a few fields?

2. Does it make sense to show more details about the certificate like the vsphere provider?  Something like showing the cert's subject, issuer and fingerprint?

### Side notes...

The CA cert pulled from the engine is the cert that issues the cert used on the engine SSL connection.  So pulling the SSL cert, matching what is done for the vsphere provider, isn't enough.  This also means that any other forklift code should know the ovirt cert is the CA cert and not a connection's SSL cert.