### PR TITLE
Use the K8S_AUTH_BEARER_TOKEN env var for authorizedFetch

### DIFF
--- a/pkg/web/src/app/queries/fetchHelpers.ts
+++ b/pkg/web/src/app/queries/fetchHelpers.ts
@@ -33,6 +33,10 @@ export const authorizedFetch = async <TResponse, TData = unknown>(
     extraHeaders['Authorization'] = `Bearer ${fetchContext.currentUser.access_token}`;
   }
 
+  if (ENV.AUTH_REQUIRED === 'false' && ENV.K8S_AUTH_BEARER_TOKEN) {
+    extraHeaders['Authorization'] = `Bearer ${ENV.K8S_AUTH_BEARER_TOKEN}`;
+  }
+
   try {
     const response = await fetch(url, {
       headers: extraHeaders,


### PR DESCRIPTION
Issue:
In https://github.com/konveyor/forklift-ui/pull/983 I added the optional `K8S_AUTH_BEARER_TOKEN` environment variable, but forgot to add it to the `authorizedFetch` method.

Solution:
Adding a check, if the UI is running without OAuth, and the `K8S_AUTH_BEARER_TOKEN` environment variable is provided, use it for authentication in the `authorizedFetch` method.

Signed-off-by: yzamir <yzamir@redhat.com>