### PR TITLE
Use --legacy-peer-deps flag in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM registry.access.redhat.com/ubi8/nodejs-16 as builder
 COPY . .
 USER root
-RUN npm install && npm run build
+RUN npm install --legacy-peer-deps && npm run build
 
 # Runner image
 FROM registry.access.redhat.com/ubi8/nodejs-16-minimal

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Clone and install dependencies:
 ```bash
 git clone https://github.com/konveyor/forklift-ui
 cd forklift-ui
-npm install
+npm install --legacy-peer-deps
 ```
 
 Create a meta.dev.json file in the config directory using [`config/meta.dev.example.json`](./config/meta.dev.example.json) as a template. Set the `inventoryApi` property to the root URL of your forklift-controller inventory API, and set the `clusterApi` property to the root URL of your host OpenShift cluster API. And also to be able to use VMware provider data to be analysed by Migration Analytics set the `inventoryPayloadApi` property to the root URL of your forklift-controller inventory Payload API.


### PR DESCRIPTION
Due to the same issue described in https://github.com/konveyor/forklift-ui/pull/962, image builds are failing when using newer versions of NodeJS / npm because of peer dependency resolution issues. For the time being we need to use the `--legacy-peer-deps` flag to switch to the old peer deps resolution behavior when installing forklift-ui dependencies. #962 did this in the CI scripts but we also need it in the Dockerfile.

cc @fbladilo 